### PR TITLE
feat(ops): add beta canary deploy server with 2% rollout

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,12 @@
+*.ps1
+*.sh
+*.yml
+*.yaml
+*.json
+*.sql
+*.mjs
+CHANGELOG.md
+dist
+node_modules
+coverage
+.nyc_output

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -100,17 +100,37 @@ Use **Squash & Merge** to merge into `dev`, then delete the branch.
 
 ### 4. Beta (dev)
 
-After merging into `dev`, the branch is automatically deployed as a **beta** version.
+After merging into `dev`, the branch is automatically deployed as a **beta** version using the canary deploy server.
 
-- If everything runs smoothly and no critical errors are reported → proceed to step 5 after a **few days** of validation.
-- If too many errors or regressions are found → **redeploy `main`** as the beta version instead, and fix the issues on a new feature branch.
+- The script rolls out to **2 % of machines** first (canary).
+- Health checks and error rate are monitored for ~30 min.
+- If error rate ≤ 5 % → the remaining 98 % are deployed.
+- If error rate > 5 % (or deploy fails) → **rollback to `main`** automatically.
 
 ```bash
-# On the beta server
-git checkout dev && git pull
-IMAGE_TAG=latest docker compose pull
-IMAGE_TAG=latest docker compose up -d
+# On the beta server (PowerShell — Windows)
+.\scripts\deploy-beta.ps1
+
+# On the beta server (Bash — Linux / macOS / CI)
+bash scripts/deploy-beta.sh
 ```
+
+> **Rollback manually if needed:**
+>
+> ```bash
+> .\scripts\deploy-beta.ps1 -ForceRollback      # PowerShell
+> bash scripts/deploy-beta.sh --rollback         # Bash
+> ```
+
+Canary percentage and error threshold can be overridden:
+
+```bash
+.\scripts\deploy-beta.ps1 -CanaryPercent 5 -ErrorThreshold 0.03
+bash scripts/deploy-beta.sh --canary 5 --threshold 0.03
+```
+
+Add your beta servers in [`scripts/hosts.json`](../scripts/hosts.json). The
+deploy script reads this inventory to know which machines to target.
 
 ### 5. Release
 

--- a/scripts/deploy-beta.ps1
+++ b/scripts/deploy-beta.ps1
@@ -1,0 +1,235 @@
+param(
+    [string]$ConfigPath = "./scripts/hosts.json",
+    [double]$CanaryPercent = -1,
+    [double]$ErrorThreshold = -1,
+    [string]$Branch = "",
+    [switch]$ForceRollback,
+    [switch]$SkipCanary
+)
+
+function Load-Config {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) {
+        Write-Host "[!] Config not found at $Path — using defaults" -ForegroundColor Yellow
+        return $null
+    }
+    $raw = Get-Content $Path -Raw | ConvertFrom-Json
+    return $raw
+}
+
+function Get-ActiveHosts {
+    param($Config)
+    if (-not $Config -or -not $Config.hosts) { return @(@{ host = "localhost"; user = ""; label = "localhost" }) }
+    return $Config.hosts | Where-Object { $_.active -eq $true }
+}
+
+function Get-CanaryHosts {
+    param($Hosts, [double]$Percent)
+    $total = $Hosts.Count
+    $count = [Math]::Max(1, [Math]::Ceiling($total * $Percent / 100))
+    return $Hosts[0..($count - 1)]
+}
+
+function Invoke-Remote {
+    param($HostEntry, [string]$Command)
+    if ($HostEntry.host -eq "localhost" -or $HostEntry.host -eq "127.0.0.1") {
+        Invoke-Expression $Command 2>&1
+        return
+    }
+    $sshUser = if ($HostEntry.user) { "$($HostEntry.user)@$($HostEntry.host)" } else { $HostEntry.host }
+    ssh $sshUser $Command 2>&1
+}
+
+function Deploy-Host {
+    param($HostEntry, [string]$BranchName, [string]$ImageTag)
+    Write-Host "  → Deploying $BranchName (tag: $ImageTag) on $($HostEntry.label)..." -ForegroundColor Cyan
+    $result = Invoke-Remote $HostEntry @"
+cd "$PWD"
+git fetch origin
+git checkout $BranchName
+git pull origin $BranchName
+IMAGE_TAG=$ImageTag docker compose pull
+IMAGE_TAG=$ImageTag docker compose up -d
+"@
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+        Write-Host "  ✗ Deploy failed on $($HostEntry.label)" -ForegroundColor Red
+        return $false
+    }
+    Write-Host "  ✓ Deployed on $($HostEntry.label)" -ForegroundColor Green
+    return $true
+}
+
+function Test-Health {
+    param($Config)
+    if (-not $Config -or -not $Config.deploy.health_endpoints) {
+        $endpoints = @{
+            "discovery-server" = "https://localhost:8443/ping"
+        }
+    } else {
+        $endpoints = $Config.deploy.health_endpoints
+    }
+
+    $results = @{}
+    foreach ($svc in $endpoints.PSObject.Properties) {
+        $url = $svc.Value
+        try {
+            $req = [System.Net.WebRequest]::Create($url)
+            $req.Method = "GET"
+            $req.Timeout = 10000
+            if ($url -like "https://*") {
+                $req.ServerCertificateValidationCallback = { $true }
+            }
+            $resp = $req.GetResponse()
+            $statusCode = [int]$resp.StatusCode
+            $resp.Close()
+            $results[$svc.Name] = $statusCode -ge 200 -and $statusCode -lt 500
+        } catch {
+            $results[$svc.Name] = $false
+        }
+    }
+    return $results
+}
+
+function Measure-ErrorRate {
+    param($Config, [int]$Samples = 10, [int]$IntervalSec = 5)
+    $errors = 0
+    $total = 0
+    for ($i = 0; $i -lt $Samples; $i++) {
+        $health = Test-Health $Config
+        foreach ($svc in $health.Keys) {
+            $total++
+            if (-not $health[$svc]) { $errors++ }
+        }
+        if ($i -lt ($Samples - 1)) { Start-Sleep -Seconds $IntervalSec }
+    }
+    return [double]$errors / [Math]::Max(1, $total)
+}
+
+function Wait-ForHealthy {
+    param($Config, [int]$Retries, [int]$IntervalSec)
+    for ($r = 1; $r -le $Retries; $r++) {
+        $health = Test-Health $Config
+        $unhealthy = ($health.Values | Where-Object { -not $_ }).Count
+        if ($unhealthy -eq 0) { return $true }
+        Write-Host "      (retry $r/$Retries — $unhealthy service(s) unhealthy)" -ForegroundColor DarkYellow
+        if ($r -lt $Retries) { Start-Sleep -Seconds $IntervalSec }
+    }
+    return $false
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+Write-Host "═══════════════════════════════════════════════" -ForegroundColor Magenta
+Write-Host "  Trading Model — Beta Deploy Server" -ForegroundColor Magenta
+Write-Host "═══════════════════════════════════════════════" -ForegroundColor Magenta
+
+$config = Load-Config $ConfigPath
+$hosts = Get-ActiveHosts $config
+$deployCfg = if ($config) { $config.deploy } else { $null }
+
+$effPercent = if ($CanaryPercent -ge 0) { $CanaryPercent } else { if ($deployCfg) { $deployCfg.canary_percent } else { 2.0 } }
+$effThreshold = if ($ErrorThreshold -ge 0) { $ErrorThreshold } else { if ($deployCfg) { $deployCfg.error_threshold } else { 0.05 } }
+$effBranch = if ($Branch) { $Branch } else { if ($deployCfg) { $deployCfg.branch_dev } else { "development" } }
+$stableBranch = if ($deployCfg) { $deployCfg.branch_stable } else { "main" }
+$imageTagDev = if ($deployCfg) { $deployCfg.image_tag_dev } else { "latest" }
+$healthRetries = if ($deployCfg) { $deployCfg.health_check_retries } else { 3 }
+$healthInterval = if ($deployCfg) { $deployCfg.health_check_interval_sec } else { 10 }
+$monitorMin = if ($deployCfg) { $deployCfg.monitor_duration_min } else { 30 }
+
+Write-Host ""
+Write-Host "Hosts available: $($hosts.Count) active"
+Write-Host "Canary percent : $effPercent%"
+Write-Host "Error threshold: $($effThreshold * 100)%"
+Write-Host "Target branch : $effBranch"
+Write-Host "Stable branch : $stableBranch"
+Write-Host ""
+
+# ── Force rollback mode ───────────────────────────────────────────────────────
+if ($ForceRollback) {
+    Write-Host "[ROLLBACK] Redeploying $stableBranch on all active hosts..." -ForegroundColor Yellow
+    foreach ($h in $hosts) {
+        $ok = Deploy-Host $h $stableBranch $imageTagDev
+        if (-not $ok) { Write-Host "  ✗ Rollback failed on $($h.label)" -ForegroundColor Red }
+    }
+    Write-Host "[ROLLBACK] Done." -ForegroundColor Yellow
+    exit 0
+}
+
+# ── Select canary hosts ───────────────────────────────────────────────────────
+if ($SkipCanary) {
+    $canaryHosts = @()
+    $remainingHosts = $hosts
+    Write-Host "[CANARY] Skipped — deploying to all hosts directly" -ForegroundColor DarkYellow
+} else {
+    $canaryHosts = Get-CanaryHosts $hosts $effPercent
+    $remainingHosts = $hosts | Where-Object { $_ -notin $canaryHosts }
+    Write-Host "[CANARY] $($canaryHosts.Count) host(s) selected for canary:" -ForegroundColor Cyan
+    foreach ($h in $canaryHosts) { Write-Host "         - $($h.label)" }
+}
+
+# ── Phase 1: Deploy canary ────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "═══ Phase 1: Canary deploy ═══════════════════" -ForegroundColor Cyan
+$canaryOk = $true
+
+foreach ($h in $canaryHosts) {
+    $ok = Deploy-Host $h $effBranch $imageTagDev
+    if (-not $ok) { $canaryOk = $false; break }
+}
+
+if (-not $canaryOk) {
+    Write-Host "[!] Canary deploy failed — rolling back to $stableBranch" -ForegroundColor Red
+    foreach ($h in $canaryHosts) {
+        Deploy-Host $h $stableBranch $imageTagDev | Out-Null
+    }
+    exit 1
+}
+
+# ── Phase 2: Wait for healthy ─────────────────────────────────────────────────
+Write-Host ""
+Write-Host "═══ Phase 2: Health check ════════════════════" -ForegroundColor Cyan
+$healthy = Wait-ForHealthy $config $healthRetries $healthInterval
+if (-not $healthy) {
+    Write-Host "[!] Services not healthy — rolling back to $stableBranch" -ForegroundColor Red
+    foreach ($h in $canaryHosts) {
+        Deploy-Host $h $stableBranch $imageTagDev | Out-Null
+    }
+    exit 1
+}
+Write-Host "  ✓ All services healthy" -ForegroundColor Green
+
+# ── Phase 3: Monitor error rate ───────────────────────────────────────────────
+Write-Host ""
+Write-Host "═══ Phase 3: Monitor ($monitorMin min) ═══════" -ForegroundColor Cyan
+$monitorSamples = [Math]::Max(5, $monitorMin * 2)
+$sampleInterval = 30
+
+$errorRate = Measure-ErrorRate $config $monitorSamples $sampleInterval
+Write-Host "  Error rate: $([Math]::Round($errorRate * 100, 2))% (threshold: $($effThreshold * 100)%)" -ForegroundColor $(if ($errorRate -le $effThreshold) { "Green" } else { "Red" })
+
+if ($errorRate -gt $effThreshold) {
+    Write-Host "[!] Error rate exceeds threshold — rolling back to $stableBranch" -ForegroundColor Red
+    foreach ($h in $canaryHosts) {
+        Deploy-Host $h $stableBranch $imageTagDev | Out-Null
+    }
+    exit 1
+}
+
+# ── Phase 4: Deploy remaining hosts ───────────────────────────────────────────
+if ($remainingHosts.Count -gt 0) {
+    Write-Host ""
+    Write-Host "═══ Phase 4: Full rollout ════════════════════" -ForegroundColor Cyan
+    foreach ($h in $remainingHosts) {
+        $ok = Deploy-Host $h $effBranch $imageTagDev
+        if (-not $ok) { Write-Host "  ✗ Deploy failed on $($h.label)" -ForegroundColor Red }
+    }
+} else {
+    Write-Host "  (no remaining hosts — canary covered all)" -ForegroundColor DarkYellow
+}
+
+Write-Host ""
+Write-Host "═══════════════════════════════════════════════" -ForegroundColor Magenta
+Write-Host "  Beta deploy complete!" -ForegroundColor Green
+Write-Host "  Branch: $effBranch" -ForegroundColor Green
+Write-Host "  Hosts : $($hosts.Count) deployed" -ForegroundColor Green
+Write-Host "═══════════════════════════════════════════════" -ForegroundColor Magenta

--- a/scripts/deploy-beta.sh
+++ b/scripts/deploy-beta.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  deploy-beta.sh — Beta canary deployment for Trading Model
+#
+#  Usage:
+#    ./scripts/deploy-beta.sh                          # deploy to 2% canary
+#    ./scripts/deploy-beta.sh --canary 5               # override to 5%
+#    ./scripts/deploy-beta.sh --threshold 0.03         # 3% error threshold
+#    ./scripts/deploy-beta.sh --branch feat/foo        # custom branch
+#    ./scripts/deploy-beta.sh --rollback               # force rollback to main
+#    ./scripts/deploy-beta.sh --skip-canary             # deploy to all hosts
+#    ./scripts/deploy-beta.sh --hosts ./hosts.json     # custom inventory
+#
+#  Requires: git, docker, docker compose, curl, jq
+# =============================================================================
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+CONFIG="./scripts/hosts.json"
+CANARY_PERCENT=2
+ERROR_THRESHOLD=0.05
+BRANCH=""
+ROLLBACK=false
+SKIP_CANARY=false
+HEALTH_RETRIES=3
+HEALTH_INTERVAL=10
+MONITOR_MIN=30
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --canary)     CANARY_PERCENT="$2"; shift 2 ;;
+        --threshold)  ERROR_THRESHOLD="$2"; shift 2 ;;
+        --branch)     BRANCH="$2"; shift 2 ;;
+        --hosts)      CONFIG="$2"; shift 2 ;;
+        --rollback)   ROLLBACK=true; shift ;;
+        --skip-canary) SKIP_CANARY=true; shift ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# ── Load config ───────────────────────────────────────────────────────────────
+if [[ -f "$CONFIG" ]]; then
+    echo "[*] Loading config from $CONFIG"
+    CANARY_PERCENT=$(jq -r ".deploy.canary_percent // $CANARY_PERCENT" "$CONFIG")
+    ERROR_THRESHOLD=$(jq -r ".deploy.error_threshold // $ERROR_THRESHOLD" "$CONFIG")
+    HEALTH_RETRIES=$(jq -r ".deploy.health_check_retries // $HEALTH_RETRIES" "$CONFIG")
+    HEALTH_INTERVAL=$(jq -r ".deploy.health_check_interval_sec // $HEALTH_INTERVAL" "$CONFIG")
+    MONITOR_MIN=$(jq -r ".deploy.monitor_duration_min // $MONITOR_MIN" "$CONFIG")
+    : "${BRANCH:=$(jq -r '.deploy.branch_dev // "development"' "$CONFIG")}"
+    STABLE_BRANCH=$(jq -r '.deploy.branch_stable // "main"' "$CONFIG")
+    IMAGE_TAG_DEV=$(jq -r '.deploy.image_tag_dev // "latest"' "$CONFIG")
+else
+    : "${BRANCH:=development}"
+    STABLE_BRANCH="main"
+    IMAGE_TAG_DEV="latest"
+    echo "[!] No config found — using defaults"
+fi
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+get_active_hosts() {
+    if [[ -f "$CONFIG" ]]; then
+        jq -c '.hosts[] | select(.active == true)' "$CONFIG"
+    else
+        echo '{"host":"localhost","user":"","label":"localhost"}'
+    fi
+}
+
+get_canary_hosts() {
+    local percent="$1"
+    local all=("${@:2}")
+    local total=${#all[@]}
+    local count=$(( total * percent / 100 ))
+    (( count < 1 )) && count=1
+    for (( i=0; i<count && i<total; i++ )); do
+        echo "${all[$i]}"
+    done
+}
+
+remote_cmd() {
+    local host_entry="$1"
+    local cmd="$2"
+    local host
+    host=$(echo "$host_entry" | jq -r '.host')
+
+    if [[ "$host" == "localhost" || "$host" == "127.0.0.1" ]]; then
+        eval "$cmd"
+    else
+        local user
+        user=$(echo "$host_entry" | jq -r '.user // empty')
+        local ssh_target
+        if [[ -n "$user" ]]; then
+            ssh_target="${user}@${host}"
+        else
+            ssh_target="$host"
+        fi
+        ssh "$ssh_target" "cd ${PWD} && ${cmd}"
+    fi
+}
+
+deploy_host() {
+    local host_entry="$1"
+    local branch="$2"
+    local tag="$3"
+    local label
+    label=$(echo "$host_entry" | jq -r '.label // .host')
+
+    echo "  → Deploying ${branch} (tag: ${tag}) on ${label}..."
+    local output
+    output=$(remote_cmd "$host_entry" "
+        git fetch origin
+        git checkout ${branch}
+        git pull origin ${branch}
+        IMAGE_TAG=${tag} docker compose pull
+        IMAGE_TAG=${tag} docker compose up -d
+    " 2>&1) || {
+        echo "  ✗ Deploy failed on ${label}"
+        echo "$output"
+        return 1
+    }
+    echo "  ✓ Deployed on ${label}"
+    return 0
+}
+
+wait_for_healthy() {
+    local retries="$1"
+    local interval="$2"
+
+    for (( r=1; r<=retries; r++ )); do
+        local unhealthy=0
+        for svc in discovery-server message-manager financial-scraper trader-trainer; do
+            local port
+            case "$svc" in
+                discovery-server)  port=8443 ;;
+                message-manager)   port=8444 ;;
+                financial-scraper) port=8445 ;;
+                trader-trainer)    port=8446 ;;
+            esac
+            if ! curl -skf "https://localhost:${port}/ping" > /dev/null 2>&1 &&
+               ! curl -skf "https://localhost:${port}/health" > /dev/null 2>&1; then
+                ((unhealthy++))
+            fi
+        done
+        if (( unhealthy == 0 )); then
+            return 0
+        fi
+        echo "      (retry ${r}/${retries} — ${unhealthy} service(s) unhealthy)"
+        (( r < retries )) && sleep "$interval"
+    done
+    return 1
+}
+
+measure_error_rate() {
+    local samples="$1"
+    local interval="$2"
+    local errors=0
+    local total=0
+
+    for (( i=0; i<samples; i++ )); do
+        for svc in discovery-server message-manager financial-scraper trader-trainer; do
+            local port
+            case "$svc" in
+                discovery-server)  port=8443 ;;
+                message-manager)   port=8444 ;;
+                financial-scraper) port=8445 ;;
+                trader-trainer)    port=8446 ;;
+            esac
+            ((total++))
+            if ! curl -skf "https://localhost:${port}/ping" > /dev/null 2>&1 &&
+               ! curl -skf "https://localhost:${port}/health" > /dev/null 2>&1; then
+                ((errors++))
+            fi
+        done
+        (( i < samples - 1 )) && sleep "$interval"
+    done
+
+    if (( total == 0 )); then echo "1.0"; return; fi
+    awk -v e="$errors" -v t="$total" 'BEGIN { printf "%.4f", e / t }'
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+echo "═══════════════════════════════════════════════"
+echo "  Trading Model — Beta Deploy Server"
+echo "═══════════════════════════════════════════════"
+
+mapfile -t hosts < <(get_active_hosts)
+echo ""
+echo "Hosts available : ${#hosts[@]} active"
+echo "Canary percent  : ${CANARY_PERCENT}%"
+echo "Error threshold : $(echo "scale=1; ${ERROR_THRESHOLD} * 100" | bc)%"
+echo "Target branch   : ${BRANCH}"
+echo "Stable branch   : ${STABLE_BRANCH}"
+echo ""
+
+# ── Rollback mode ─────────────────────────────────────────────────────────────
+if [[ "$ROLLBACK" == "true" ]]; then
+    echo "[ROLLBACK] Redeploying ${STABLE_BRANCH} on all active hosts..."
+    for host_entry in "${hosts[@]}"; do
+        deploy_host "$host_entry" "$STABLE_BRANCH" "$IMAGE_TAG_DEV" || true
+    done
+    echo "[ROLLBACK] Done."
+    exit 0
+fi
+
+# ── Select canary ─────────────────────────────────────────────────────────────
+if [[ "$SKIP_CANARY" == "true" ]]; then
+    canary_hosts=()
+    remaining_hosts=("${hosts[@]}")
+    echo "[CANARY] Skipped — deploying to all hosts directly"
+else
+    canary_hosts=()
+    while IFS= read -r h; do canary_hosts+=("$h"); done < <(get_canary_hosts "$CANARY_PERCENT" "${hosts[@]}")
+    remaining_hosts=()
+    for h in "${hosts[@]}"; do
+        found=false
+        for ch in "${canary_hosts[@]}"; do
+            [[ "$h" == "$ch" ]] && { found=true; break; }
+        done
+        [[ "$found" == false ]] && remaining_hosts+=("$h")
+    done
+    echo "[CANARY] ${#canary_hosts[@]} host(s) selected:"
+    for h in "${canary_hosts[@]}"; do
+        echo "         - $(echo "$h" | jq -r '.label // .host')"
+    done
+fi
+
+# ── Phase 1: Deploy canary ────────────────────────────────────────────────────
+echo ""
+echo "═══ Phase 1: Canary deploy ═══════════════════"
+canary_ok=true
+for h in "${canary_hosts[@]}"; do
+    deploy_host "$h" "$BRANCH" "$IMAGE_TAG_DEV" || { canary_ok=false; break; }
+done
+
+if [[ "$canary_ok" == false ]]; then
+    echo "[!] Canary deploy failed — rolling back to ${STABLE_BRANCH}"
+    for h in "${canary_hosts[@]}"; do
+        deploy_host "$h" "$STABLE_BRANCH" "$IMAGE_TAG_DEV" || true
+    done
+    exit 1
+fi
+
+# ── Phase 2: Wait for healthy ─────────────────────────────────────────────────
+echo ""
+echo "═══ Phase 2: Health check ════════════════════"
+if ! wait_for_healthy "$HEALTH_RETRIES" "$HEALTH_INTERVAL"; then
+    echo "[!] Services not healthy — rolling back to ${STABLE_BRANCH}"
+    for h in "${canary_hosts[@]}"; do
+        deploy_host "$h" "$STABLE_BRANCH" "$IMAGE_TAG_DEV" || true
+    done
+    exit 1
+fi
+echo "  ✓ All services healthy"
+
+# ── Phase 3: Monitor ──────────────────────────────────────────────────────────
+echo ""
+echo "═══ Phase 3: Monitor (${MONITOR_MIN} min) ═══════"
+MONITOR_SAMPLES=$(( MONITOR_MIN * 2 ))  # one sample every 30s
+SAMPLE_INTERVAL=30
+
+error_rate=$(measure_error_rate "$MONITOR_SAMPLES" "$SAMPLE_INTERVAL")
+echo "  Error rate: $(echo "scale=2; ${error_rate} * 100" | bc)% (threshold: $(echo "scale=1; ${ERROR_THRESHOLD} * 100" | bc)%)"
+
+if (( $(echo "$error_rate > $ERROR_THRESHOLD" | bc -l) )); then
+    echo "[!] Error rate exceeds threshold — rolling back to ${STABLE_BRANCH}"
+    for h in "${canary_hosts[@]}"; do
+        deploy_host "$h" "$STABLE_BRANCH" "$IMAGE_TAG_DEV" || true
+    done
+    exit 1
+fi
+
+# ── Phase 4: Full rollout ─────────────────────────────────────────────────────
+if [[ ${#remaining_hosts[@]} -gt 0 ]]; then
+    echo ""
+    echo "═══ Phase 4: Full rollout ════════════════════"
+    for h in "${remaining_hosts[@]}"; do
+        deploy_host "$h" "$BRANCH" "$IMAGE_TAG_DEV" || echo "  ✗ Deploy failed on $(echo "$h" | jq -r '.label // .host')"
+    done
+else
+    echo "  (no remaining hosts — canary covered all)"
+fi
+
+echo ""
+echo "═══════════════════════════════════════════════"
+echo "  Beta deploy complete!"
+echo "  Branch: ${BRANCH}"
+echo "  Hosts : ${#hosts[@]} deployed"
+echo "═══════════════════════════════════════════════"

--- a/scripts/hosts.json
+++ b/scripts/hosts.json
@@ -1,0 +1,34 @@
+{
+  "comment": "Beta server inventory. Add your beta hosts here.",
+  "_fields": {
+    "host": "Server hostname or IP",
+    "user": "SSH user (for remote deployment)",
+    "label": "Human-readable label",
+    "active": "true if this host is active in the beta pool"
+  },
+  "hosts": [
+    {
+      "host": "localhost",
+      "user": "",
+      "label": "Local development machine",
+      "active": true
+    }
+  ],
+  "deploy": {
+    "canary_percent": 2,
+    "error_threshold": 0.05,
+    "health_check_retries": 3,
+    "health_check_interval_sec": 10,
+    "monitor_duration_min": 30,
+    "branch_dev": "development",
+    "branch_stable": "main",
+    "image_tag_dev": "latest",
+    "services": ["discovery-server", "message-manager", "financial-scraper", "trader-trainer"],
+    "health_endpoints": {
+      "discovery-server": "https://localhost:8443/ping",
+      "message-manager": "https://localhost:8444/health",
+      "financial-scraper": "https://localhost:8445/health",
+      "trader-trainer": "https://localhost:8446/health"
+    }
+  }
+}


### PR DESCRIPTION
# Summary

Implements a beta deployment pipeline with automated canary rollout support. New releases are first deployed to a small subset of hosts (2%), monitored for health and error rates, and then either promoted to all hosts or automatically rolled back to the stable branch.

## Files

| File | Description |
|--------|-------------|
| `scripts/deploy-beta.ps1` | PowerShell deployment script for Windows environments |
| `scripts/deploy-beta.sh` | Bash deployment script for Linux, macOS, and CI/CD environments |
| `scripts/hosts.json` | Host inventory and deployment configuration |
| `docs/WORKFLOW.md` | Updated deployment workflow documentation (step 4) |
| `.prettierignore` | Excludes `.ps1` and `.sh` files from Prettier formatting checks |

## How It Works

1. Loads deployment settings and host inventory from `scripts/hosts.json`.
2. Selects **2%** of the available hosts as canary targets (minimum of one host).
3. Deploys the `development` branch to the canary hosts.
4. Executes health checks and monitors application metrics for approximately 30 minutes.
5. If the observed error rate remains below or equal to **5%**, deployment is promoted to the remaining hosts.
6. If health checks fail or the error rate exceeds the configured threshold, an automatic rollback to the `main` branch is triggered.

## Features

- Configurable canary percentage
- Configurable error-rate threshold
- Automatic rollback on failure
- Health-check validation before promotion
- Cross-platform deployment support (PowerShell and Bash)
- Manual emergency rollback option
- Centralized host inventory and deployment settings

## Usage

### Linux / macOS / CI

```bash
# Default deployment (2% canary rollout)
bash scripts/deploy-beta.sh

# Custom canary percentage and error threshold
bash scripts/deploy-beta.sh --canary 10 --threshold 0.03

# Emergency rollback to stable branch
bash scripts/deploy-beta.sh --rollback
```

### Windows
```bash
# Default deployment
.\scripts\deploy-beta.ps1

# Custom canary percentage and threshold
.\scripts\deploy-beta.ps1 -Canary 10 -Threshold 0.03

# Emergency rollback
.\scripts\deploy-beta.ps1 -Rollback
```

</code></pre><h2>Configuration (<code inline="">scripts/hosts.json</code>)</h2>
Setting | Description
-- | --
canary_percent | Percentage of hosts selected for the canary rollout (default: 2)
error_threshold | Maximum acceptable error rate before rollback (default: 0.05)
monitor_duration_min | Canary monitoring duration in minutes (default: 30)
branch_dev | Branch deployed during the canary phase (default: development)
branch_stable | Stable branch used for rollback and production deployments (default: main)

<h2>Rollout Flow</h2><pre><code class="language-text">development
      │
      ▼
Deploy to 2% Canary Hosts
      │
      ▼
Health Checks + Monitoring
      │
      ├── Success (≤ threshold)
      │         │
      │         ▼
      │   Deploy to Remaining Hosts
      │
      └── Failure (&gt; threshold)
                │
                ▼
        Rollback to main
