### PR TITLE
:memo:(docs): add issue templates for docs, refactor, perf, test, chore, cicd

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,28 @@
+---
+name: Chore
+about: Maintenance tasks, dependency updates, tooling changes
+title: ':wrench:(scope): Brief description'
+labels: chore
+assignees: ''
+---
+
+## Description
+
+<!-- What maintenance task needs to be done -->
+
+## Why
+
+<!-- Why is this chore necessary (deprecation, security, compatibility) -->
+
+## Scope
+
+<!-- Which packages, services, or config files are affected -->
+
+## Checklist
+
+- [ ] Dependencies updated
+- [ ] Config files modified
+- [ ] CI/CD updated
+- [ ] Docs updated
+
+## Additional Context

--- a/.github/ISSUE_TEMPLATE/cicd.md
+++ b/.github/ISSUE_TEMPLATE/cicd.md
@@ -1,0 +1,29 @@
+---
+name: CI/CD
+about: Changes to CI/CD pipelines, workflows, or infrastructure
+title: ':construction_worker:(scope): Brief description'
+labels: cicd
+assignees: ''
+---
+
+## Description
+
+<!-- What CI/CD change is needed -->
+
+## Motivation
+
+<!-- Why is this change needed (reliability, speed, security) -->
+
+## Workflows Affected
+
+<!-- List the workflow files that will change -->
+
+## Testing
+
+<!-- How will you validate the CI/CD change (dry-run, manual trigger, etc.) -->
+
+## Rollback Plan
+
+<!-- How to revert if the change causes issues -->
+
+## Additional Context

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,23 @@
+---
+name: Documentation
+about: Report a documentation issue or suggest improvements
+title: ':memo:(scope): Brief description'
+labels: documentation
+assignees: ''
+---
+
+## Description
+
+<!-- What documentation is affected and what needs to change -->
+
+## Proposed Changes
+
+<!-- List specific files, sections, or topics to add/update/remove -->
+
+## Impact
+
+<!-- Which docs/ area does this affect (standards, deployment, architecture)? -->
+
+## Additional Context
+
+<!-- Any references, screenshots, or examples -->

--- a/.github/ISSUE_TEMPLATE/performance.md
+++ b/.github/ISSUE_TEMPLATE/performance.md
@@ -1,0 +1,34 @@
+---
+name: Performance
+about: Report a performance issue or suggest an optimisation
+title: ':zap:(scope): Brief description'
+labels: performance
+assignees: ''
+---
+
+## Current Behavior
+
+<!-- Describe the current performance issue (slow response, high memory, etc.) -->
+
+## Expected Improvement
+
+<!-- Quantified targets if possible (e.g., reduce latency by 50%) -->
+
+## Reproduction
+
+<!-- Steps to reproduce the performance issue -->
+1.
+2.
+3.
+
+## Environment
+
+- Service:
+- Load/scale:
+- Metrics (if available):
+
+## Proposed Solution
+
+<!-- How would you improve performance? -->
+
+## Additional Context

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,0 +1,27 @@
+---
+name: Refactor
+about: Suggest a code restructuring or improvement
+title: ':recycle:(scope): Brief description'
+labels: refactor
+assignees: ''
+---
+
+## Motivation
+
+<!-- Why is this refactor needed? What problem does it solve? -->
+
+## Proposed Changes
+
+<!-- What specific code areas will change -->
+
+## Benefits
+
+<!-- Expected improvements (readability, maintainability, performance, etc.) -->
+
+## Risks / Migration
+
+<!-- Any breaking changes or migration steps required -->
+
+## Related Issues
+
+<!-- Link to related issues or PRs -->

--- a/.github/ISSUE_TEMPLATE/test.md
+++ b/.github/ISSUE_TEMPLATE/test.md
@@ -1,0 +1,25 @@
+---
+name: Test
+about: Add or improve tests
+title: ':white_check_mark:(scope): Brief description'
+labels: test
+assignees: ''
+---
+
+## Test Scope
+
+<!-- What functionality needs testing? Unit, integration, or e2e? -->
+
+## Current Coverage
+
+<!-- What is tested now, and what gaps exist -->
+
+## Proposed Tests
+
+<!-- Describe the test cases to add -->
+
+## Related Code
+
+<!-- Link to source files that need test coverage -->
+
+## Additional Context


### PR DESCRIPTION
## Description

Add six missing issue templates to cover all change types listed in the gitmoji/PR checklist:

| Template | Gitmoji | Label |
|----------|---------|-------|
| `documentation.md` | :memo: | documentation |
| `refactor.md` | :recycle: | refactor |
| `performance.md` | :zap: | performance |
| `test.md` | :white_check_mark: | test |
| `chore.md` | :wrench: | chore |
| `cicd.md` | :construction_worker: | cicd |

Each template follows the same YAML front-matter convention as the existing Bug Report and Feature Request templates, with sections appropriate to the change type.

## Type of Change

- [x] :memo: Documentation

## Related Issues

Closes #72

## Checklist

- [x] Code follows [project standards](docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](docs/standards/COMMIT.md)

## Breaking Changes

None

## Test Plan

- Verify GitHub surfaces the new templates when creating an issue
- Verify each template has correct title format and labels
