### PR TITLE
:memo:(docs): add cross-references between CONTRIBUTING.md and CONTRIBUTE.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,5 +3,6 @@
 Thanks for your interest in contributing to trading-model!
 
 - [Full contribution workflow](docs/deployment/CONTRIBUTE.md) — from idea to production
+- [New contributor guide](docs/deployment/CONTRIBUTE.md#new-contributor) — first steps
 - [Code standards](docs/standards/) — commit messages, PRs, writing guidelines
 - [Architecture overview](docs/architecture/ARCHITECTURE.md)

--- a/docs/deployment/CONTRIBUTE.md
+++ b/docs/deployment/CONTRIBUTE.md
@@ -1,5 +1,7 @@
 # Contribute — Full Workflow from Idea to Production
 
+> **Quick start:** See [CONTRIBUTING.md](../../CONTRIBUTING.md) for a concise overview before diving into the full workflow.
+
 ## Branch Strategy
 
 ```
@@ -218,10 +220,11 @@ main ←── merge dev ────→ tag ──→ stable deploy
 
 ### New contributor
 
-1. Set up the machine (see [SETUP.md](SETUP.md))
-2. Create an Issue or pick an existing one
-3. Create a branch and submit your first PR
-4. Request a review from a maintainer
+1. Read [CONTRIBUTING.md](../../CONTRIBUTING.md) for a quick overview
+2. Set up the machine (see [SETUP.md](SETUP.md))
+3. Create an Issue or pick an existing one
+4. Create a branch and submit your first PR
+5. Request a review from a maintainer
 
 ### General developer / Maintainer
 


### PR DESCRIPTION
## Description

Add bidirectional cross-references between the root-level `CONTRIBUTING.md` and the detailed `docs/deployment/CONTRIBUTE.md`:

- **`CONTRIBUTING.md`** — added direct link to the "New contributor" section in `CONTRIBUTE.md`
- **`docs/deployment/CONTRIBUTE.md`** — added a "Quick start" callout linking back to `CONTRIBUTING.md`, and updated the "New contributor" steps to reference the root overview first

This ensures discoverability regardless of where a contributor enters the documentation.

## Type of Change

- [x] 📝 Documentation

## Related Issues

<!-- No issue — follow-up from earlier root-level doc migration -->

## Checklist

- [x] Code follows [project standards](docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] Docs updated if needed
- [x] Commit messages follow [gitmoji convention](docs/standards/COMMIT.md)

## Breaking Changes

None

## Test Plan

- Verify relative links resolve correctly on GitHub
