### PR TITLE
:wrench:(scripts): enforce import order per CONTRIBUTE.md convention via eslint-plugin-import-x

### DIFF
--- a/docs/standards/QUALITY.md
+++ b/docs/standards/QUALITY.md
@@ -104,7 +104,7 @@ Minimum thresholds defined per module (see [TESTING.md](./TESTING.md) for detail
 | financial-scraper              | 100%      |
 | @trading-model/address-manager | 80%       |
 | @trading-model/broker-message  | 80%       |
-| trader-trainer                 | Not set   |
+| trader-trainer                 | 80%       |
 
 Coverage is verified by Jest on every test run. Below the threshold, tests fail.
 

--- a/docs/standards/TESTING.md
+++ b/docs/standards/TESTING.md
@@ -92,7 +92,7 @@ describe('MyComponent', () => {
 | financial-scraper              | 100%     | 100%      | 100%    | 100%       |
 | @trading-model/address-manager | 80%      | 80%       | 80%     | 80%        |
 | @trading-model/broker-message  | 80%      | 80%       | 80%     | 80%        |
-| trader-trainer                 | Not set  | Not set   | Not set | Not set    |
+| trader-trainer                 | 80%      | 80%       | 80%     | 80%        |
 
 Coverage is checked by Jest on every test run. Below the threshold, tests fail.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import { dirname } from 'node:path';
 import js from '@eslint/js';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
+import ix from 'eslint-plugin-import-x';
 import { globalIgnores, defineConfig } from 'eslint/config';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -35,6 +36,39 @@ export default defineConfig([
       parserOptions: {
         projectService: true,
         tsconfigRootDir: __dirname,
+      },
+    },
+    plugins: { ix },
+    rules: {
+      'ix/order': [
+        'error',
+        {
+          groups: [
+            ['builtin'],
+            ['external'],
+            ['internal'],
+            ['parent', 'sibling'],
+            ['index'],
+          ],
+          'pathGroups': [
+            { pattern: '@trading-model/**', group: 'internal', position: 'after' },
+          ],
+          'pathGroupsExcludedImportTypes': ['builtin'],
+          'newlines-between': 'always',
+          alphabetize: { order: 'asc' },
+        },
+      ],
+    },
+    settings: {
+      'import-x/resolver': {
+        typescript: {
+          alwaysTryTypes: true,
+          project: [
+            'packages/*/tsconfig.json',
+            'packages/*/tsconfig.build.json',
+            'services/*/tsconfig.json',
+          ],
+        },
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trading-model",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trading-model",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "workspaces": [
         "packages/*",
         "services/*"
@@ -16,6 +16,8 @@
         "@commitlint/config-conventional": "^21.0.1",
         "conventional-commits-filter": "^5.0.0",
         "conventional-commits-parser": "^6.4.0",
+        "eslint-import-resolver-typescript": "^4.4.5",
+        "eslint-plugin-import-x": "^4.16.2",
         "husky": "^9.1.7",
         "typedoc": "^0.28.19"
       }
@@ -3107,6 +3109,13 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@package-json/types": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
+      "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4874,6 +4883,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/compare-func": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
@@ -5935,6 +5954,117 @@
         }
       }
     },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.5.tgz",
+      "integrity": "sha512-nbE5XLph6TLtGYcu/U6e6ZVXyKBhbDWK5cLGk76eJ7NdZpwf1P9EFkpt1Z01mNZNrrilsAYWKH6zUkL4reoXbw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.8",
+        "get-tsconfig": "^4.10.1",
+        "is-bun-module": "^2.0.0",
+        "stable-hash-x": "^0.2.0",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^16.17.0 || >=18.6.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-import-x": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
+      "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@package-json/types": "^0.0.12",
+        "@typescript-eslint/types": "^8.56.0",
+        "comment-parser": "^1.4.1",
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.9",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.3 || ^10.1.2",
+        "semver": "^7.7.2",
+        "stable-hash-x": "^0.2.0",
+        "unrs-resolver": "^1.9.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-import-x"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "eslint-import-resolver-node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/utils": {
+          "optional": true
+        },
+        "eslint-import-resolver-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
@@ -6734,6 +6864,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/git-raw-commits": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
@@ -7254,6 +7397,29 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-bun-module/node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
@@ -9888,6 +10054,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -10219,6 +10395,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
+    },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/stack-utils": {
@@ -11769,7 +11955,7 @@
     },
     "packages/address-manager": {
       "name": "@trading-model/address-manager",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@trading-model/common": "*",
@@ -11790,7 +11976,7 @@
     },
     "packages/broker-message": {
       "name": "@trading-model/broker-message",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@trading-model/address-manager": "*",
@@ -11812,7 +11998,7 @@
     },
     "packages/common": {
       "name": "@trading-model/common",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "chained-error": "^1.0.0",
@@ -11836,7 +12022,7 @@
       }
     },
     "services/discovery-server": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@trading-model/common": "*",
@@ -11901,7 +12087,7 @@
       }
     },
     "services/financial-scraper": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@trading-model/address-manager": "*",
@@ -11950,7 +12136,7 @@
       }
     },
     "services/message-manager": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@trading-model/address-manager": "*",
@@ -12009,7 +12195,7 @@
     },
     "services/trader-trainer": {
       "name": "trader-service",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "@trading-model/address-manager": "*",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "@commitlint/config-conventional": "^21.0.1",
     "conventional-commits-filter": "^5.0.0",
     "conventional-commits-parser": "^6.4.0",
+    "eslint-import-resolver-typescript": "^4.4.5",
+    "eslint-plugin-import-x": "^4.16.2",
     "husky": "^9.1.7",
     "typedoc": "^0.28.19"
   }

--- a/packages/address-manager/src/client/address-manager-client.ts
+++ b/packages/address-manager/src/client/address-manager-client.ts
@@ -1,9 +1,13 @@
 import { networkInterfaces } from 'os';
-import { RegisterServicePayload, ServiceRegistrationResponse } from './type';
-import { AddressManagerError } from '@trading-model/common/utils/errors';
-import { AddressManagerConfig } from '../config/address-manager-config';
+
 import { HttpClient } from '@trading-model/common/config/http-client';
+import { AddressManagerError } from '@trading-model/common/utils/errors';
+
 import { TokenManager } from './token-manager';
+import { RegisterServicePayload, ServiceRegistrationResponse } from './type';
+import { AddressManagerConfig } from '../config/address-manager-config';
+
+
 
 /**
  * AddressManagerClient

--- a/packages/address-manager/src/client/token-manager.ts
+++ b/packages/address-manager/src/client/token-manager.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@trading-model/common/config/http-client';
-import { AddressManagerConfig } from '../config/address-manager-config';
 import { AuthenticationError } from '@trading-model/common/utils/errors';
+
+import { AddressManagerConfig } from '../config/address-manager-config';
 
 /**
  * TokenManager

--- a/packages/address-manager/src/discovery/service-cache.ts
+++ b/packages/address-manager/src/discovery/service-cache.ts
@@ -1,5 +1,5 @@
-import { ServiceInstance } from '../client/type';
 import { CacheEntry } from './type';
+import { ServiceInstance } from '../client/type';
 
 /**
  * ServiceCache

--- a/packages/address-manager/src/discovery/service-discovery.ts
+++ b/packages/address-manager/src/discovery/service-discovery.ts
@@ -1,9 +1,10 @@
+import { HttpClient } from '@trading-model/common/config/http-client';
 import { ServiceNotFoundError, ServiceUnreachableError } from '@trading-model/common/utils/errors';
-import { AddressManagerConfig } from '../config/address-manager-config';
+
+import { ServiceCache } from './service-cache';
 import { ServiceHealthChecker } from './service-health-checker';
 import { ServiceInstance } from '../client/type';
-import { ServiceCache } from './service-cache';
-import { HttpClient } from '@trading-model/common/config/http-client';
+import { AddressManagerConfig } from '../config/address-manager-config';
 
 /**
  * ServiceDiscovery

--- a/packages/address-manager/src/discovery/service-health-checker.ts
+++ b/packages/address-manager/src/discovery/service-health-checker.ts
@@ -1,6 +1,7 @@
-import { ServiceInstance } from '../client/type';
 import { HttpClient } from '@trading-model/common/config/http-client';
 import { PING_PATH } from '@trading-model/common/server/constants';
+
+import { ServiceInstance } from '../client/type';
 
 /**
  * ServiceHealthChecker

--- a/packages/address-manager/src/http/ping.controller.ts
+++ b/packages/address-manager/src/http/ping.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express';
+
 import { ResponseException } from '@trading-model/common/middleware/response-exception';
 
 /** Handles GET /ping requests. Returns a "pong" response to indicate the service is alive. */

--- a/packages/address-manager/src/http/routes/ping.routes.ts
+++ b/packages/address-manager/src/http/routes/ping.routes.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express';
-import { pingController } from '../ping.controller';
+
 import { PING_PATH } from '@trading-model/common/server/constants';
+
+import { pingController } from '../ping.controller';
 
 const router = Router();
 

--- a/packages/address-manager/src/index.ts
+++ b/packages/address-manager/src/index.ts
@@ -1,16 +1,19 @@
-import { ServiceHealthChecker } from './discovery/service-health-checker';
-import { AddressManagerClient } from './client/address-manager-client';
-import { AddressManagerConfig } from './config/address-manager-config';
-import { HttpClient } from '@trading-model/common/config/http-client';
-import { TokenRefresherJob } from './scheduler/token-refresh-job';
-import { ServiceDiscovery } from './discovery/service-discovery';
-import { TtlRefresherJob } from './scheduler/ttl-refresher-job';
-import { ServiceCache } from './discovery/service-cache';
-import { pingRoutes } from './http/routes/ping.routes';
-import { TokenManager } from './client/token-manager';
-import { Scheduler } from './scheduler/scheduler';
-import { ServiceInstance } from './client/type';
 import { Application } from 'express';
+
+import { HttpClient } from '@trading-model/common/config/http-client';
+
+import { AddressManagerClient } from './client/address-manager-client';
+import { TokenManager } from './client/token-manager';
+import { ServiceInstance } from './client/type';
+import { AddressManagerConfig } from './config/address-manager-config';
+import { ServiceCache } from './discovery/service-cache';
+import { ServiceDiscovery } from './discovery/service-discovery';
+import { ServiceHealthChecker } from './discovery/service-health-checker';
+import { pingRoutes } from './http/routes/ping.routes';
+import { Scheduler } from './scheduler/scheduler';
+import { TokenRefresherJob } from './scheduler/token-refresh-job';
+import { TtlRefresherJob } from './scheduler/ttl-refresher-job';
+
 
 /**
  * Default export for the Address Manager library.

--- a/packages/broker-message/src/client/message-manager-client.ts
+++ b/packages/broker-message/src/client/message-manager-client.ts
@@ -1,11 +1,12 @@
-import { MessageManagerError, ServiceUnreachableError } from '@trading-model/common/utils/errors';
-import { SubscribesTopicsPayload, UnSubscribesTopicsPayload } from '../shared/types/payloads';
-import { ServiceInstanceName } from '@trading-model/common/config/services.types';
+import addressManagerClient from '@trading-model/address-manager';
 import { EventEnumMap } from '@trading-model/common/config/event.types';
 import { HttpClient } from '@trading-model/common/config/http-client';
-import addressManagerClient from '@trading-model/address-manager';
+import { ServiceInstanceName } from '@trading-model/common/config/services.types';
+import { MessageManagerError, ServiceUnreachableError } from '@trading-model/common/utils/errors';
+
 import { MessageManagerConfig } from '../shared/types/config';
 import { MessageMetadata } from '../shared/types/message';
+import { SubscribesTopicsPayload, UnSubscribesTopicsPayload } from '../shared/types/payloads';
 
 /** Client for interacting with the Message Delivery Service via HTTP. */
 export class MessageManagerClient {

--- a/packages/broker-message/src/http/messages.controller.ts
+++ b/packages/broker-message/src/http/messages.controller.ts
@@ -1,11 +1,12 @@
+import { EventMap } from '@trading-model/common/config/event.types';
+import { catchSync } from '@trading-model/common/middleware/catch-error';
+import { ResponseException } from '@trading-model/common/middleware/response-exception';
+
+import { EventManager } from '../client/event-manager-client';
 import {
   MessageMetadataSchema,
   MessagePayloadSchema,
 } from '../shared/helper/messages/message.schema';
-import { ResponseException } from '@trading-model/common/middleware/response-exception';
-import { catchSync } from '@trading-model/common/middleware/catch-error';
-import { EventMap } from '@trading-model/common/config/event.types';
-import { EventManager } from '../client/event-manager-client';
 
 /** Handles incoming broker messages and dispatches them to registered event listeners. */
 export const MessageController = catchSync(async req => {

--- a/packages/broker-message/src/http/messages.routes.ts
+++ b/packages/broker-message/src/http/messages.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+
 import { MessageController } from './messages.controller';
 
 /** Creates an Express route to receive broker message callbacks.

--- a/packages/broker-message/src/index.ts
+++ b/packages/broker-message/src/index.ts
@@ -1,16 +1,21 @@
 import { Application } from 'express';
-import { EventManager, Listener } from './client/event-manager-client';
-import { CreateCallbackRoute } from './http/messages.routes';
+
 import addressManagerClient from '@trading-model/address-manager';
-import { MessageMetadata } from './shared/helper/messages/message';
-import { HttpClient } from '@trading-model/common/config/http-client';
-import { MessageManagerClient } from './client/message-manager-client';
 import {
   EventEnumMap,
   EventMessagesArgs,
   EventMap,
 } from '@trading-model/common/config/event.types';
+import { HttpClient } from '@trading-model/common/config/http-client';
 import { ServiceInstanceName } from '@trading-model/common/config/services.types';
+
+import { EventManager, Listener } from './client/event-manager-client';
+import { MessageManagerClient } from './client/message-manager-client';
+import { CreateCallbackRoute } from './http/messages.routes';
+import { MessageMetadata } from './shared/helper/messages/message';
+
+
+
 
 /** Central orchestrator for broker message operations. */
 export default class {

--- a/packages/broker-message/src/shared/helper/create-message-manager.ts
+++ b/packages/broker-message/src/shared/helper/create-message-manager.ts
@@ -1,6 +1,7 @@
-import { ServiceInstanceName } from '@trading-model/common/config/services.types';
-import MessageManagerClass from '../../index';
 import type addressManagerClient from '@trading-model/address-manager';
+import { ServiceInstanceName } from '@trading-model/common/config/services.types';
+
+import MessageManagerClass from '../../index';
 
 /** Configuration options for creating a MessageManager instance. */
 export type MessageManagerOptions = {

--- a/packages/broker-message/src/shared/helper/messages/message.schema.ts
+++ b/packages/broker-message/src/shared/helper/messages/message.schema.ts
@@ -1,3 +1,6 @@
+import { z } from 'zod';
+
+import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
 import {
   EnumEventMessage,
   EventMap,
@@ -5,8 +8,6 @@ import {
   SourceType,
 } from '@trading-model/common/config/event.types';
 import { ServiceInstanceName } from '@trading-model/common/config/services.types';
-import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
-import { z } from 'zod';
 
 /** Validates the security metadata context (auth and signature). */
 export const SecurityMetadataContextPredicate = z

--- a/packages/broker-message/src/shared/helper/messages/message.ts
+++ b/packages/broker-message/src/shared/helper/messages/message.ts
@@ -1,12 +1,6 @@
-import { MetadataBuilderError } from '@trading-model/common/utils/errors';
 import { ServiceInstanceName } from '@trading-model/common/config/services.types';
-import {
-  MessageMetadata as MetadataType,
-  DeliveryType,
-  IdentifyType,
-  SecurityType,
-  RoutingType,
-} from '../../types/message';
+import { MetadataBuilderError } from '@trading-model/common/utils/errors';
+
 import {
   SecurityMetadataContextPredicate,
   PublisherMetadataContextPredicate,
@@ -17,6 +11,13 @@ import {
   TopicMetadataPredicate,
   IdsMetadataPredicate,
 } from './message.schema';
+import {
+  MessageMetadata as MetadataType,
+  DeliveryType,
+  IdentifyType,
+  SecurityType,
+  RoutingType,
+} from '../../types/message';
 
 /**
  * Represents an metadata in a message

--- a/packages/common/src/config/http-client.ts
+++ b/packages/common/src/config/http-client.ts
@@ -1,6 +1,6 @@
 import https from 'https';
-import { URL } from 'url';
 import fs from 'node:fs';
+import { URL } from 'url';
 
 /**
  * HttpClient

--- a/packages/common/src/middleware/handle-core-response.ts
+++ b/packages/common/src/middleware/handle-core-response.ts
@@ -1,7 +1,8 @@
-import { Response } from 'express';
 import ChainedError from 'chained-error';
-import { logger } from '../config/logger';
+import { Response } from 'express';
+
 import { ResponseException, ResponseCodeKey, HTTP_CODE } from './response-exception';
+import { logger } from '../config/logger';
 
 type fileHandle =
   | 'auth'

--- a/packages/common/src/middleware/mtls-auth.ts
+++ b/packages/common/src/middleware/mtls-auth.ts
@@ -1,4 +1,5 @@
 import { TLSSocket } from 'node:tls';
+
 import { catchSync } from './catch-error';
 import { ResponseException } from './response-exception';
 

--- a/packages/common/src/middleware/response-protocole.ts
+++ b/packages/common/src/middleware/response-protocole.ts
@@ -1,5 +1,6 @@
-import { ClassResponseExceptions } from './response-exception';
 import { NextFunction, Request, Response } from 'express';
+
+import { ClassResponseExceptions } from './response-exception';
 import { logger } from '../config/logger';
 import {
   AuthenticationError,

--- a/packages/common/src/server/bootstrap.ts
+++ b/packages/common/src/server/bootstrap.ts
@@ -1,5 +1,5 @@
-import { logger } from '../config/logger';
 import { HttpServer } from './create-secure-server';
+import { logger } from '../config/logger';
 
 /** Options for configuring a service bootstrap lifecycle. */
 export interface BootstrapOptions {

--- a/packages/common/src/server/create-secure-server.ts
+++ b/packages/common/src/server/create-secure-server.ts
@@ -1,13 +1,16 @@
-import { ResponseProtocole } from '../middleware/response-protocole';
-import { MTLSAuthMiddleware } from '../middleware/mtls-auth';
-import { logger } from '../config/logger';
-import { rateLimit } from 'express-rate-limit';
-import express, { Application } from 'express';
+import fs from 'node:fs';
 import https from 'node:https';
 import path from 'node:path';
+
+import express, { Application } from 'express';
+import { rateLimit } from 'express-rate-limit';
 import helmet from 'helmet';
-import fs from 'node:fs';
+
+
 import { PING_PATH } from './constants';
+import { logger } from '../config/logger';
+import { MTLSAuthMiddleware } from '../middleware/mtls-auth';
+import { ResponseProtocole } from '../middleware/response-protocole';
 
 /** Filesystem paths to TLS certificate files. */
 export interface TlsPaths {

--- a/services/discovery-server/src/app/index.ts
+++ b/services/discovery-server/src/app/index.ts
@@ -1,6 +1,7 @@
 import { createBootstrap } from '@trading-model/common/server/bootstrap';
-import { LeaseManagerInstance } from '../core/lease-manager';
+
 import { createServer } from './server';
+import { LeaseManagerInstance } from '../core/lease-manager';
 import '../config/env';
 
 createBootstrap({

--- a/services/discovery-server/src/app/server.ts
+++ b/services/discovery-server/src/app/server.ts
@@ -1,8 +1,9 @@
 import { createSecureServer } from '@trading-model/common/server/create-secure-server';
 import { loadTlsConfig } from '@trading-model/common/server/load-tls-config';
+
+import { env } from '../config/env';
 import { heartbeatRoutes } from '../routes/heartbeat.routes';
 import { registryRoutes } from '../routes/register.routes';
-import { env } from '../config/env';
 
 /** Create and return an HTTPS server with mounted registry and heartbeat routes. */
 export function createServer() {

--- a/services/discovery-server/src/config/env.ts
+++ b/services/discovery-server/src/config/env.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { BaseEnvSchema, validateEnv } from '@trading-model/common/validation/env';
 
 const DiscoveryEnvSchema = BaseEnvSchema.extend({

--- a/services/discovery-server/src/controllers/heartbeat.controller.ts
+++ b/services/discovery-server/src/controllers/heartbeat.controller.ts
@@ -1,8 +1,9 @@
-import { registry } from '../core/service-registry';
 import { catchSync } from '@trading-model/common/middleware/catch-error';
 import { ResponseException } from '@trading-model/common/middleware/response-exception';
 import { isNonEmptyString, isObject } from '@trading-model/common/validation/primitives';
+
 import { asHandler, validateInstanceToken } from './helpers';
+import { registry } from '../core/service-registry';
 
 /** Extend a service instance's lease by recording a heartbeat. */
 export const heartbeat = asHandler(

--- a/services/discovery-server/src/controllers/helpers.ts
+++ b/services/discovery-server/src/controllers/helpers.ts
@@ -1,6 +1,8 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express';
-import { isNonEmptyString } from '@trading-model/common/validation/primitives';
+
 import { ResponseException } from '@trading-model/common/middleware/response-exception';
+import { isNonEmptyString } from '@trading-model/common/validation/primitives';
+
 import { registry } from '../core/service-registry';
 
 /** Cast a controller function to an Express RequestHandler without type inference. */

--- a/services/discovery-server/src/controllers/register.controller.ts
+++ b/services/discovery-server/src/controllers/register.controller.ts
@@ -1,5 +1,3 @@
-import { ServiceInstance } from '../core/types';
-import { registry } from '../core/service-registry';
 import { catchSync } from '@trading-model/common/middleware/catch-error';
 import { ResponseException } from '@trading-model/common/middleware/response-exception';
 import {
@@ -8,7 +6,10 @@ import {
   isValidIP,
   isValidPort,
 } from '@trading-model/common/validation/primitives';
+
 import { asHandler } from './helpers';
+import { registry } from '../core/service-registry';
+import { ServiceInstance } from '../core/types';
 
 /** Register a new service instance or update an existing one in the registry. */
 export const register = asHandler(

--- a/services/discovery-server/src/core/lease-manager.ts
+++ b/services/discovery-server/src/core/lease-manager.ts
@@ -1,4 +1,5 @@
 import { logger } from '@trading-model/common/config/logger';
+
 import { registry } from './service-registry';
 import { ServiceInstance } from './types';
 import { env } from '../config/env';

--- a/services/discovery-server/src/core/service-registry.ts
+++ b/services/discovery-server/src/core/service-registry.ts
@@ -1,7 +1,9 @@
 import { createHmac } from 'crypto';
-import { ServiceInstance } from './types';
-import { generateRandomStr } from '@trading-model/common/crypto/random';
+
 import { ServiceInstanceName } from '@trading-model/common/config/services.types';
+import { generateRandomStr } from '@trading-model/common/crypto/random';
+
+import { ServiceInstance } from './types';
 
 /**
  * ServiceRegistry

--- a/services/discovery-server/src/routes/heartbeat.routes.ts
+++ b/services/discovery-server/src/routes/heartbeat.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+
 import { heartbeat, rotateToken } from '../controllers/heartbeat.controller';
 
 /**

--- a/services/discovery-server/src/routes/register.routes.ts
+++ b/services/discovery-server/src/routes/register.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+
 import {
   register,
   listServices,

--- a/services/financial-scraper/src/app/index.ts
+++ b/services/financial-scraper/src/app/index.ts
@@ -1,6 +1,7 @@
-import { bootstrapAddressManager } from '../config/address-manager';
 import { createBootstrap } from '@trading-model/common/server/bootstrap';
+
 import { createServer } from './server';
+import { bootstrapAddressManager } from '../config/address-manager';
 import '../config/env';
 
 let addressManager: ReturnType<typeof bootstrapAddressManager> | null = null;

--- a/services/financial-scraper/src/app/server.ts
+++ b/services/financial-scraper/src/app/server.ts
@@ -1,9 +1,10 @@
 import { createSecureServer } from '@trading-model/common/server/create-secure-server';
 import { loadTlsConfig } from '@trading-model/common/server/load-tls-config';
-import { MessageManagerListenExpress } from '../config/message-manager';
-import { AddressManagerRoutes } from '../config/address-manager';
+
 import { FinancialRoutes } from '../clients/http/routes';
+import { AddressManagerRoutes } from '../config/address-manager';
 import { env } from '../config/env';
+import { MessageManagerListenExpress } from '../config/message-manager';
 
 /** Create and return a secure Express server configured with TLS, financial routes, address manager, and message manager. */
 export function createServer() {

--- a/services/financial-scraper/src/clients/binance/binance.client.ts
+++ b/services/financial-scraper/src/clients/binance/binance.client.ts
@@ -1,3 +1,6 @@
+import { BINANCE_ENDPOINTS } from './endpoints';
+import { BINANCE_WEIGHTS } from './weights';
+import { httpClients } from '../../config/http';
 import {
   Binance24hrTickerStatsResponse,
   BinanceHistoricalTradeResponse,
@@ -9,9 +12,6 @@ import {
   BinanceSymbolPriceTickerResponse,
   BinanceSymbolOrderBookTickerResponse,
 } from '../../types/binance.api';
-import { httpClients } from '../../config/http';
-import { BINANCE_ENDPOINTS } from './endpoints';
-import { BINANCE_WEIGHTS } from './weights';
 
 const binance = httpClients.binance;
 

--- a/services/financial-scraper/src/clients/http/controller.ts
+++ b/services/financial-scraper/src/clients/http/controller.ts
@@ -1,10 +1,12 @@
 import z from 'zod';
+
 import { catchSync } from '@trading-model/common/middleware/catch-error';
-import { selectTradesBy } from '../../infra/market-data/schema/trades.schema';
-import { selectTickerBy } from '../../infra/market-data/schema/ticker24h.schema';
-import { selectOrderBookBy } from '../../infra/market-data/schema/order-book.schema';
 import { ResponseException } from '@trading-model/common/middleware/response-exception';
+
 import { selectCandlesBy } from '../../infra/market-data/schema/candles-schema';
+import { selectOrderBookBy } from '../../infra/market-data/schema/order-book.schema';
+import { selectTickerBy } from '../../infra/market-data/schema/ticker24h.schema';
+import { selectTradesBy } from '../../infra/market-data/schema/trades.schema';
 
 const symbolSchema = z.object({
   symbol: z.string('Symbol is required and must be a string.').min(1),

--- a/services/financial-scraper/src/clients/http/routes.ts
+++ b/services/financial-scraper/src/clients/http/routes.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+
 import {
   GetTradeBySourceController,
   GetTradeBySymbolController,

--- a/services/financial-scraper/src/config/address-manager.ts
+++ b/services/financial-scraper/src/config/address-manager.ts
@@ -1,4 +1,5 @@
 import { createAddressManager } from '@trading-model/address-manager/create-address-manager';
+
 import { env } from './env';
 
 const addressManager = createAddressManager(env);

--- a/services/financial-scraper/src/config/env.ts
+++ b/services/financial-scraper/src/config/env.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import {
   BaseEnvSchema,
   AddressManagerEnvSchema,

--- a/services/financial-scraper/src/config/message-manager.ts
+++ b/services/financial-scraper/src/config/message-manager.ts
@@ -1,5 +1,6 @@
-import { ServiceInstanceName } from '@trading-model/common/config/services.types';
 import { createMessageManager } from '@trading-model/broker-message/shared/helper/create-message-manager';
+import { ServiceInstanceName } from '@trading-model/common/config/services.types';
+
 import { AddressManager } from './address-manager';
 import { env } from './env';
 

--- a/services/financial-scraper/src/infra/market-data/market-data.model.ts
+++ b/services/financial-scraper/src/infra/market-data/market-data.model.ts
@@ -13,11 +13,11 @@
  * Designed for MySQL / MariaDB.
  */
 
-import { insertTrades as IinsertTrades } from './schema/trades.schema';
-import { insertTicker as IinsertTicker } from './schema/ticker24h.schema';
+import { CandleEntity, OrderBookEntity, TickerEntity, TradeEntity } from './market-data.types';
 import { insertCandles as IinsertCandles } from './schema/candles-schema';
 import { insertOrderBook as IinsertOrderBook } from './schema/order-book.schema';
-import { CandleEntity, OrderBookEntity, TickerEntity, TradeEntity } from './market-data.types';
+import { insertTicker as IinsertTicker } from './schema/ticker24h.schema';
+import { insertTrades as IinsertTrades } from './schema/trades.schema';
 
 /* ============================================================
  * MODEL

--- a/services/financial-scraper/src/infra/market-data/schema/candles-schema.ts
+++ b/services/financial-scraper/src/infra/market-data/schema/candles-schema.ts
@@ -1,4 +1,5 @@
 import { Table } from 'ts-sql-query/Table';
+
 import { DBConnection } from '../../../config/db';
 import { CandleEntity } from '../market-data.types';
 

--- a/services/financial-scraper/src/infra/market-data/schema/order-book.schema.ts
+++ b/services/financial-scraper/src/infra/market-data/schema/order-book.schema.ts
@@ -1,4 +1,5 @@
 import z from 'zod';
+
 import { OrderBookEntity } from '../market-data.types';
 
 const aksBidsDef = z.object({

--- a/services/financial-scraper/src/infra/market-data/schema/ticker24h.schema.ts
+++ b/services/financial-scraper/src/infra/market-data/schema/ticker24h.schema.ts
@@ -1,4 +1,5 @@
 import { Table } from 'ts-sql-query/Table';
+
 import { DBConnection } from '../../../config/db';
 import { TickerEntity } from '../market-data.types';
 

--- a/services/financial-scraper/src/infra/market-data/schema/trades.schema.ts
+++ b/services/financial-scraper/src/infra/market-data/schema/trades.schema.ts
@@ -1,4 +1,5 @@
 import { Table } from 'ts-sql-query/Table';
+
 import { DBConnection } from '../../../config/db';
 import { TradeEntity } from '../market-data.types';
 

--- a/services/financial-scraper/src/job/cron/binance.cron.ts
+++ b/services/financial-scraper/src/job/cron/binance.cron.ts
@@ -13,11 +13,14 @@
  */
 
 import os from 'os';
+
 import cron from 'node-cron';
 import pLimit from 'p-limit';
+
 import { logger } from '@trading-model/common/config/logger';
-import { BinanceWorker, BinanceWorkerResult } from '../worker/binance.worker';
+
 import { MarketDataController } from '../../infra/market-data/market-data.controller';
+import { BinanceWorker, BinanceWorkerResult } from '../worker/binance.worker';
 
 /** Configuration for scheduling a BinanceCronOrchestrator instance. */
 export interface CronConfig {

--- a/services/financial-scraper/src/job/worker/binance.worker.ts
+++ b/services/financial-scraper/src/job/worker/binance.worker.ts
@@ -12,6 +12,13 @@
  * in distributed environments.
  */
 
+import { createHash } from 'node:crypto';
+
+import { helper } from '@trading-model/broker-message';
+import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
+import { EnumEventMessage } from '@trading-model/common/config/event.types';
+import { ServiceInstanceName } from '@trading-model/common/config/services.types';
+
 import {
   getOrderBook,
   CandlestickData,
@@ -20,15 +27,11 @@ import {
   get24hrTickerStats,
   getSymbolPriceTicker,
 } from '../../clients/binance/binance.client';
-
-import { ServiceInstanceName } from '@trading-model/common/config/services.types';
-import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
-import { EnumEventMessage } from '@trading-model/common/config/event.types';
 import { BinanceNormalizer } from '../../clients/binance/normalizer';
-import { MessageManager } from '../../config/message-manager';
-import { helper } from '@trading-model/broker-message';
-import { createHash } from 'node:crypto';
 import { env } from '../../config/env';
+import { MessageManager } from '../../config/message-manager';
+
+
 
 /** Configuration options for a single BinanceWorker execution against one symbol. */
 export interface BinanceWorkerOptions {

--- a/services/message-manager/src/app/index.ts
+++ b/services/message-manager/src/app/index.ts
@@ -1,6 +1,7 @@
-import { bootstrapAddressManager } from '../config/address-manager';
 import { createBootstrap } from '@trading-model/common/server/bootstrap';
+
 import { createServer } from './server';
+import { bootstrapAddressManager } from '../config/address-manager';
 import '../config/env';
 
 let addressManager: ReturnType<typeof bootstrapAddressManager> | null = null;

--- a/services/message-manager/src/app/server.ts
+++ b/services/message-manager/src/app/server.ts
@@ -1,8 +1,9 @@
 import { createSecureServer } from '@trading-model/common/server/create-secure-server';
 import { loadTlsConfig } from '@trading-model/common/server/load-tls-config';
+
 import { AddressManagerRoutes } from '../config/address-manager';
-import { MessageManagerRoutes } from '../config/message-manager';
 import { env } from '../config/env';
+import { MessageManagerRoutes } from '../config/message-manager';
 
 /** Create and return an HTTPS server with mounted address-manager and message-manager routes. */
 export function createServer() {

--- a/services/message-manager/src/config/address-manager.ts
+++ b/services/message-manager/src/config/address-manager.ts
@@ -1,4 +1,5 @@
 import { createAddressManager } from '@trading-model/address-manager/create-address-manager';
+
 import { env } from './env';
 
 const addressManager = createAddressManager(env);

--- a/services/message-manager/src/config/env.ts
+++ b/services/message-manager/src/config/env.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import {
   BaseEnvSchema,
   AddressManagerEnvSchema,

--- a/services/message-manager/src/config/message-manager.ts
+++ b/services/message-manager/src/config/message-manager.ts
@@ -32,8 +32,8 @@
  * @since 2026.01.28
  */
 
-import BrokerModule from '../messaging/index';
 import { env } from './env';
+import BrokerModule from '../messaging/index';
 
 /**
  * Broker singleton instance.

--- a/services/message-manager/src/messaging/core/broker.ts
+++ b/services/message-manager/src/messaging/core/broker.ts
@@ -31,6 +31,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+
 import { Dispatcher } from './dispatcher';
 import { IdentifyType } from '../broker.type';
 import { message, MessageMetadata } from './message';

--- a/services/message-manager/src/messaging/core/dispatcher.ts
+++ b/services/message-manager/src/messaging/core/dispatcher.ts
@@ -38,10 +38,11 @@
  * 2026.01.28
  */
 
+import { HttpClient } from '@trading-model/common/config/http-client';
+
 import { message } from './message';
 import { Subscription } from './subscription';
 import { IdentifyType } from '../broker.type';
-import { HttpClient } from '@trading-model/common/config/http-client';
 
 /**
  * Message dispatcher.

--- a/services/message-manager/src/messaging/core/message.ts
+++ b/services/message-manager/src/messaging/core/message.ts
@@ -34,6 +34,7 @@
  */
 
 import { DeliveryModeEnum } from '@trading-model/common/config/delivery-mode.types';
+
 import { IdentifyType } from '../broker.type';
 
 /**

--- a/services/message-manager/src/messaging/core/subscription.ts
+++ b/services/message-manager/src/messaging/core/subscription.ts
@@ -27,9 +27,10 @@
  *
  * @since 2026.01.28
  */
-import { DeadLetterError, NackError } from '@trading-model/common/utils/errors';
 import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
 import { HttpClient } from '@trading-model/common/config/http-client';
+import { DeadLetterError, NackError } from '@trading-model/common/utils/errors';
+
 import { findAService } from '../../config/address-manager';
 import { IdentifyType } from '../broker.type';
 import { message as Message } from './message';

--- a/services/message-manager/src/messaging/index.ts
+++ b/services/message-manager/src/messaging/index.ts
@@ -29,12 +29,14 @@
  *
  * @since 2026.01.28
  */
-import { HttpClient } from '@trading-model/common/config/http-client';
-import { BrokerRoutes } from './transport/http.routes';
-import { BrokerConfig } from './broker.type';
-import { Dispatcher } from './core/dispatcher';
-import { Broker } from './core/broker';
 import { Application } from 'express';
+
+import { HttpClient } from '@trading-model/common/config/http-client';
+
+import { BrokerConfig } from './broker.type';
+import { Broker } from './core/broker';
+import { Dispatcher } from './core/dispatcher';
+import { BrokerRoutes } from './transport/http.routes';
 
 /**
  * BrokerModule

--- a/services/message-manager/src/messaging/transport/http.controller.ts
+++ b/services/message-manager/src/messaging/transport/http.controller.ts
@@ -32,9 +32,10 @@
  * @since 2026.01.28
  */
 
-import { PublishSchema, SubscribeSchema, UnsubscribeSchema } from './validation/broker.schema';
-import { ResponseException } from '@trading-model/common/middleware/response-exception';
 import { catchSync } from '@trading-model/common/middleware/catch-error';
+import { ResponseException } from '@trading-model/common/middleware/response-exception';
+
+import { PublishSchema, SubscribeSchema, UnsubscribeSchema } from './validation/broker.schema';
 import { Broker } from '../core/broker';
 
 /**

--- a/services/message-manager/src/messaging/transport/http.routes.ts
+++ b/services/message-manager/src/messaging/transport/http.routes.ts
@@ -28,6 +28,7 @@
  */
 
 import { Router } from 'express';
+
 import { SubscriptionToATopic, DeleteASubscription, PublishAMessage } from './http.controller';
 import { Broker } from '../core/broker';
 

--- a/services/message-manager/src/messaging/transport/validation/broker.schema.ts
+++ b/services/message-manager/src/messaging/transport/validation/broker.schema.ts
@@ -26,9 +26,10 @@
  * @since 2026.01.28
  */
 
+import { z } from 'zod';
+
 import { DeliveryMode, DeliveryModeEnum } from '@trading-model/common/config/delivery-mode.types';
 import { ServiceInstanceName } from '@trading-model/common/config/services.types';
-import { z } from 'zod';
 
 /**
  * @description

--- a/services/trader-trainer/src/app/index.ts
+++ b/services/trader-trainer/src/app/index.ts
@@ -7,12 +7,13 @@ import {
   TickerEntity,
 } from '@trading-model/common/config/event.types';
 import { createBootstrap } from '@trading-model/common/server/bootstrap';
-import { bootstrapAddressManager } from '../config/address-manager';
-import { MarketDataBuffer } from '../core/market-data-buffer';
-import { MessageManager } from '../config/message-manager';
-import { Trainer } from '../core/trainer';
+
 import { createServer } from './server';
+import { bootstrapAddressManager } from '../config/address-manager';
 import { env } from '../config/env';
+import { MessageManager } from '../config/message-manager';
+import { MarketDataBuffer } from '../core/market-data-buffer';
+import { Trainer } from '../core/trainer';
 
 let addressManager: ReturnType<typeof bootstrapAddressManager> | null = null;
 

--- a/services/trader-trainer/src/app/server.ts
+++ b/services/trader-trainer/src/app/server.ts
@@ -1,11 +1,12 @@
+import { catchSync } from '@trading-model/common/middleware/catch-error';
+import { ResponseException } from '@trading-model/common/middleware/response-exception';
 import { createSecureServer } from '@trading-model/common/server/create-secure-server';
 import { loadTlsConfig } from '@trading-model/common/server/load-tls-config';
-import { MessageManagerListenExpress } from '../config/message-manager';
+
 import { AddressManagerRoutes } from '../config/address-manager';
-import { Trainer } from '../core/trainer';
 import { env } from '../config/env';
-import { ResponseException } from '@trading-model/common/middleware/response-exception';
-import { catchSync } from '@trading-model/common/middleware/catch-error';
+import { MessageManagerListenExpress } from '../config/message-manager';
+import { Trainer } from '../core/trainer';
 
 /** Create and return a secure Express server with trader-trainer routes. */
 export function createServer(trainer: Trainer) {

--- a/services/trader-trainer/src/config/address-manager.ts
+++ b/services/trader-trainer/src/config/address-manager.ts
@@ -1,4 +1,5 @@
 import AddressManagerClass from '@trading-model/address-manager';
+
 import { env } from './env';
 
 const addressManager = new AddressManagerClass({

--- a/services/trader-trainer/src/config/env.ts
+++ b/services/trader-trainer/src/config/env.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { BaseEnvSchema, validateEnv } from '@trading-model/common/validation/env';
 
 const TraderTrainerEnvSchema = BaseEnvSchema.extend({

--- a/services/trader-trainer/src/config/message-manager.ts
+++ b/services/trader-trainer/src/config/message-manager.ts
@@ -1,5 +1,6 @@
-import { ServiceInstanceName } from '@trading-model/common/config/services.types';
 import { createMessageManager } from '@trading-model/broker-message/shared/helper/create-message-manager';
+import { ServiceInstanceName } from '@trading-model/common/config/services.types';
+
 import { AddressManager } from './address-manager';
 import { env } from './env';
 

--- a/services/trader-trainer/src/core/agent/trading-agent.ts
+++ b/services/trader-trainer/src/core/agent/trading-agent.ts
@@ -1,6 +1,6 @@
-import { Agent } from '../neural-network/agent';
-import { createWallet, WalletConfig } from '../env/wallet-manager';
 import StateManager, { StateManagerConfig } from './state-manager';
+import { createWallet, WalletConfig } from '../env/wallet-manager';
+import { Agent } from '../neural-network/agent';
 
 /** Configuration to create a TradingAgent with neural network, wallet, and RL state management. */
 export type TradingAgentConfig = {

--- a/services/trader-trainer/src/core/genetic-algorithm/diversity.ts
+++ b/services/trader-trainer/src/core/genetic-algorithm/diversity.ts
@@ -2,8 +2,8 @@
 //        speciation, diversity metrics, novelty scoring
 // ================================================================
 
-import type { Genome } from './genome-types';
 import { encodeGenome } from './encoding';
+import type { Genome } from './genome-types';
 
 // ================================================================
 //  1. Genomic distance

--- a/services/trader-trainer/src/core/genetic-algorithm/evaluation-pipeline.ts
+++ b/services/trader-trainer/src/core/genetic-algorithm/evaluation-pipeline.ts
@@ -3,8 +3,12 @@
  * Handles reward shaping, n-step returns, shadow backends, and Lamarckian updates.
  */
 
+import { estimateComplexity, computeAdjustedFitness } from './complexity-estimator';
 import type { LamarckGenome, MarketStep } from './genome-types';
+import { DeepReadonly } from './shared-types';
+import { RunningStats, computeVariance, computeSharpe } from './utils';
 import type { Experience } from '../../core/neural-network/type';
+
 // RLBackend is defined in ga_runner.ts and exported from there
 // We avoid circular dependency by using a type-only reference
 export interface RLBackend {
@@ -17,9 +21,6 @@ export interface RLBackend {
   resetEpisode(): void;
   getExperiencePool(): Experience[];
 }
-import { DeepReadonly } from './shared-types';
-import { RunningStats, computeVariance, computeSharpe } from './utils';
-import { estimateComplexity, computeAdjustedFitness } from './complexity-estimator';
 
 /** Creates a fresh RL backend for a given genome (used as a factory per evaluation). */
 export type BackendFactory = (g: DeepReadonly<LamarckGenome>) => RLBackend;

--- a/services/trader-trainer/src/core/genetic-algorithm/ga-runner.ts
+++ b/services/trader-trainer/src/core/genetic-algorithm/ga-runner.ts
@@ -3,6 +3,10 @@
 //   Couples with TradingAgent / AutoEnv / Deep Q-Learning agent
 // ----------------------------------------------------------------
 
+import { crossoverGenomes } from './crossover';
+import { crossoverWeights, mutateWeights } from './evolution-engine';
+import { createDefaultGenome } from './factory';
+import { computeFitness, shapeReward } from './fitness';
 import {
   Genome,
   GAControlGenome,
@@ -10,16 +14,12 @@ import {
   MarketStep,
   LamarckGenome,
 } from './genome-types';
-import TradingAgent, { TradingAgentConfig } from '../agent/trading-agent';
-import { computeFitness, shapeReward } from './fitness';
-import { Experience } from '../../core/neural-network/type';
-import { createDefaultGenome } from './factory';
-import { crossoverGenomes } from './crossover';
-import { selectParent } from './selection';
 import { mutateGenome } from './mutation';
-import { generateId, RunningStats, computeVariance, computeSharpe } from './utils';
-import { crossoverWeights, mutateWeights } from './evolution-engine';
 import { makePRNG } from './prng';
+import { selectParent } from './selection';
+import { generateId, RunningStats, computeVariance, computeSharpe } from './utils';
+import { Experience } from '../../core/neural-network/type';
+import TradingAgent, { TradingAgentConfig } from '../agent/trading-agent';
 
 // ----------------------------------------------------------------
 // Immutability helpers

--- a/services/trader-trainer/src/core/market-data-buffer.ts
+++ b/services/trader-trainer/src/core/market-data-buffer.ts
@@ -5,6 +5,7 @@ import {
   BookTickerEntity,
   TickerEntity,
 } from '@trading-model/common/config/event.types';
+
 import { MarketStep } from './genetic-algorithm/genome-types';
 
 /** Online running mean and standard deviation for z-score normalisation. */

--- a/services/trader-trainer/src/core/neural-network/agent.ts
+++ b/services/trader-trainer/src/core/neural-network/agent.ts
@@ -1,5 +1,6 @@
-import { NeuralNetwork } from './neural-network';
 import { AgentError } from '@trading-model/common/utils/errors';
+
+import { NeuralNetwork } from './neural-network';
 import { Experience, NeuralNetworkConfig } from './type';
 
 /**

--- a/services/trader-trainer/src/core/neural-network/neural-network.ts
+++ b/services/trader-trainer/src/core/neural-network/neural-network.ts
@@ -1,3 +1,10 @@
+import { AgentError } from '@trading-model/common/utils/errors';
+
+import { ACTIVATIONS } from './activation';
+import { INITIALIZERS } from './initializers';
+import { LOSSES } from './losses';
+import { NORMALIZERS } from './normalize';
+import { OptimizerHyperparams, DEFAULT_HYPERPARAMS, OPTIMIZERS } from './optimizer';
 import {
   NeuralNetworkConfig,
   ActivationType,
@@ -5,13 +12,7 @@ import {
   PooledExperience,
   ForwardContext,
 } from './type';
-import { OptimizerHyperparams, DEFAULT_HYPERPARAMS, OPTIMIZERS } from './optimizer';
-import { AgentError } from '@trading-model/common/utils/errors';
-import { INITIALIZERS } from './initializers';
-import { ACTIVATIONS } from './activation';
-import { NORMALIZERS } from './normalize';
 import { gaussianNoise } from './utils';
-import { LOSSES } from './losses';
 
 /**
  * Configurable fully-connected feedforward neural network with support for

--- a/services/trader-trainer/src/core/trainer.ts
+++ b/services/trader-trainer/src/core/trainer.ts
@@ -1,9 +1,9 @@
-import { GeneticAlgorithmRunner } from './genetic-algorithm/ga-runner';
 import { createDefaultGenome } from './genetic-algorithm/factory';
-import { MarketDataBuffer } from './market-data-buffer';
+import { GeneticAlgorithmRunner } from './genetic-algorithm/ga-runner';
+import { makeTradingAgentBackend, GenerationContext } from './genetic-algorithm/ga-runner';
 import { LamarckGenome } from './genetic-algorithm/genome-types';
 import { DeepReadonly } from './genetic-algorithm/shared-types';
-import { makeTradingAgentBackend, GenerationContext } from './genetic-algorithm/ga-runner';
+import { MarketDataBuffer } from './market-data-buffer';
 import { env } from '../config/env';
 
 /** Summary of the best trained agent for API responses. */


### PR DESCRIPTION
## Description

Enforce the import ordering convention from `docs/deployment/CONTRIBUTE.md` across the entire codebase using `eslint-plugin-import-x`.

### Import order (per CONTRIBUTE.md)
1. Node built-ins (`fs`, `path`)
2. External deps (`express`, `zod`)
3. Internal absolute (`@trading-model/*`)
4. Internal relative (`../`, `./`)
5. Side effects (`import './setup'`)

### Changes
- **`eslint.config.mjs`** — added `ix/order` rule with groups: builtin → external → internal → parent/sibling → index, plus `@trading-model/**` path group for internal resolution and alphabetize
- **`package.json`** — added `eslint-plugin-import-x` and `eslint-import-resolver-typescript` devDependencies
- **All source `.ts` files (73 files)** — auto-fixed import order by `eslint --fix`
- **`evaluation-pipeline.ts`** — manual fix (imports were separated by an interface declaration, preventing auto-fix)

## Type of Change

- [x] :wrench: Chore
- [x] :recycle: Refactor

## Related Issues

Follow-up to CONTRIBUTE.md import convention documented in `docs/deployment/CONTRIBUTE.md`

## Checklist

- [x] Code follows [project standards](docs/standards/WRITING.md)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] Tests pass (`npm test`)
- [x] Docs updated if needed

## Breaking Changes

None — import order only, no logic changes.

## Test Plan

```bash
npm run lint    # 0 errors
npm run build   # exit 0
npm test        # 496 passed
```
