### PR TITLE
:bug:(message-manager): implement Dead Letter Queue in subscription.ts

### DIFF
--- a/docs/architecture/api/message-manager.md
+++ b/docs/architecture/api/message-manager.md
@@ -162,7 +162,7 @@ Body (validated by `UnsubscribeSchema`):
 ## Features
 
 - **TTL**: Message expiration based on time-to-live configured in metadata
-- **Dead Letter Queue**: Undelivered messages after retry exhaustion
+- **Dead Letter Queue**: Undelivered messages persisted as JSON Lines (NDJSON) to `dead-letter-queue.jsonl` with failure reason, delivery attempt count, and timestamp
 - **Deduplication**: Via `deduplicationId` in delivery metadata
 - **Partitioning**: Via `partitionKey` in routing metadata
 - **Priority**: Via `priority` in routing metadata
@@ -176,6 +176,7 @@ HTTP Routes (http.routes.ts)
       → Broker (core/broker.ts)
         → Subscription Manager (core/subscription.ts)
         → Message Dispatcher (core/dispatcher.ts)
+        → Dead Letter Queue (core/dlq-repository.ts)
         → Message Store (core/message.ts + MongoDB)
 ```
 

--- a/services/message-manager/src/messaging/core/dispatcher.ts
+++ b/services/message-manager/src/messaging/core/dispatcher.ts
@@ -41,6 +41,7 @@
 import { HttpClient } from '@trading-model/common/config/http-client';
 import { IdentifyType, message } from '@trading-model/common/contracts/message.types';
 
+import { DqlRepository } from './dlq-repository';
 import { Subscription } from './subscription';
 
 /**
@@ -69,7 +70,10 @@ export class Dispatcher {
    * @lifecycle
    * Instantiated during application bootstrap.
    */
-  constructor(private HTTPCLIENT: HttpClient) {}
+  constructor(
+    private HTTPCLIENT: HttpClient,
+    private readonly dlqRepository: DqlRepository
+  ) {}
 
   /**
    * Register a subscription for a topic.
@@ -96,7 +100,12 @@ export class Dispatcher {
 
     if (current.some(s => s.serviceIdentity.instanceId === consumerIdentity.instanceId)) return;
 
-    const subscription = new Subscription(topic, callbackPath, consumerIdentity);
+    const subscription = new Subscription(
+      topic,
+      callbackPath,
+      consumerIdentity,
+      this.dlqRepository
+    );
 
     this.subscriptionsByTopic.set(topic, [...current, subscription]);
   }

--- a/services/message-manager/src/messaging/core/dlq-repository.ts
+++ b/services/message-manager/src/messaging/core/dlq-repository.ts
@@ -25,7 +25,7 @@ export class DqlRepository {
   constructor(private readonly filePath: string = './dead-letter-queue.jsonl') {}
 
   /**
-   * Persist a message to the Dead Letter Queue.
+   * Persists a message to the Dead Letter Queue.
    *
    * @param entry - The entry to persist.
    */

--- a/services/message-manager/src/messaging/core/dlq-repository.ts
+++ b/services/message-manager/src/messaging/core/dlq-repository.ts
@@ -1,0 +1,35 @@
+import { appendFile } from 'node:fs/promises';
+
+/** Single entry written to the Dead Letter Queue. */
+export interface DqlEntry {
+  /** The failed message payload and metadata. */
+  message: unknown;
+
+  /** Human-readable reason for the failure. */
+  reason?: string;
+
+  /** Number of delivery attempts made before the message was dead-lettered. */
+  deliveryAttempt: number;
+
+  /** ISO-8601 timestamp when the entry was created. */
+  timestamp: string;
+}
+
+/**
+ * File-based Dead Letter Queue repository.
+ *
+ * Appends dead-lettered messages as JSON Lines (NDJSON) to a file.
+ * Each line is a JSON-serialized DqlEntry.
+ */
+export class DqlRepository {
+  constructor(private readonly filePath: string = './dead-letter-queue.jsonl') {}
+
+  /**
+   * Persist a message to the Dead Letter Queue.
+   *
+   * @param entry - The entry to persist.
+   */
+  async add(entry: DqlEntry): Promise<void> {
+    await appendFile(this.filePath, JSON.stringify(entry) + '\n', 'utf-8');
+  }
+}

--- a/services/message-manager/src/messaging/core/subscription.ts
+++ b/services/message-manager/src/messaging/core/subscription.ts
@@ -32,6 +32,7 @@ import { HttpClient } from '@trading-model/common/config/http-client';
 import { IdentifyType, message as Message } from '@trading-model/common/contracts/message.types';
 import { DeadLetterError, NackError } from '@trading-model/common/utils/errors';
 
+import { DqlRepository } from './dlq-repository';
 import { findAService } from '../../config/address-manager';
 
 /**
@@ -79,7 +80,8 @@ export class Subscription {
   constructor(
     public readonly topic: string,
     public readonly callbackURL: string,
-    public readonly serviceIdentity: IdentifyType
+    public readonly serviceIdentity: IdentifyType,
+    private readonly dqlRepository: DqlRepository
   ) {}
 
   /**
@@ -135,12 +137,12 @@ export class Subscription {
         context.deliveryAttempt++;
 
         if (e instanceof DeadLetterError) {
-          await this.sendToDLQ(message, e.reason);
+          await this.sendToDLQ(message, e.reason, context.deliveryAttempt);
           return;
         }
 
         if (this.isExpired(ttl, emittedAt)) {
-          await this.sendToDLQ(message, 'TTL_EXPIRED');
+          await this.sendToDLQ(message, 'TTL_EXPIRED', context.deliveryAttempt);
           return;
         }
 
@@ -183,19 +185,23 @@ export class Subscription {
   /**
    * Routes a message to the Dead Letter Queue (DLQ).
    *
+   * Persists the failed message with failure metadata to the DLQ repository.
+   *
    * @template T
-   * @param {Message<T>} message Failed message
-   * @param {string} [reason] Optional failure reason
-   * @returns {Promise<void>}
-   * @description
-   * Placeholder for routing messages to an HTTP endpoint, persistent storage,
-   * or event sink.
+   * @param message - Failed message.
+   * @param reason - Human-readable failure reason.
+   * @param deliveryAttempt - Number of delivery attempts before dead-lettering.
    */
-  private async sendToDLQ<T>(_message: Message<T>, _reason?: string): Promise<void> {
-    void _message;
-    void _reason;
-    // PLACEHOLDER: HTTP ENDPOINT, STORAGE, or EVENT SINK
-    // Example:
-    // await httpClient.post("https://dlq.internal/messages", { message, reason });
+  private async sendToDLQ<T>(
+    message: Message<T>,
+    reason: string | undefined,
+    deliveryAttempt: number
+  ): Promise<void> {
+    await this.dqlRepository.add({
+      message,
+      reason,
+      deliveryAttempt,
+      timestamp: new Date().toISOString(),
+    });
   }
 }

--- a/services/message-manager/src/messaging/index.ts
+++ b/services/message-manager/src/messaging/index.ts
@@ -36,6 +36,7 @@ import { HttpClient } from '@trading-model/common/config/http-client';
 import { BrokerConfig } from './broker.type';
 import { Broker } from './core/broker';
 import { Dispatcher } from './core/dispatcher';
+import { DqlRepository } from './core/dlq-repository';
 import { BrokerRoutes } from './transport/http.routes';
 
 /**
@@ -72,7 +73,8 @@ export default class BrokerModule {
       key: config.KeyCertificatPath,
     });
 
-    this.Dispatcher = new Dispatcher(this.HTTPCLIENT);
+    const dqlRepository = new DqlRepository();
+    this.Dispatcher = new Dispatcher(this.HTTPCLIENT, dqlRepository);
     this.Broker = new Broker(this.Dispatcher);
 
     this.listen = app => app.use(BrokerRoutes(this.Broker));

--- a/services/message-manager/tests/integration/message-broker.integration.spec.ts
+++ b/services/message-manager/tests/integration/message-broker.integration.spec.ts
@@ -1,7 +1,12 @@
+import { unlink } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { Broker } from '../../src/messaging/core/broker';
 import { Dispatcher } from '../../src/messaging/core/dispatcher';
+import { DqlRepository } from '../../src/messaging/core/dlq-repository';
 import { createMockHttpClient } from '../helpers/broker.helper';
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach, afterAll } from '@jest/globals';
 import { mockServiceIdentity, mockSubscriberIdentity } from '../fixtures/broker.fixture';
 
 jest.mock('config/address-manager', () => ({
@@ -14,11 +19,19 @@ describe('Message Broker Integration', () => {
   let httpClient: ReturnType<typeof createMockHttpClient>;
   let dispatcher: Dispatcher;
   let broker: Broker;
+  const dlqFilePath = join(tmpdir(), `dlq-test-int-${Date.now()}.jsonl`);
 
   beforeEach(() => {
     httpClient = createMockHttpClient();
-    dispatcher = new Dispatcher(httpClient as never);
+    const dqlRepository = new DqlRepository(dlqFilePath);
+    dispatcher = new Dispatcher(httpClient as never, dqlRepository);
     broker = new Broker(dispatcher);
+  });
+
+  afterAll(async () => {
+    if (existsSync(dlqFilePath)) {
+      await unlink(dlqFilePath);
+    }
   });
 
   it('should deliver a published message to a subscribed service', async () => {

--- a/services/message-manager/tests/unit/messaging/core/dispatcher.spec.ts
+++ b/services/message-manager/tests/unit/messaging/core/dispatcher.spec.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { unlink } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, jest, beforeEach, afterAll } from '@jest/globals';
 import { Dispatcher } from '../../../../src/messaging/core/dispatcher';
+import { DqlRepository } from '../../../../src/messaging/core/dlq-repository';
 import { createMockHttpClient } from '../../../helpers/broker.helper';
 import {
   createMockMessage,
@@ -16,10 +21,19 @@ jest.mock('config/address-manager', () => ({
 describe('Dispatcher', () => {
   let mockHttpClient: ReturnType<typeof createMockHttpClient>;
   let dispatcher: Dispatcher;
+  let dqlRepository: DqlRepository;
+  const dlqFilePath = join(tmpdir(), `dlq-test-disp-${Date.now()}.jsonl`);
 
   beforeEach(() => {
     mockHttpClient = createMockHttpClient();
-    dispatcher = new Dispatcher(mockHttpClient as never);
+    dqlRepository = new DqlRepository(dlqFilePath);
+    dispatcher = new Dispatcher(mockHttpClient as never, dqlRepository);
+  });
+
+  afterAll(async () => {
+    if (existsSync(dlqFilePath)) {
+      await unlink(dlqFilePath);
+    }
   });
 
   describe('registerSubscription', () => {

--- a/services/message-manager/tests/unit/messaging/core/dlq-repository.spec.ts
+++ b/services/message-manager/tests/unit/messaging/core/dlq-repository.spec.ts
@@ -1,0 +1,87 @@
+import { unlink } from 'node:fs/promises';
+import { readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from '@jest/globals';
+import { DqlRepository, DqlEntry } from '../../../../src/messaging/core/dlq-repository';
+
+describe('DqlRepository', () => {
+  const testFilePath = join(tmpdir(), `dlq-test-${Date.now()}.jsonl`);
+
+  afterAll(async () => {
+    if (existsSync(testFilePath)) {
+      await unlink(testFilePath);
+    }
+  });
+
+  describe('add', () => {
+    it('should append a JSON line to the file', async () => {
+      const repo = new DqlRepository(testFilePath);
+
+      const entry: DqlEntry = {
+        message: { payload: 'test', metadata: { topic: 'test.topic' } },
+        reason: 'DeadLetterError',
+        deliveryAttempt: 3,
+        timestamp: '2026-06-06T12:00:00.000Z',
+      };
+
+      await repo.add(entry);
+
+      const lines = readFileSync(testFilePath, 'utf-8').trim().split('\n');
+      expect(lines).toHaveLength(1);
+
+      const parsed = JSON.parse(lines[0]);
+      expect(parsed.message).toEqual(entry.message);
+      expect(parsed.reason).toBe('DeadLetterError');
+      expect(parsed.deliveryAttempt).toBe(3);
+      expect(parsed.timestamp).toBe('2026-06-06T12:00:00.000Z');
+    });
+
+    it('should append multiple entries as separate lines', async () => {
+      const repo = new DqlRepository(testFilePath);
+
+      await repo.add({
+        message: { id: 1 },
+        deliveryAttempt: 1,
+        timestamp: '2026-06-06T12:00:01.000Z',
+      });
+
+      await repo.add({
+        message: { id: 2 },
+        reason: 'TTL_EXPIRED',
+        deliveryAttempt: 2,
+        timestamp: '2026-06-06T12:00:02.000Z',
+      });
+
+      const lines = readFileSync(testFilePath, 'utf-8').trim().split('\n');
+      expect(lines).toHaveLength(3);
+
+      const first = JSON.parse(lines[1]);
+      expect(first.message).toEqual({ id: 1 });
+
+      const second = JSON.parse(lines[2]);
+      expect(second.message).toEqual({ id: 2 });
+      expect(second.reason).toBe('TTL_EXPIRED');
+    });
+
+    it('should work with default file path when no path provided', () => {
+      const repo = new DqlRepository();
+      expect(repo).toBeInstanceOf(DqlRepository);
+    });
+
+    it('should handle entry without reason', async () => {
+      const repo = new DqlRepository(testFilePath);
+
+      await repo.add({
+        message: 'plain string payload',
+        deliveryAttempt: 0,
+        timestamp: '2026-06-06T12:00:03.000Z',
+      });
+
+      const line = readFileSync(testFilePath, 'utf-8').trim().split('\n').pop()!;
+      const parsed = JSON.parse(line);
+      expect(parsed.reason).toBeUndefined();
+      expect(parsed.message).toBe('plain string payload');
+    });
+  });
+});

--- a/services/message-manager/tests/unit/messaging/core/subscription.spec.ts
+++ b/services/message-manager/tests/unit/messaging/core/subscription.spec.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { unlink, writeFile } from 'node:fs/promises';
+import { readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, jest, beforeEach, afterAll } from '@jest/globals';
 import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
 import { DeadLetterError, NackError } from '@trading-model/common/utils/errors';
 import { Subscription } from '../../../../src/messaging/core/subscription';
+import { DqlRepository } from '../../../../src/messaging/core/dlq-repository';
 import { createMockHttpClient } from '../../../helpers/broker.helper';
 import { createMockMessage, mockServiceIdentity } from '../../../fixtures/broker.fixture';
 
@@ -14,10 +19,27 @@ jest.mock('config/address-manager', () => ({
 describe('Subscription', () => {
   let mockHttpClient: ReturnType<typeof createMockHttpClient>;
   let subscription: Subscription;
+  let dqlRepository: DqlRepository;
+  const dlqFilePath = join(tmpdir(), `dlq-test-sub-${Date.now()}.jsonl`);
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockHttpClient = createMockHttpClient();
-    subscription = new Subscription('test.topic', 'message/callback', mockServiceIdentity);
+    dqlRepository = new DqlRepository(dlqFilePath);
+    subscription = new Subscription(
+      'test.topic',
+      'message/callback',
+      mockServiceIdentity,
+      dqlRepository
+    );
+    if (existsSync(dlqFilePath)) {
+      await writeFile(dlqFilePath, '', 'utf-8');
+    }
+  });
+
+  afterAll(async () => {
+    if (existsSync(dlqFilePath)) {
+      await unlink(dlqFilePath);
+    }
   });
 
   describe('dispatch', () => {
@@ -59,6 +81,11 @@ describe('Subscription', () => {
       await subscription.dispatch(mockHttpClient as never, message);
 
       expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+
+      const content = readFileSync(dlqFilePath, 'utf-8').trim();
+      const entry = JSON.parse(content);
+      expect(entry.reason).toBe('Unrecoverable');
+      expect(entry.message.payload).toBe('payload');
     });
 
     it('should stop retrying and send to DLQ on TTL expiration', async () => {
@@ -75,6 +102,11 @@ describe('Subscription', () => {
       await subscription.dispatch(mockHttpClient as never, message);
 
       expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+
+      const content = readFileSync(dlqFilePath, 'utf-8').trim();
+      const entry = JSON.parse(content);
+      expect(entry.reason).toBe('TTL_EXPIRED');
+      expect(entry.message.payload).toBe('payload');
       mockDateNow.mockRestore();
     });
 


### PR DESCRIPTION
# Description

`sendToDLQ()` in `subscription.ts` was a no-op — failed messages were silently dropped with no audit trail. Implemented a file-based Dead Letter Queue using `DqlRepository` that persists undeliverable messages as JSON Lines (NDJSON) with failure reason, delivery attempt count, and timestamp.

## Type of Change

- [x] :bug: fix — Bug fix
- [x] :white_check_mark: test — Tests
- [x] :memo: docs — Documentation

## Changes

### ✅ Additions

- `services/message-manager/src/messaging/core/dlq-repository.ts` — `DqlRepository` class that appends failed messages to a JSON Lines file
- `services/message-manager/tests/unit/messaging/core/dlq-repository.spec.ts` — unit tests for `DqlRepository`

### :recycle: Modifications

- `services/message-manager/src/messaging/core/subscription.ts` — injects `DqlRepository`, implements `sendToDLQ()` to persist message + reason + deliveryAttempt + timestamp
- `services/message-manager/src/messaging/core/dispatcher.ts` — accepts `DqlRepository`, passes it to `Subscription` constructor
- `services/message-manager/src/messaging/index.ts` — instantiates `DqlRepository`, passes to `Dispatcher`
- `services/message-manager/tests/unit/messaging/core/subscription.spec.ts` — verifies DLQ file is written on DeadLetterError and TTL expiration
- `services/message-manager/tests/unit/messaging/core/dispatcher.spec.ts` — passes `DqlRepository` to `Dispatcher` constructor
- `services/message-manager/tests/integration/message-broker.integration.spec.ts` — passes `DqlRepository` to `Dispatcher`
- `docs/architecture/api/message-manager.md` — updated DLQ feature description and internal architecture diagram

## Breaking Changes

No — behavior is identical, failed messages are now persisted instead of silently dropped.

## Tests

- [x] Existing tests pass
- [x] New tests added for `DqlRepository` and DLQ entry verification in subscription
- [ ] Manual tests performed

## Checklist

- [x] Code follows [project standards](../docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)

## Closes Issues

Closes #87

## Additional Notes

Part of the code-quality audit (#80). The DLQ uses a file-based JSON Lines format (`dead-letter-queue.jsonl` by default) — lightweight, append-only, and parseable. Future iterations may migrate to MongoDB (already declared in `package.json` as `mongodb` dependency).
