### PR TITLE
:bug:(config): remove default changeme password for MYSQL_ROOT_PASSWORD in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,14 +32,14 @@ services:
     container_name: trading-mysql
     restart: unless-stopped
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-changeme}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE:-financial_scraper}
     volumes:
       - mysql-data:/var/lib/mysql
     networks:
       - trading-net
     healthcheck:
-      test: mysqladmin ping -h localhost -u root -p${MYSQL_ROOT_PASSWORD:-changeme}
+      test: mysqladmin ping -h localhost -u root -p${MYSQL_ROOT_PASSWORD}
       interval: 10s
       timeout: 5s
       retries: 5
@@ -148,7 +148,7 @@ services:
       MESSAGE_BUS_SHUTDOWN_TIMEOUT_MS: '5000'
       MESSAGE_CALLBACK_PATH: message
       DB_USER: ${MYSQL_USER:-root}
-      DB_PASSWORD: ${MYSQL_ROOT_PASSWORD:-changeme}
+      DB_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       DB_NAME: ${MYSQL_DATABASE:-financial_scraper}
       DB_HOST: mysql
       DB_PORT: '3306'


### PR DESCRIPTION
# Description

`MYSQL_ROOT_PASSWORD` defaulted to `changeme` in 3 places in docker-compose.yml. Removed the fallback so Docker Compose fails at startup if the variable is not explicitly set, preventing unauthorized database access.

## Type of Change

- [x] :bug: fix — Bug fix

## Changes

### :recycle: Modifications

- `docker-compose.yml:35` — `MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}` (removed `:-changeme`)
- `docker-compose.yml:42` — healthcheck `-p${MYSQL_ROOT_PASSWORD}` (removed `:-changeme`)
- `docker-compose.yml:151` — `DB_PASSWORD: ${MYSQL_ROOT_PASSWORD}` (removed `:-changeme`)

## Breaking Changes

Yes — deployments without `MYSQL_ROOT_PASSWORD` set in the environment will now fail to start instead of silently using `changeme`. This is the intended security fix.

## Tests

- [x] Existing tests pass
- [ ] New tests added
- [ ] Manual tests performed

## Checklist

- [x] Code follows [project standards](../docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)

## Closes Issues

Closes #88

## Additional Notes

Part of the code-quality audit (#80). Production deployments should use Docker secrets instead of environment variables for sensitive credentials.
