### PR TITLE
:bug:(middleware): validate socket is TLSSocket before cast in mtls-auth

### DIFF
--- a/docs/architecture/api/common.md
+++ b/docs/architecture/api/common.md
@@ -168,6 +168,7 @@ mTLS authentication middleware.
 - **Import**: `@trading-model/common/middleware/mtls-auth`
 - Checks `socket.authorized`, extracts client certificate identity
 - Attaches `clientIdentity` to the request (declared via global Express `Request` augmentation — `declare global { namespace Express { interface Request { clientIdentity: string } } }`)
+- Rejects non-TLS connections (e.g. plain HTTP) with a Forbidden error to prevent unauthenticated access
 
 ### handleCoreResponse / handleCoreAuthResponse
 

--- a/packages/common/src/middleware/mtls-auth.ts
+++ b/packages/common/src/middleware/mtls-auth.ts
@@ -16,8 +16,10 @@ declare global {
 /**
  * mTLS Authentication Middleware
  *
- * This middleware enforces mutual TLS (mTLS) authentication at the transport layer.
- * It ensures that:
+ * Enforces mutual TLS (mTLS) authentication at the transport layer.
+ * Rejects non-TLS connections immediately to prevent unauthenticated access.
+ * Verifies that:
+ *  - The socket is a valid TLS socket
  *  - The TLS handshake was successfully authorized
  *  - A valid client certificate was presented
  *  - A stable client identity can be extracted from the certificate
@@ -30,8 +32,23 @@ declare global {
  *   - Used on internal / service-to-service endpoints
  */
 export const MTLSAuthMiddleware = catchSync((req, res, next) => {
-  // Express request socket is expected to be a TLS socket when mTLS is enabled
+  /**
+   * Step 0 — Validate socket is TLS
+   *
+   * `req.socket as TLSSocket` silently succeeds on non-TLS connections
+   * (HTTP, plain TCP). Verify TLS-specific properties before proceeding
+   * to ensure we fail closed when mTLS is not the transport.
+   */
   const socket = req.socket as TLSSocket;
+
+  if (typeof socket.getPeerCertificate !== 'function') {
+    throw ResponseException(
+      JSON.stringify({
+        error: 'Non-TLS connection rejected',
+        reason: 'mTLS authentication requires a TLS socket',
+      })
+    ).Forbidden();
+  }
 
   /**
    * Step 1 — Verify TLS authorization

--- a/packages/common/tests/unit/mtls-auth.spec.ts
+++ b/packages/common/tests/unit/mtls-auth.spec.ts
@@ -34,6 +34,12 @@ describe('MTLSAuthMiddleware', () => {
     next = jest.fn();
   });
 
+  it('should throw Forbidden when socket is not a TLSSocket', () => {
+    req.socket = { constructor: { name: 'Socket' } };
+
+    expect(() => MTLSAuthMiddleware(req, res, next)).toThrow();
+  });
+
   it('should throw Forbidden when socket is not authorized', () => {
     req.socket = {
       authorized: false,


### PR DESCRIPTION
## Description

Replace the unvalidated `req.socket as TLSSocket` cast with a runtime guard that verifies TLS-specific socket properties. On non-TLS connections (plain HTTP, TCP), `socket.authorized` is `undefined`, causing `!socket.authorized` to throw a false Forbidden — or worse, potentially allow unauthenticated access if the guard logic were incorrect.

The fix fails closed: if the socket is not TLS, the middleware throws Forbidden (403).

## Type of Change

- [x] 🐛 Bug fix

## Related Issues

Closes #90

## Checklist

- [x] Code follows [project standards](../docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

No — production mTLS routes always have a TLSSocket; the guard only affects non-TLS routes that should never reach this middleware.

## Test Plan

- `npm run -w @trading-model/common test:coverage` — 182 tests, 100% statements/branches/functions/lines
- `npm run build` — compiles clean
- `npx eslint packages/common/src/middleware/mtls-auth.ts` — 0 errors
- `npx prettier --check packages/common/src/middleware/mtls-auth.ts packages/common/tests/unit/mtls-auth.spec.ts` — clean
