### PR TITLE
:bug:(address-manager): use https:// for health checks instead of http://

### DIFF
--- a/docs/architecture/api/address-manager.md
+++ b/docs/architecture/api/address-manager.md
@@ -124,7 +124,7 @@ Calls made to the Discovery Server:
 | POST   | `{addressManagerUrl}/services/ttl/refresh`   | `AddressManagerClient` | Refresh service lease TTL (Bearer token auth) |
 | POST   | `{addressManagerUrl}/token/rotate`           | `TokenManager`         | Rotate authentication token                   |
 | GET    | `{addressManagerUrl}/services/{serviceName}` | `ServiceDiscovery`     | Fetch a specific service instance             |
-| GET    | `http://{ip}:{port}/ping`                    | `ServiceHealthChecker` | Health-check a discovered service             |
+| GET    | `https://{host}:{port}/ping`                 | `ServiceHealthChecker` | Health-check a discovered service             |
 
 ## Environment Schema
 
@@ -169,7 +169,7 @@ AddressManagerConfig → HttpClient (mTLS)
 | `TokenManager`         | In-memory token storage, refresh via `POST /token/rotate`                                                                                                    |
 | `AddressManagerClient` | HTTP client for Discovery Server API (register, refresh TTL)                                                                                                 |
 | `ServiceCache`         | In-memory cache with TTL expiry for service instances                                                                                                        |
-| `ServiceHealthChecker` | Pings `http://{ip}:{port}/ping` to verify liveness                                                                                                           |
+| `ServiceHealthChecker` | Pings `https://{host}:{port}/ping` to verify liveness                                                                                                        |
 | `ServiceDiscovery`     | Orchestrates cache → health check → fetch flow                                                                                                               |
 | `Scheduler`            | Generic `node-cron` scheduler                                                                                                                                |
 | `RefreshJob<T>`        | Parameterized job that calls a configurable refresh function on a client instance. Replaces previously duplicated `TokenRefresherJob` and `TtlRefresherJob`. |

--- a/packages/address-manager/src/discovery/service-health-checker.ts
+++ b/packages/address-manager/src/discovery/service-health-checker.ts
@@ -74,7 +74,7 @@ export class ServiceHealthChecker {
    */
   private buildPingUrl(instance: ServiceInstance): string {
     const hostname = this.resolveDnsName(instance.serviceName);
-    return `http://${hostname}:${instance.port}${PING_PATH}`;
+    return `https://${hostname}:${instance.port}${PING_PATH}`;
   }
 
   /**

--- a/packages/address-manager/tests/unit/service-health-checker.spec.ts
+++ b/packages/address-manager/tests/unit/service-health-checker.spec.ts
@@ -34,7 +34,7 @@ describe('ServiceHealthChecker', () => {
     const result = await checker.isHealthy(instance);
 
     expect(result).toBe(true);
-    expect(httpClient.get).toHaveBeenCalledWith('http://user-service:8080/ping', {
+    expect(httpClient.get).toHaveBeenCalledWith('https://user-service:8080/ping', {
       timeoutMs: 2000,
     });
   });
@@ -45,7 +45,7 @@ describe('ServiceHealthChecker', () => {
     const result = await checker.isHealthy(instance);
 
     expect(result).toBe(false);
-    expect(httpClient.get).toHaveBeenCalledWith('http://user-service:8080/ping', {
+    expect(httpClient.get).toHaveBeenCalledWith('https://user-service:8080/ping', {
       timeoutMs: 2000,
     });
   });
@@ -63,7 +63,7 @@ describe('ServiceHealthChecker', () => {
 
   test('buildPingUrl generates correct URL with identity mapping', async () => {
     const url = (checker as any).buildPingUrl(instance);
-    expect(url).toBe('http://user-service:8080/ping');
+    expect(url).toBe('https://user-service:8080/ping');
   });
 
   describe('DNS name mapping', () => {
@@ -76,7 +76,7 @@ describe('ServiceHealthChecker', () => {
 
       const customInstance = { ...instance, serviceName: 'user-service' };
       const url = (checker as any).buildPingUrl(customInstance);
-      expect(url).toBe('http://custom-host:8080/ping');
+      expect(url).toBe('https://custom-host:8080/ping');
     });
 
     test('falls back to service name for unmapped services', async () => {
@@ -84,7 +84,7 @@ describe('ServiceHealthChecker', () => {
       checker = new ServiceHealthChecker(httpClient, 2000, dnsMap);
 
       const url = (checker as any).buildPingUrl(instance);
-      expect(url).toBe('http://user-service:8080/ping');
+      expect(url).toBe('https://user-service:8080/ping');
     });
 
     test('uses mapped DNS name in actual health check request', async () => {
@@ -94,7 +94,7 @@ describe('ServiceHealthChecker', () => {
 
       await checker.isHealthy(instance);
 
-      expect(httpClient.get).toHaveBeenCalledWith('http://discovery-server:8080/ping', {
+      expect(httpClient.get).toHaveBeenCalledWith('https://discovery-server:8080/ping', {
         timeoutMs: 2000,
       });
     });


### PR DESCRIPTION
## Description

Health check requests in `ServiceHealthChecker` used `http://` instead of `https://`, bypassing TLS/mTLS entirely. Availability information leaked in plaintext, and health checks would fail on services requiring TLS.

Changed the protocol to `https://` in `buildPingUrl()` to match the mTLS-protected deployment environment.

## Type of Change

- [x] 🐛 Bug fix

## Related Issues

Closes #91

## Checklist

- [x] Code follows [project standards](../docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

No — the `buildPingUrl` method is `private`; no external consumers are affected.

## Test Plan

- `npm run -w @trading-model/address-manager test:coverage` — 60 tests pass, 100% coverage on `service-health-checker.ts`
- `npx eslint packages/address-manager/src/discovery/service-health-checker.ts` — 0 errors
- `npx prettier --check packages/address-manager/src/discovery/service-health-checker.ts packages/address-manager/tests/unit/service-health-checker.spec.ts docs/architecture/api/address-manager.md` — clean
