### PR TITLE
:bug:(common): replace process.exit(1) in env.ts with typed ConfigurationError

### DIFF
--- a/docs/architecture/api/common.md
+++ b/docs/architecture/api/common.md
@@ -107,7 +107,7 @@ import {
 | ------------------------- | -------------------------------------------------------------------------------------- |
 | `BaseEnvSchema`           | `NODE_ENV`, `PORT`, `TLS_KEY_PATH`, `TLS_CERT_PATH`, `TLS_CA_PATH`, `LOG_LEVEL`        |
 | `AddressManagerEnvSchema` | `APP_NAME`, `SERVICE_NAME`, `INSTANCE_ID`, `CACHE_TTL_MS`, `ADDRESS_MANAGER_URL`, etc. |
-| `validateEnv(schema)`     | Parses `process.env` and exit(1) on failure                                            |
+| `validateEnv(schema)`     | Parses `process.env` and throws `ConfigurationError` on failure                        |
 
 ## HttpClient
 

--- a/packages/common/src/utils/errors.ts
+++ b/packages/common/src/utils/errors.ts
@@ -110,3 +110,10 @@ export class AgentError extends AgentBaseError {
     super(message, cause);
   }
 }
+
+/** Thrown when environment configuration validation fails. */
+export class ConfigurationError extends TradingModelError {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause);
+  }
+}

--- a/packages/common/src/validation/env.ts
+++ b/packages/common/src/validation/env.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { ConfigurationError } from '../utils/errors';
+
 /** Zod schema for base environment variables shared across all services. */
 export const BaseEnvSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'staging', 'production']).default('development'),
@@ -41,7 +43,7 @@ export const AddressManagerEnvSchema = z.object({
     .string()
     .optional()
     .default('{}')
-    .transform((val) => {
+    .transform(val => {
       try {
         const parsed = JSON.parse(val);
         return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
@@ -58,7 +60,9 @@ export type AddressManagerEnv = z.infer<typeof AddressManagerEnvSchema>;
 
 /**
  * Validates environment variables against a Zod schema.
- * Exits the process on validation failure.
+ *
+ * @throws {ConfigurationError} When validation fails — callers should handle
+ * this at the application boundary (e.g. exit with a clear message).
  */
 export function validateEnv<T extends z.ZodType>(schema: T): z.infer<T> {
   const parsed = schema.safeParse(process.env);
@@ -72,8 +76,8 @@ export function validateEnv<T extends z.ZodType>(schema: T): z.infer<T> {
         /* fallback */
       }
     }
-    console.error('❌ Invalid environment configuration', { errors });
-    process.exit(1);
+    console.error('Invalid environment configuration', { errors });
+    throw new ConfigurationError('Environment validation failed', parsed.error);
   }
 
   return parsed.data;

--- a/packages/common/tests/unit/env.spec.ts
+++ b/packages/common/tests/unit/env.spec.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
-import {
-  validateEnv,
-  BaseEnvSchema,
-  AddressManagerEnvSchema,
-} from '../../src/validation/env';
+import { validateEnv, BaseEnvSchema, AddressManagerEnvSchema } from '../../src/validation/env';
+import { ConfigurationError } from '../../src/utils/errors';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -14,7 +11,6 @@ describe('validateEnv', () => {
     jest.restoreAllMocks();
     process.env = { ...OLD_ENV };
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    jest.spyOn(process, 'exit').mockImplementation((() => undefined) as any);
   });
 
   afterEach(() => {
@@ -35,14 +31,13 @@ describe('validateEnv', () => {
     expect(result.TLS_CA_PATH).toBe('/some/ca');
   });
 
-  it('should exit process on invalid env', () => {
+  it('should throw ConfigurationError on invalid env', () => {
     delete process.env.NODE_ENV;
     delete process.env.TLS_KEY_PATH;
     delete process.env.TLS_CERT_PATH;
     delete process.env.TLS_CA_PATH;
 
-    validateEnv(BaseEnvSchema);
-    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(() => validateEnv(BaseEnvSchema)).toThrow(ConfigurationError);
   });
 
   it('should apply default values', () => {
@@ -86,8 +81,7 @@ describe('validateEnv', () => {
       delete process.env.TLS_CERT_PATH;
       delete process.env.TLS_CA_PATH;
 
-      validate2(BaseSchema2);
-      expect(process.exit).toHaveBeenCalledWith(1);
+      expect(() => validate2(BaseSchema2)).toThrow('Environment validation failed');
     });
   });
 
@@ -102,8 +96,7 @@ describe('validateEnv', () => {
     delete process.env.TLS_CERT_PATH;
     delete process.env.TLS_CA_PATH;
 
-    validateEnv(BaseEnvSchema);
-    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(() => validateEnv(BaseEnvSchema)).toThrow(ConfigurationError);
   });
 
   it('should handle invalid env when treeifyError is not a function', () => {
@@ -116,8 +109,7 @@ describe('validateEnv', () => {
     delete process.env.TLS_CERT_PATH;
     delete process.env.TLS_CA_PATH;
 
-    validateEnv(BaseEnvSchema);
-    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(() => validateEnv(BaseEnvSchema)).toThrow(ConfigurationError);
 
     zod.z.treeifyError = origTreeifyError;
   });

--- a/services/discovery-server/tests/unit/env.spec.ts
+++ b/services/discovery-server/tests/unit/env.spec.ts
@@ -48,8 +48,7 @@ describe('env configuration', () => {
     expect(env.CLEANUP_SERVICE_INTERVAL_MS).toBe(10000);
   });
 
-  it('should exit process on invalid env', () => {
-    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  it('should throw ConfigurationError on invalid env', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     process.env.TLS_KEY_PATH = '';
@@ -58,11 +57,9 @@ describe('env configuration', () => {
     process.env.ERROR_URL_WEBHOOK = 'not-a-url';
 
     jest.isolateModules(() => {
-      require('../../src/config/env');
+      expect(() => require('../../src/config/env')).toThrow('Environment validation failed');
     });
 
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
     errorSpy.mockRestore();
   });
 });

--- a/services/financial-scraper/tests/unit/config/env.spec.ts
+++ b/services/financial-scraper/tests/unit/config/env.spec.ts
@@ -52,34 +52,24 @@ describe('env', () => {
     expect(env.APP_NAME).toBe('financial-scraper');
   });
 
-  it('should exit process on validation failure when required vars missing', () => {
-    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit(1)');
-    });
+  it('should throw on validation failure when required vars missing', () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     process.env = {};
 
-    expect(() => require('../../../src/config/env')).toThrow('process.exit(1)');
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(() => require('../../../src/config/env')).toThrow();
 
-    exitSpy.mockRestore();
     consoleSpy.mockRestore();
   });
 
-  it('should exit process when APP_NAME is missing', () => {
-    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit(1)');
-    });
+  it('should throw when APP_NAME is missing', () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     setRequiredVars();
     delete process.env.APP_NAME;
 
-    expect(() => require('../../../src/config/env')).toThrow('process.exit(1)');
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(() => require('../../../src/config/env')).toThrow();
 
-    exitSpy.mockRestore();
     consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Description

Replace `process.exit(1)` in the shared `validateEnv()` utility with a typed `ConfigurationError` (extends `TradingModelError`). Callers can now handle configuration failures gracefully — falling back to defaults, reporting via health endpoint, etc. — instead of the process dying abruptly.

## Type of Change

- [x] 🐛 Bug fix

## Changes

### ✅ Additions

- `ConfigurationError` class in `packages/common/src/utils/errors.ts` — extends `TradingModelError`, thrown when env validation fails

### :recycle: Modifications

- `packages/common/src/validation/env.ts`: `process.exit(1)` → `throw new ConfigurationError(...)`; removed emoji from `console.error`; updated JSDoc
- `packages/common/tests/unit/env.spec.ts`: replaced `expect(process.exit).toHaveBeenCalledWith(1)` with `expect(() => validateEnv(...)).toThrow(ConfigurationError)` in all 4 tests; removed `process.exit` mock
- `services/discovery-server/tests/unit/env.spec.ts`: updated invalid-env test to catch `ConfigurationError` instead of spying on `process.exit`
- `services/financial-scraper/tests/unit/config/env.spec.ts`: updated both invalid-env tests to use `toThrow()` instead of `process.exit` mock
- `docs/architecture/api/common.md`: `exit(1) on failure` → `throws ConfigurationError on failure`

### :fire: Removals

- None

## Related Issues

Closes #93

## Checklist

- [x] Code follows [project standards](../docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

No — `ConfigurationError` extends `TradingModelError` (which extends `Error`), so existing `try/catch` blocks that catch `Error` continue to work. Callers that relied on `process.exit(1)` side effects (none exist — it was always terminal) are unaffected.

## Test Plan

- `npm run -w @trading-model/common test:coverage` — 181 tests, 100% statements/branches/functions/lines
- `npm run -w discovery-server test:coverage` — 86 tests, 100% coverage
- `npm run -w financial-scraper test:coverage` — 208 tests, 100% coverage
- `npx eslint packages/common/src/validation/env.ts packages/common/src/utils/errors.ts` — 0 errors
- `npx prettier --check packages/common/src/validation/env.ts packages/common/src/utils/errors.ts packages/common/tests/unit/env.spec.ts services/discovery-server/tests/unit/env.spec.ts services/financial-scraper/tests/unit/config/env.spec.ts docs/architecture/api/common.md` — clean

## Additional Notes

- The `dist/` output of `@trading-model/common` must be rebuilt (`npm run -w @trading-model/common build`) before downstream service tests pass, since they resolve the compiled JS, not the source.
