### PR TITLE
:bug:(common): fix race condition in server.close() promise resolving before close completes

### DIFF
--- a/docs/architecture/api/common.md
+++ b/docs/architecture/api/common.md
@@ -88,6 +88,7 @@ Features:
 - `GET /ping` endpoint (constant `PING_PATH`)
 - `MTLSAuthMiddleware` injected automatically
 - `ResponseProtocole` as last middleware
+- `server.close()` returns a promise that resolves only after all in-flight connections have drained (uses Node.js callback form)
 
 ## Environment Validation
 

--- a/packages/common/src/server/create-secure-server.ts
+++ b/packages/common/src/server/create-secure-server.ts
@@ -6,7 +6,6 @@ import express, { Application } from 'express';
 import { rateLimit } from 'express-rate-limit';
 import helmet from 'helmet';
 
-
 import { PING_PATH } from './constants';
 import { logger } from '../config/logger';
 import { MTLSAuthMiddleware } from '../middleware/mtls-auth';
@@ -92,14 +91,17 @@ export function createSecureServer(options: SecureServerOptions): HttpServer {
   });
 
   return {
+    /**
+     * Close the HTTPS server and wait for all in-flight connections to drain.
+     * Uses the Node.js callback form to guarantee the promise resolves only
+     * after the server has fully stopped.
+     */
     close: () =>
       new Promise<void>((resolve, reject) => {
-        try {
-          httpsServer.close();
-          resolve();
-        } catch (e) {
-          reject(e);
-        }
+        httpsServer.close(err => {
+          if (err) reject(err);
+          else resolve();
+        });
       }),
   };
 }

--- a/packages/common/tests/unit/create-secure-server.spec.ts
+++ b/packages/common/tests/unit/create-secure-server.spec.ts
@@ -31,7 +31,7 @@ jest.mock('node:https', () => ({
   createServer: jest.fn((_options: any, _app: any) => {
     mockHttpsServer = {
       listen: jest.fn((_port: number, cb: () => void) => cb()),
-      close: jest.fn(),
+      close: jest.fn((cb: (err?: Error) => void) => cb && cb()),
     };
     return mockHttpsServer;
   }),
@@ -147,10 +147,10 @@ describe('createSecureServer', () => {
     expect(mockHttpsServer.close).toHaveBeenCalled();
   });
 
-  it('should reject when HTTPS server close throws', async () => {
+  it('should reject when HTTPS server close returns an error', async () => {
     const server = createSecureServer(defaultOptions);
-    mockHttpsServer.close.mockImplementationOnce(() => {
-      throw new Error('close error');
+    mockHttpsServer.close.mockImplementationOnce((cb: (err: Error | undefined) => void) => {
+      cb(new Error('close error'));
     });
     await expect(server.close()).rejects.toThrow('close error');
   });


### PR DESCRIPTION
## Description

Fix a race condition in `createSecureServer` where `server.close()` resolved its promise immediately, before the HTTPS server actually finished closing. In-flight connections could be terminated prematurely, and callers `await`ing `server.close()` would proceed before shutdown completed.

## Type of Change

- [x] 🐛 Bug fix

## Changes

### ✅ Additions

- None

### :recycle: Modifications

- `packages/common/src/server/create-secure-server.ts:95-103` — replaced `httpsServer.close(); resolve()` with the Node.js callback form `httpsServer.close(err => { if (err) reject(err); else resolve(); })`, so the promise only resolves after the server is fully closed
- `packages/common/tests/unit/create-secure-server.spec.ts` — updated mock `close` to invoke its callback; updated rejection test to pass error via callback instead of throwing
- `docs/architecture/api/common.md` — documented that `server.close()` waits for in-flight connections to drain

### :fire: Removals

- Removed unnecessary `try/catch` wrapper — the callback form handles both synchronous and asynchronous errors

## Related Issues

Closes #95

## Checklist

- [x] Code follows [project standards](../docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Test Plan

- `npm run -w @trading-model/common test:coverage` — 187 tests, 100% statements/branches/functions/lines
- `npx eslint packages/common/src/server/create-secure-server.ts` — 0 errors
- `npx prettier --check packages/common/src/server/create-secure-server.ts packages/common/tests/unit/create-secure-server.spec.ts docs/architecture/api/common.md` — clean

## Additional Notes

The previous implementation called `resolve()` synchronously after `httpsServer.close()` returned, but Node's `server.close()` is asynchronous — it takes a callback that fires when all connections have drained. The fix wraps this in `new Promise<void>` with the standard callback pattern, making `await server.close()` truly wait for shutdown.
