### PR TITLE
:bug:(message-manager): fix infinite retry loop with backoff, circuit breaker and alerting

### DIFF
--- a/docs/architecture/api/message-manager.md
+++ b/docs/architecture/api/message-manager.md
@@ -153,15 +153,18 @@ Body (validated by `UnsubscribeSchema`):
 
 ## Delivery Semantics
 
-| Mode            | Description                                               |
-| --------------- | --------------------------------------------------------- |
-| `AT_MOST_ONCE`  | Delivered at most once (no retries)                       |
-| `AT_LEAST_ONCE` | Delivered at least once (retries until ACK or TTL expiry) |
-| `EXACTLY_ONCE`  | Delivered exactly once (idempotent)                       |
+| Mode            | Description                                                                   |
+| --------------- | ----------------------------------------------------------------------------- |
+| `AT_MOST_ONCE`  | Delivered at most once (no retries)                                           |
+| `AT_LEAST_ONCE` | Delivered at least once (retries with exponential backoff, up to 10 attempts) |
+| `EXACTLY_ONCE`  | Delivered exactly once (idempotent)                                           |
 
 ## Features
 
 - **TTL**: Message expiration based on time-to-live configured in metadata
+- **Retry with backoff**: `AT_LEAST_ONCE` retries up to 10 times with exponential backoff (1s base, 60s cap) and ±20% random jitter
+- **Circuit breaker**: After 5 consecutive dispatch failures, new messages are routed directly to the Dead Letter Queue to prevent cascading failures; the breaker resets on the next successful delivery
+- **Alerting**: Persistent delivery failures are logged at ERROR level with topic, service name, and attempt count
 - **Dead Letter Queue**: Undelivered messages persisted as JSON Lines (NDJSON) to `dead-letter-queue.jsonl` with failure reason, delivery attempt count, and timestamp
 - **Deduplication**: Via `deduplicationId` in delivery metadata
 - **Partitioning**: Via `partitionKey` in routing metadata

--- a/services/message-manager/src/config/logger.ts
+++ b/services/message-manager/src/config/logger.ts
@@ -1,0 +1,1 @@
+export { logger } from '@trading-model/common/config/logger';

--- a/services/message-manager/src/messaging/core/subscription.ts
+++ b/services/message-manager/src/messaging/core/subscription.ts
@@ -31,9 +31,26 @@ import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
 import { HttpClient } from '@trading-model/common/config/http-client';
 import { IdentifyType, message as Message } from '@trading-model/common/contracts/message.types';
 import { DeadLetterError, NackError } from '@trading-model/common/utils/errors';
+import { sleep } from '@trading-model/common/utils/sleep';
 
 import { DqlRepository } from './dlq-repository';
 import { findAService } from '../../config/address-manager';
+import { logger } from '../../config/logger';
+
+/** Maximum number of delivery retries before routing to DLQ. */
+const MAX_RETRIES = 10;
+
+/** Base delay (ms) for exponential backoff between retries. */
+const BASE_DELAY_MS = 1000;
+
+/** Maximum delay (ms) cap for exponential backoff. */
+const MAX_DELAY_MS = 60_000;
+
+/** Random jitter factor applied to backoff delay (±20%). */
+const JITTER_FACTOR = 0.2;
+
+/** Consecutive dispatch failures before the circuit breaker opens. */
+const CIRCUIT_BREAKER_THRESHOLD = 5;
 
 /**
  * Runtime context provided to subscribers during message delivery.
@@ -72,10 +89,14 @@ interface SubscribersContext {
  * @class Subscription
  */
 export class Subscription {
+  /** Consecutive dispatch failures across messages (circuit breaker state). */
+  private failureCount = 0;
+
   /**
-   * @param {string} topic Topic name subscribed to
-   * @param {string} callbackURL Relative HTTP endpoint for message delivery
-   * @param {IdentifyType} serviceIdentity Identity of the consuming service
+   * @param topic - Topic name subscribed to.
+   * @param callbackURL - Relative HTTP endpoint for message delivery.
+   * @param serviceIdentity - Identity of the consuming service.
+   * @param dqlRepository - Repository for dead-lettered messages.
    */
   constructor(
     public readonly topic: string,
@@ -85,27 +106,50 @@ export class Subscription {
   ) {}
 
   /**
+   * Compute exponential backoff delay with random jitter.
+   *
+   * @param attempt - Zero-based delivery attempt number.
+   * @returns Delay in milliseconds.
+   */
+  private static backoffDelay(attempt: number): number {
+    const exponential = Math.min(BASE_DELAY_MS * Math.pow(2, attempt), MAX_DELAY_MS);
+    const jitter = exponential * JITTER_FACTOR * (Math.random() * 2 - 1);
+    return Math.round(exponential + jitter);
+  }
+
+  /**
    * Dispatches a message to the subscribed service.
    *
-   * @description
    * Resolves the target service address, sends the message via HTTP,
-   * retries according to delivery semantics, and handles TTL expiration.
+   * retries with exponential backoff up to MAX_RETRIES, and falls
+   * back to the Dead Letter Queue when all retries are exhausted.
+   * A circuit breaker prevents cascading failures when the target
+   * service is persistently unavailable.
    *
    * Delivery behavior depends on `DeliveryMode`:
-   * - `AT_LEAST_ONCE`: retries until ACK or TTL expiry
+   * - `AT_LEAST_ONCE`: retries until ACK, max retries, or TTL expiry
    * - `AT_MOST_ONCE`: no retry on NACK
    * - `EXACTLY_ONCE`: stops after first delivery
    *
-   * @template T Message payload type
-   * @param {Message<T>} message Message to dispatch
-   * @param {HttpClient} httpClient HTTP client instance
-   * @returns {Promise<void>}
+   * @template T - Message payload type.
+   * @param httpClient - HTTP client instance.
+   * @param message - Message to dispatch.
    */
   async dispatch<T>(httpClient: HttpClient, message: Message<T>): Promise<void> {
     const ttl = message.metadata.delivery?.ttl ?? 0;
     const deliveryMode = message.metadata.delivery?.mode ?? DeliveryMode.AT_LEAST_ONCE;
 
     const emittedAt = new Date(message.metadata.emittedAt ?? 0).getTime();
+
+    if (this.failureCount >= CIRCUIT_BREAKER_THRESHOLD) {
+      logger.warn('Circuit breaker open — rejecting dispatch', {
+        topic: this.topic,
+        service: this.serviceIdentity.serviceName,
+        failureCount: this.failureCount,
+      });
+      await this.sendToDLQ(message, 'CIRCUIT_OPEN', this.failureCount);
+      return;
+    }
 
     let acknowledged = false;
 
@@ -150,13 +194,25 @@ export class Subscription {
           return;
         }
 
-        // retry (AT LEAST ONCE)
-        // FUTURE: backof / jitter / circuit breaker;
+        if (context.deliveryAttempt >= MAX_RETRIES) {
+          this.failureCount++;
+          logger.error('Max retries exceeded — routing to DLQ', {
+            topic: this.topic,
+            service: this.serviceIdentity.serviceName,
+            deliveryAttempt: context.deliveryAttempt,
+          });
+          await this.sendToDLQ(message, 'MAX_RETRIES_EXCEEDED', context.deliveryAttempt);
+          return;
+        }
+
+        await sleep(Subscription.backoffDelay(context.deliveryAttempt));
       }
 
       if (deliveryMode === DeliveryMode.EXACTLY_ONCE || deliveryMode === DeliveryMode.AT_MOST_ONCE)
         return;
     }
+
+    this.failureCount = 0;
   }
 
   /**

--- a/services/message-manager/tests/unit/messaging/core/subscription.spec.ts
+++ b/services/message-manager/tests/unit/messaging/core/subscription.spec.ts
@@ -10,6 +10,10 @@ import { DqlRepository } from '../../../../src/messaging/core/dlq-repository';
 import { createMockHttpClient } from '../../../helpers/broker.helper';
 import { createMockMessage, mockServiceIdentity } from '../../../fixtures/broker.fixture';
 
+jest.mock('@trading-model/common/utils/sleep', () => ({
+  sleep: jest.fn(() => Promise.resolve()),
+}));
+
 jest.mock('config/address-manager', () => ({
   findAService: jest
     .fn<() => Promise<{ ip: string; port: number }>>()
@@ -58,7 +62,7 @@ describe('Subscription', () => {
       expect(body).toBeDefined();
     });
 
-    it('should retry on generic error with AT_LEAST_ONCE mode', async () => {
+    it('should retry with exponential backoff on generic error with AT_LEAST_ONCE mode', async () => {
       mockHttpClient.post
         .mockRejectedValueOnce(new Error('Network error'))
         .mockRejectedValueOnce(new Error('Network error'))
@@ -67,6 +71,7 @@ describe('Subscription', () => {
       const message = createMockMessage('payload', {
         delivery: { mode: DeliveryMode.AT_LEAST_ONCE, ttl: 60000 },
       });
+
       await subscription.dispatch(mockHttpClient as never, message);
 
       expect(mockHttpClient.post).toHaveBeenCalledTimes(3);
@@ -130,6 +135,67 @@ describe('Subscription', () => {
       await subscription.dispatch(mockHttpClient as never, message);
 
       expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('should route to DLQ when max retries exceeded', async () => {
+      mockHttpClient.post.mockRejectedValue(new Error('Transient error'));
+
+      const message = createMockMessage('payload', {
+        delivery: { mode: DeliveryMode.AT_LEAST_ONCE, ttl: 60000 },
+      });
+
+      await subscription.dispatch(mockHttpClient as never, message);
+
+      const content = readFileSync(dlqFilePath, 'utf-8').trim();
+      const entry = JSON.parse(content);
+      expect(entry.reason).toBe('MAX_RETRIES_EXCEEDED');
+    });
+
+    it('should open circuit breaker after threshold failures and reject directly to DLQ', async () => {
+      mockHttpClient.post.mockRejectedValue(new Error('Service down'));
+
+      const message = createMockMessage('payload', {
+        delivery: { mode: DeliveryMode.AT_LEAST_ONCE, ttl: 60000 },
+      });
+
+      // exhaust retries 5 times to reach CIRCUIT_BREAKER_THRESHOLD
+      for (let i = 0; i < 5; i++) {
+        await subscription.dispatch(mockHttpClient as never, message);
+      }
+
+      // 6th dispatch — circuit is open, goes directly to DLQ with CIRCUIT_OPEN
+      await subscription.dispatch(mockHttpClient as never, message);
+
+      const content = readFileSync(dlqFilePath, 'utf-8').trim();
+      const lines = content.split('\n');
+      const lastEntry = JSON.parse(lines[lines.length - 1]);
+      expect(lastEntry.reason).toBe('CIRCUIT_OPEN');
+    });
+
+    it('should reset circuit breaker on successful delivery', async () => {
+      mockHttpClient.post
+        .mockRejectedValue(new Error('Service down'))
+        .mockResolvedValueOnce(undefined);
+
+      const message = createMockMessage('payload', {
+        delivery: { mode: DeliveryMode.AT_LEAST_ONCE, ttl: 60000 },
+      });
+
+      // first message — fails (retries exhausted), failureCount = 1
+      await subscription.dispatch(mockHttpClient as never, message);
+
+      // second message — succeeds, failureCount resets to 0
+      mockHttpClient.post.mockReset();
+      mockHttpClient.post.mockResolvedValue(undefined);
+
+      await subscription.dispatch(mockHttpClient as never, message);
+
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+
+      // third message — also succeeds, confirming failureCount was reset
+      await subscription.dispatch(mockHttpClient as never, message);
+
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(2);
     });
 
     it('should succeed on first attempt with AT_MOST_ONCE mode', async () => {


### PR DESCRIPTION
## Description

Fix the infinite retry loop in subscription delivery that had no backoff, no max retries, and no circuit breaker. Replace it with:

- Exponential backoff with jitter (1s base, 60s cap, ±20% jitter)
- Max retries cap (10 attempts) before routing to DLQ
- Circuit breaker (5 consecutive failures → open, reject new messages directly to DLQ)
- ERROR-level alerting on persistent delivery failures

## Type of Change

- [x] 🐛 Bug fix

## Changes

### ✅ Additions

- `services/message-manager/src/messaging/core/subscription.ts`: static `backoffDelay()` method for exponential backoff with jitter; class-level `failureCount` circuit breaker state; constants: `MAX_RETRIES` (10), `BASE_DELAY_MS` (1000), `MAX_DELAY_MS` (60000), `JITTER_FACTOR` (0.2), `CIRCUIT_BREAKER_THRESHOLD` (5)
- `services/message-manager/src/config/logger.ts`: re-exports logger from `@trading-model/common/config/logger`
- 3 new tests: max retries exceeded → DLQ, circuit breaker opens after threshold, circuit breaker resets on success

### :recycle: Modifications

- `services/message-manager/src/messaging/core/subscription.ts`:
  - Before dispatch: circuit breaker check — rejects with `CIRCUIT_OPEN` if `failureCount >= 5`
  - Catch block: checks `deliveryAttempt >= MAX_RETRIES` → increments `failureCount`, logs ERROR, routes to DLQ
  - Catch block: calls `sleep(backoffDelay(attempt))` before next retry
  - After successful dispatch: resets `failureCount = 0`
- `services/message-manager/tests/unit/messaging/core/subscription.spec.ts`: updated retry test to work with sleep mock; added new test cases
- `docs/architecture/api/message-manager.md`: updated delivery semantics table and Features section with retry, backoff, circuit breaker details

### :fire: Removals

- Removed `// FUTURE: backof / jitter / circuit breaker` comment

## Related Issues

Closes #96

## Checklist

- [x] Code follows [project standards](../docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Test Plan

- `npm run -w message-manager test -- --coverage` — 79 tests, 100% statements/branches/functions/lines
- `npx eslint services/message-manager/src/messaging/core/subscription.ts` — 0 errors
- `npx prettier --check services/message-manager/src/messaging/core/subscription.ts services/message-manager/tests/unit/messaging/core/subscription.spec.ts services/message-manager/src/config/logger.ts` — clean

## Additional Notes

The sleep utility (`@trading-model/common/utils/sleep`) is mocked in tests to resolve instantly, avoiding real wall-clock delays for exponential backoff (max theoretical wait ~8 min without mock).
