### PR TITLE
:bug:(address-manager): fix fire-and-forget registerService without catch handler

### DIFF
--- a/docs/architecture/api/address-manager.md
+++ b/docs/architecture/api/address-manager.md
@@ -88,6 +88,8 @@ import { createAddressManager } from '@trading-model/address-manager';
 
 1. `start()` → registers the service via `POST /register` on the discovery-server
 2. The received token is stored in the `TokenManager`
+3. Registration retries with exponential backoff (1s base, 30s cap, up to 10 attempts) if the discovery-server is unreachable; errors are logged at each attempt
+4. Registration aborts early if `stop()` is called during retry
 
 ### TTL Refresh
 

--- a/packages/address-manager/src/index.ts
+++ b/packages/address-manager/src/index.ts
@@ -1,6 +1,8 @@
 import { Application } from 'express';
 
 import { HttpClient } from '@trading-model/common/config/http-client';
+import { logger } from '@trading-model/common/config/logger';
+import { sleep } from '@trading-model/common/utils/sleep';
 
 import { AddressManagerClient } from './client/address-manager-client';
 import { TokenManager } from './client/token-manager';
@@ -12,6 +14,15 @@ import { ServiceHealthChecker } from './discovery/service-health-checker';
 import { pingRoutes } from './http/routes/ping.routes';
 import { RefreshJob } from './scheduler/refresh-job';
 import { Scheduler } from './scheduler/scheduler';
+
+/** Maximum registration retry attempts before giving up. */
+const MAX_REGISTRATION_RETRIES = 10;
+
+/** Base delay (ms) for exponential backoff between registration retries. */
+const REGISTRATION_BASE_DELAY_MS = 1000;
+
+/** Maximum delay (ms) cap for registration retry backoff. */
+const REGISTRATION_MAX_DELAY_MS = 30_000;
 
 /**
  * Default export for the Address Manager library.
@@ -38,6 +49,7 @@ export default class AddressManager {
   private readonly httpClient: HttpClient;
   private readonly tokenRefreshIntervalMs: number;
   private readonly ttlRefreshIntervalMs: number;
+  private shouldRetryRegistration = true;
 
   constructor(config: AddressManagerConfig) {
     this.httpClient = new HttpClient({
@@ -54,7 +66,11 @@ export default class AddressManager {
     );
 
     this.serviceCache = new ServiceCache(config.cacheTtlMs);
-    this.healthChecker = new ServiceHealthChecker(this.httpClient, config.servicePingTimeoutMs, config.dnsNameMap);
+    this.healthChecker = new ServiceHealthChecker(
+      this.httpClient,
+      config.servicePingTimeoutMs,
+      config.dnsNameMap
+    );
 
     this.serviceDiscovery = new ServiceDiscovery(
       this.httpClient,
@@ -83,15 +99,51 @@ export default class AddressManager {
   }
 
   /**
+   * Register the service with exponential backoff retry.
+   *
+   * Attempts to register until success, max retries are exhausted,
+   * or `stop()` is called. Each failure is logged with attempt count.
+   */
+  private async retryRegistration(): Promise<void> {
+    for (let attempt = 1; attempt <= MAX_REGISTRATION_RETRIES; attempt++) {
+      if (!this.shouldRetryRegistration) return;
+
+      try {
+        const res = await this.addressManagerClient.registerService();
+        this.tokenManager.setToken(res.token);
+        return;
+      } catch (error) {
+        logger.error('Service registration failed', {
+          attempt,
+          maxRetries: MAX_REGISTRATION_RETRIES,
+          error,
+        });
+
+        if (attempt < MAX_REGISTRATION_RETRIES) {
+          const delay = Math.min(
+            REGISTRATION_BASE_DELAY_MS * Math.pow(2, attempt),
+            REGISTRATION_MAX_DELAY_MS
+          );
+          await sleep(delay);
+        }
+      }
+    }
+
+    logger.error('Service registration failed after max retries', {
+      maxRetries: MAX_REGISTRATION_RETRIES,
+    });
+  }
+
+  /**
    * Starts periodic registration, token refresh, and TTL refresh cycles.
    *
-   * - Registers the service with the discovery server
+   * - Registers the service with the discovery server (with retry)
    * - Starts a scheduler with token and TTL refresh jobs
    *
    * @returns A handle with a `stop` method to gracefully shut down all cycles.
    */
   start(): { stop: () => void } {
-    this.addressManagerClient.registerService().then(res => this.tokenManager.setToken(res.token));
+    this.retryRegistration();
 
     const scheduler = new Scheduler();
 
@@ -107,6 +159,7 @@ export default class AddressManager {
 
     return {
       stop: () => {
+        this.shouldRetryRegistration = false;
         scheduler.stop();
       },
     };

--- a/packages/address-manager/tests/unit/address-manager.spec.ts
+++ b/packages/address-manager/tests/unit/address-manager.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 
+jest.mock('@trading-model/common/utils/sleep', () => ({
+  sleep: jest.fn(() => Promise.resolve()),
+}));
+
 const mockHttpClientInstance = {
   post: jest.fn(),
   get: jest.fn(),
@@ -131,13 +135,59 @@ describe('AddressManager', () => {
 
       const handle = am.start();
 
+      await new Promise(process.nextTick);
+
       expect(mockAddressManagerClientInstance.registerService).toHaveBeenCalled();
+      expect(mockTokenManagerInstance.setToken).toHaveBeenCalledWith('new-token');
       expect(mockSchedulerInstance.register).toHaveBeenCalledTimes(2);
       expect(mockSchedulerInstance.start).toHaveBeenCalled();
       expect(handle).toHaveProperty('stop');
 
       handle.stop();
       expect(mockSchedulerInstance.stop).toHaveBeenCalled();
+    });
+
+    it('should retry registration on failure and succeed on retry', async () => {
+      (mockAddressManagerClientInstance.registerService as any)
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({ token: 'retry-token' });
+
+      const handle = am.start();
+
+      await new Promise(process.nextTick);
+
+      expect(mockAddressManagerClientInstance.registerService).toHaveBeenCalledTimes(2);
+      expect(mockTokenManagerInstance.setToken).toHaveBeenCalledWith('retry-token');
+
+      handle.stop();
+    });
+
+    it('should log error after max retries exhausted', async () => {
+      (mockAddressManagerClientInstance.registerService as any).mockRejectedValue(
+        new Error('Service unreachable')
+      );
+
+      const handle = am.start();
+
+      await new Promise(process.nextTick);
+
+      expect(mockAddressManagerClientInstance.registerService).toHaveBeenCalledTimes(10);
+
+      handle.stop();
+    });
+
+    it('should abort registration retry loop when stop is called', async () => {
+      // keep registration pending — the retry loop will await it
+      (mockAddressManagerClientInstance.registerService as any).mockReturnValue(
+        new Promise(() => {})
+      );
+
+      const handle = am.start();
+      handle.stop();
+
+      // stop sets shouldRetryRegistration to false; the loop checks it before each retry
+      // Since the first registration never settles, no further retries happen
+      expect(mockAddressManagerClientInstance.registerService).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Description

Fix the fire-and-forget `registerService().then()` call that had no `.catch()` handler. If service registration failed (e.g., discovery-server was down), the error was silently swallowed and the service operated without a valid registration or token.

## Type of Change

- [x] 🐛 Bug fix

## Changes

### ✅ Additions

- `packages/address-manager/src/index.ts`: private `retryRegistration()` method with exponential backoff (1s base, 30s cap, up to 10 attempts), error logging at each attempt, and graceful abort when `stop()` is called
- Constants: `MAX_REGISTRATION_RETRIES` (10), `REGISTRATION_BASE_DELAY_MS` (1000), `REGISTRATION_MAX_DELAY_MS` (30000)
- 3 new tests: retry on failure then succeed, log after max retries exhausted, abort retry on stop

### :recycle: Modifications

- `packages/address-manager/src/index.ts`: `start()` now calls `retryRegistration()` instead of fire-and-forget `.then()`; `stop()` sets `shouldRetryRegistration = false` to abort retry loop
- `packages/address-manager/tests/unit/address-manager.spec.ts`: added `sleep` mock; updated existing start test to verify token is set
- `docs/architecture/api/address-manager.md`: Registration section now describes retry behavior

### :fire: Removals

- Removed `registerService().then(res => this.tokenManager.setToken(res.token))` fire-and-forget pattern

## Related Issues

Closes #97

## Checklist

- [x] Code follows [project standards](../docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Test Plan

- `npm run -w @trading-model/address-manager test -- --coverage` — 63 tests, 98%+ coverage (above 80% threshold)
- `npx eslint packages/address-manager/src/index.ts` — 0 errors
- `npx prettier --check packages/address-manager/src/index.ts packages/address-manager/tests/unit/address-manager.spec.ts docs/architecture/api/address-manager.md` — clean

## Additional Notes

The retry loop checks `shouldRetryRegistration` before each attempt, so calling `stop()` during an active retry phase cleanly aborts further attempts. The loop runs in the background (fire-and-forget from `start()`) to keep `start()` synchronous — matching the existing call pattern in service bootstrap.
