### PR TITLE
:bug:(common): add Zod schema validation for HTTP client responses

### DIFF
--- a/docs/architecture/api/common.md
+++ b/docs/architecture/api/common.md
@@ -121,14 +121,21 @@ HTTP client with mTLS support for service-to-service calls.
 import { HttpClient } from '@trading-model/common/config/http-client';
 ```
 
-| Method                            | Signature |
-| --------------------------------- | --------- |
-| `get<T>(url, options?)`           | `GET`     |
-| `post<T>(url, body?, options?)`   | `POST`    |
-| `delete<T>(url, body?, options?)` | `DELETE`  |
+| Method                                     | Signature |
+| ------------------------------------------ | --------- |
+| `get<T>(url, options?, schema?)`           | `GET`     |
+| `post<T>(url, body?, options?, schema?)`   | `POST`    |
+| `delete<T>(url, body?, options?, schema?)` | `DELETE`  |
 
 Options: `timeoutMs`, `headers`
-Errors: `HttpClientError` (non-2xx status), `HttpClientTimeoutError` (timeout)
+
+Schema validation (optional `z.ZodType<T>`):
+
+- When a Zod schema is provided, the response is validated at runtime against it
+- If validation fails, a `z.ZodError` is thrown
+- Without a schema, the response is cast as `T` (no runtime check)
+
+Errors: `HttpClientError` (non-2xx status), `HttpClientTimeoutError` (timeout), `z.ZodError` (schema validation)
 
 ## Middleware
 

--- a/packages/common/src/config/http-client.ts
+++ b/packages/common/src/config/http-client.ts
@@ -2,6 +2,8 @@ import https from 'https';
 import fs from 'node:fs';
 import { URL } from 'url';
 
+import { z } from 'zod';
+
 /**
  * HttpClient
  *
@@ -22,25 +24,40 @@ export class HttpClient {
   }
 
   /** Sends a GET request and returns the parsed response. */
-  async get<T = void>(url: string, options?: HttpRequestOptions): Promise<T> {
-    return this.request<T>('GET', url, undefined, options);
+  async get<T = void>(
+    url: string,
+    options?: HttpRequestOptions,
+    schema?: z.ZodType<T>
+  ): Promise<T> {
+    return this.request<T>('GET', url, undefined, options, schema);
   }
 
   /** Sends a POST request with an optional JSON body and returns the parsed response. */
-  async post<T = void>(url: string, body?: unknown, options?: HttpRequestOptions): Promise<T> {
-    return this.request<T>('POST', url, body, options);
+  async post<T = void>(
+    url: string,
+    body?: unknown,
+    options?: HttpRequestOptions,
+    schema?: z.ZodType<T>
+  ): Promise<T> {
+    return this.request<T>('POST', url, body, options, schema);
   }
 
   /** Sends a DELETE request and returns the parsed response. */
-  async delete<T = void>(url: string, body?: unknown, options?: HttpRequestOptions): Promise<T> {
-    return this.request<T>('DELETE', url, body, options);
+  async delete<T = void>(
+    url: string,
+    body?: unknown,
+    options?: HttpRequestOptions,
+    schema?: z.ZodType<T>
+  ): Promise<T> {
+    return this.request<T>('DELETE', url, body, options, schema);
   }
 
   private async request<T>(
     method: HttpMethod,
     urlStr: string,
     body?: unknown,
-    options?: HttpRequestOptions
+    options?: HttpRequestOptions,
+    schema?: z.ZodType<T>
   ): Promise<T> {
     const url = new URL(urlStr);
 
@@ -77,9 +94,10 @@ export class HttpClient {
 
           try {
             if (contentType.includes('application/json')) {
-              resolve(JSON.parse(data) as T);
+              const parsed = JSON.parse(data);
+              resolve(schema ? schema.parse(parsed) : (parsed as T));
             } else {
-              resolve(data as unknown as T);
+              resolve(schema ? schema.parse(data) : (data as unknown as T));
             }
           } catch (err) {
             reject(err);

--- a/packages/common/tests/unit/http-client.spec.ts
+++ b/packages/common/tests/unit/http-client.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { z } from 'zod';
 
 jest.mock('https');
 jest.mock('fs', () => ({
@@ -165,6 +166,73 @@ describe('HttpClient', () => {
 
       const result = await promise;
       expect(result).toBe('true');
+    });
+  });
+
+  describe('schema validation', () => {
+    it('should validate JSON response with schema', async () => {
+      const responseData = JSON.stringify({ data: 'test' });
+      const schema = z.object({ data: z.string() });
+
+      const promise = client.get('https://example.com/api', undefined, schema);
+      simulateResponse(200, responseData, 'application/json');
+
+      const result = await promise;
+      expect(result).toEqual({ data: 'test' });
+    });
+
+    it('should reject when JSON response does not match schema', async () => {
+      const responseData = JSON.stringify({ data: 123 });
+      const schema = z.object({ data: z.string() });
+
+      const promise = client.get('https://example.com/api', undefined, schema);
+      simulateResponse(200, responseData, 'application/json');
+
+      await expect(promise).rejects.toThrow(z.ZodError);
+    });
+
+    it('should validate non-JSON response with schema', async () => {
+      const schema = z.literal('raw-string');
+
+      const promise = client.get('https://example.com/api', undefined, schema);
+      (requestCallback as any)({
+        on: jest.fn((e: string, cb2: any) => {
+          if (e === 'data') cb2('raw-string');
+          if (e === 'end') cb2();
+        }),
+        statusCode: 200,
+        headers: {},
+      });
+
+      const result = await promise;
+      expect(result).toBe('raw-string');
+    });
+
+    it('should reject when non-JSON response does not match schema', async () => {
+      const schema = z.literal('expected');
+
+      const promise = client.get('https://example.com/api', undefined, schema);
+      (requestCallback as any)({
+        on: jest.fn((e: string, cb2: any) => {
+          if (e === 'data') cb2('actual');
+          if (e === 'end') cb2();
+        }),
+        statusCode: 200,
+        headers: {},
+      });
+
+      await expect(promise).rejects.toThrow(z.ZodError);
+    });
+
+    it('should validate post response with schema', async () => {
+      const responseData = JSON.stringify({ id: 1, name: 'test' });
+      const schema = z.object({ id: z.number(), name: z.string() });
+
+      const promise = client.post('https://example.com/api', { name: 'test' }, undefined, schema);
+      simulateResponse(201, responseData, 'application/json');
+
+      const result = await promise;
+      expect(result).toEqual({ id: 1, name: 'test' });
     });
   });
 });


### PR DESCRIPTION
## Description

`JSON.parse(data) as T` and `data as unknown as T` performed no runtime validation. If the response shape didn't match type T, callers got silently corrupted data — no validation, no error, no stack trace.

Adds an optional `schema?: z.ZodType<T>` parameter to `get()`, `post()`, and `delete()`. When provided, the response is validated at runtime. When omitted, the existing cast behavior is preserved for backward compatibility.

## Type of Change

- [x] 🐛 Bug fix

## Changes

### ✅ Additions

- `packages/common/src/config/http-client.ts`: optional `schema` parameter on `get()`, `post()`, `delete()`, and private `request()`
- 5 new tests: valid/invalid schema for JSON and non-JSON responses, post with schema
- `docs/architecture/api/common.md`: HttpClient docs now document schema parameter, `z.ZodError` in error list

### :recycle: Modifications

- `packages/common/src/config/http-client.ts`: `JSON.parse(data)` path now calls `schema.parse(parsed)` when schema is provided; non-JSON path calls `schema.parse(data)` when schema is provided

## Related Issues

Closes #99

## Checklist

- [x] Code follows [project standards](../docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)

## Breaking Changes

- [x] No — the `schema` parameter is optional, all existing callers work without changes

## Test Plan

- `npm run -w @trading-model/common test -- --coverage` — 193 tests, 100% coverage
- `npx eslint packages/common/src/config/http-client.ts` — 0 errors
- `npx prettier --check packages/common/src/config/http-client.ts packages/common/tests/unit/http-client.spec.ts docs/architecture/api/common.md` — clean
- `npm test` — all 1202 workspace tests pass

## Additional Notes

All existing callers (address-manager, broker-message) continue to work without passing a schema, relying on the backward-compatible cast behavior. Callers can opt into runtime validation by passing a Zod schema as the last argument.
