### PR TITLE
:bug:(discovery): remove asHandler cast and use RequestHandler directly

### DIFF
--- a/services/discovery-server/src/controllers/heartbeat.controller.ts
+++ b/services/discovery-server/src/controllers/heartbeat.controller.ts
@@ -1,49 +1,45 @@
+import { RequestHandler } from 'express';
+
 import { catchSync } from '@trading-model/common/middleware/catch-error';
 import { ResponseException } from '@trading-model/common/middleware/response-exception';
 import { isNonEmptyString, isObject } from '@trading-model/common/validation/primitives';
 
-import { asHandler, validateInstanceToken } from './helpers';
+import { validateInstanceToken } from './helpers';
 import { registry } from '../core/service-registry';
 
 /** Extend a service instance's lease by recording a heartbeat. */
-export const heartbeat = asHandler(
-  catchSync(async req => {
-    if (!isObject(req.body)) {
-      throw ResponseException('Invalid request body').BadRequest();
-    }
+export const heartbeat: RequestHandler = catchSync(async req => {
+  if (!isObject(req.body)) {
+    throw ResponseException('Invalid request body').BadRequest();
+  }
 
-    const { serviceName, instanceId } = req.body as Record<string, unknown>;
+  const { serviceName, instanceId } = req.body as Record<string, unknown>;
 
-    if (!isNonEmptyString(serviceName))
-      throw ResponseException('serviceName is required').BadRequest();
+  if (!isNonEmptyString(serviceName))
+    throw ResponseException('serviceName is required').BadRequest();
 
-    if (!isNonEmptyString(instanceId))
-      throw ResponseException('instanceId is required').BadRequest();
+  if (!isNonEmptyString(instanceId)) throw ResponseException('instanceId is required').BadRequest();
 
-    validateInstanceToken(req.headers['x-instance-token'], instanceId);
+  validateInstanceToken(req.headers['x-instance-token'], instanceId);
 
-    const ttl = registry.updateHeartbeat(serviceName, instanceId);
+  const ttl = registry.updateHeartbeat(serviceName, instanceId);
 
-    if (!ttl) throw ResponseException('Instance not found').NotFound();
+  if (!ttl) throw ResponseException('Instance not found').NotFound();
 
-    throw ResponseException({ ttl }).Success();
-  })
-);
+  throw ResponseException({ ttl }).Success();
+});
 
 /** Issue a new authentication token for a service instance, invalidating the previous one. */
-export const rotateToken = asHandler(
-  catchSync(async req => {
-    if (!isObject(req.body)) throw ResponseException('Invalid request body').BadRequest();
+export const rotateToken: RequestHandler = catchSync(async req => {
+  if (!isObject(req.body)) throw ResponseException('Invalid request body').BadRequest();
 
-    const { instanceId } = req.body as Record<string, unknown>;
+  const { instanceId } = req.body as Record<string, unknown>;
 
-    if (!isNonEmptyString(instanceId))
-      throw ResponseException('instanceId is required').BadRequest();
+  if (!isNonEmptyString(instanceId)) throw ResponseException('instanceId is required').BadRequest();
 
-    validateInstanceToken(req.headers['x-instance-token'], instanceId);
+  validateInstanceToken(req.headers['x-instance-token'], instanceId);
 
-    const newToken = registry.updateToken(instanceId);
+  const newToken = registry.updateToken(instanceId);
 
-    throw ResponseException({ token: newToken }).Success();
-  })
-);
+  throw ResponseException({ token: newToken }).Success();
+});

--- a/services/discovery-server/src/controllers/helpers.ts
+++ b/services/discovery-server/src/controllers/helpers.ts
@@ -1,14 +1,7 @@
-import { NextFunction, Request, RequestHandler, Response } from 'express';
-
 import { ResponseException } from '@trading-model/common/middleware/response-exception';
 import { isNonEmptyString } from '@trading-model/common/validation/primitives';
 
 import { registry } from '../core/service-registry';
-
-/** Cast a controller function to an Express RequestHandler without type inference. */
-export function asHandler(fn: (req: Request, res: Response, next: NextFunction) => unknown): RequestHandler {
-  return fn as unknown as RequestHandler;
-}
 
 /** Validate the x-instance-token header against the stored token for a given instance. */
 export function validateInstanceToken(tokenHeader: unknown, instanceId: string): void {

--- a/services/discovery-server/src/controllers/register.controller.ts
+++ b/services/discovery-server/src/controllers/register.controller.ts
@@ -1,3 +1,5 @@
+import { RequestHandler } from 'express';
+
 import { catchSync } from '@trading-model/common/middleware/catch-error';
 import { ResponseException } from '@trading-model/common/middleware/response-exception';
 import {
@@ -7,87 +9,78 @@ import {
   isValidPort,
 } from '@trading-model/common/validation/primitives';
 
-import { asHandler } from './helpers';
 import { registry } from '../core/service-registry';
 import { ServiceInstance } from '../core/types';
 
 /** Register a new service instance or update an existing one in the registry. */
-export const register = asHandler(
-  catchSync(async req => {
-    if (!isObject(req.body)) throw ResponseException('Invalid request body').BadRequest();
+export const register: RequestHandler = catchSync(async req => {
+  if (!isObject(req.body)) throw ResponseException('Invalid request body').BadRequest();
 
-    const { serviceName, instanceId, ip, port } = req.body as Record<string, unknown>;
+  const { serviceName, instanceId, ip, port } = req.body as Record<string, unknown>;
 
-    if (!isNonEmptyString(serviceName))
-      throw ResponseException('serviceName is required').BadRequest();
+  if (!isNonEmptyString(serviceName))
+    throw ResponseException('serviceName is required').BadRequest();
 
-    if (!registry.verifyInstanceName(serviceName))
-      throw ResponseException('Invalid service name').BadRequest();
+  if (!registry.verifyInstanceName(serviceName))
+    throw ResponseException('Invalid service name').BadRequest();
 
-    if (!isValidIP(ip)) throw ResponseException('Invalid IP address').BadRequest();
+  if (!isValidIP(ip)) throw ResponseException('Invalid IP address').BadRequest();
 
-    if (!isValidPort(port)) throw ResponseException('Invalid port').BadRequest();
+  if (!isValidPort(port)) throw ResponseException('Invalid port').BadRequest();
 
-    let safeInstanceId: string;
+  let safeInstanceId: string;
 
-    if (instanceId !== undefined) {
-      if (!isNonEmptyString(instanceId)) throw ResponseException('Invalid instanceId').BadRequest();
-      safeInstanceId = instanceId;
-    } else {
-      safeInstanceId = registry.generateInstanceId(serviceName, ip, port);
-    }
+  if (instanceId !== undefined) {
+    if (!isNonEmptyString(instanceId)) throw ResponseException('Invalid instanceId').BadRequest();
+    safeInstanceId = instanceId;
+  } else {
+    safeInstanceId = registry.generateInstanceId(serviceName, ip, port);
+  }
 
-    const instance: ServiceInstance = {
-      instanceId: safeInstanceId,
-      serviceName,
-      ip,
-      port,
-      ttl: 30_000,
-      protocol: 'mtls',
-      registeredAt: Date.now(),
-      lastHeartbeat: Date.now(),
-    };
+  const instance: ServiceInstance = {
+    instanceId: safeInstanceId,
+    serviceName,
+    ip,
+    port,
+    ttl: 30_000,
+    protocol: 'mtls',
+    registeredAt: Date.now(),
+    lastHeartbeat: Date.now(),
+  };
 
-    const registered = registry.registerInstance(instance);
+  const registered = registry.registerInstance(instance);
 
-    throw ResponseException(registered).OK();
-  })
-);
+  throw ResponseException(registered).OK();
+});
 
 /** Return the list of all registered service names. */
-export const listServices = asHandler(
-  catchSync(async () => {
-    throw ResponseException(registry.listServiceNames()).Success();
-  })
-);
+export const listServices: RequestHandler = catchSync(async () => {
+  throw ResponseException(registry.listServiceNames()).Success();
+});
 
 /** Return all registered instances for a given service name. */
-export const getServiceInstances = asHandler(
-  catchSync(async req => {
-    const { serviceName } = req.params;
+export const getServiceInstances: RequestHandler = catchSync(async req => {
+  const { serviceName } = req.params;
 
-    if (!isNonEmptyString(serviceName))
-      throw ResponseException('serviceName is required').BadRequest();
+  if (!isNonEmptyString(serviceName))
+    throw ResponseException('serviceName is required').BadRequest();
 
-    if (!registry.verifyInstanceName(serviceName))
-      throw ResponseException('Unknown service').NotFound();
+  if (!registry.verifyInstanceName(serviceName))
+    throw ResponseException('Unknown service').NotFound();
 
-    throw ResponseException(registry.getInstances(serviceName)).Success();
-  })
-);
+  throw ResponseException(registry.getInstances(serviceName)).Success();
+});
 
 /** Return metadata for a specific service instance by service name and instance ID. */
-export const getInstance = asHandler(
-  catchSync(async req => {
-    const { serviceName, instanceId } = req.params;
+export const getInstance: RequestHandler = catchSync(async req => {
+  const { serviceName, instanceId } = req.params;
 
-    if (!isNonEmptyString(serviceName) || !isNonEmptyString(instanceId))
-      throw ResponseException('Invalid route parameters').BadRequest();
+  if (!isNonEmptyString(serviceName) || !isNonEmptyString(instanceId))
+    throw ResponseException('Invalid route parameters').BadRequest();
 
-    const instance = registry.getInstance(serviceName, instanceId);
+  const instance = registry.getInstance(serviceName, instanceId);
 
-    if (!instance) throw ResponseException('Instance not found').NotFound();
+  if (!instance) throw ResponseException('Instance not found').NotFound();
 
-    throw ResponseException(instance).Success();
-  })
-);
+  throw ResponseException(instance).Success();
+});

--- a/services/discovery-server/tests/unit/helpers.spec.ts
+++ b/services/discovery-server/tests/unit/helpers.spec.ts
@@ -16,19 +16,11 @@ jest.mock('@trading-model/common/validation/primitives', () => ({
   isNonEmptyString: (v: any) => typeof v === 'string' && v.trim().length > 0,
 }));
 
-import { validateInstanceToken, asHandler } from '../../src/controllers/helpers';
+import { validateInstanceToken } from '../../src/controllers/helpers';
 import { registry } from '../../src/core/service-registry';
 import { ResponseException } from '@trading-model/common/middleware/response-exception';
 
 describe('helpers', () => {
-  describe('asHandler', () => {
-    it('should return the same function', () => {
-      const fn = () => 'test';
-      const handler = asHandler(fn);
-      expect(handler).toBe(fn);
-    });
-  });
-
   describe('validateInstanceToken', () => {
     beforeEach(() => {
       jest.clearAllMocks();


### PR DESCRIPTION
## Description

`fn as unknown as RequestHandler` discarded all type information. If the function signature didn't match `RequestHandler`, TypeScript couldn't catch it — parameter mismatches became runtime errors.

Removes the `asHandler` helper entirely. Controller handlers are now typed directly as `RequestHandler`, leveraging TypeScript's natural `void` return type compatibility with async middleware functions.

## Type of Change

- [x] 🐛 Bug fix

## Changes

### :fire: Removals

- `services/discovery-server/src/controllers/helpers.ts`: removed `asHandler()` function and its unused imports (`NextFunction`, `Request`, `Response`, `RequestHandler`)

### :recycle: Modifications

- `services/discovery-server/src/controllers/register.controller.ts`: 4 handlers (`register`, `listServices`, `getServiceInstances`, `getInstance`) typed as `RequestHandler` directly instead of wrapped via `asHandler()`
- `services/discovery-server/src/controllers/heartbeat.controller.ts`: 2 handlers (`heartbeat`, `rotateToken`) typed as `RequestHandler` directly
- `services/discovery-server/tests/unit/helpers.spec.ts`: removed `asHandler` test and import

## Related Issues

Closes #102

## Checklist

- [x] Code follows [project standards](../docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)

## Breaking Changes

- [ ] Yes (describe below)
- [x] No — no runtime behavior change; `asHandler` was an identity function with a type cast

## Test Plan

- `npm run -w discovery-server test -- --coverage` — 85 tests, 100% coverage
- `npx eslint services/discovery-server/src/controllers/helpers.ts services/discovery-server/src/controllers/register.controller.ts services/discovery-server/src/controllers/heartbeat.controller.ts` — 0 errors
- `npx prettier --check services/discovery-server/src/controllers/helpers.ts services/discovery-server/src/controllers/register.controller.ts services/discovery-server/src/controllers/heartbeat.controller.ts services/discovery-server/tests/unit/helpers.spec.ts` — clean
- `npm test` — all 1196 workspace tests pass

## Additional Notes

This was possible because TypeScript allows assigning a function returning `Promise<void>` to a function returning `void` — Express's `RequestHandler` returns `void`, and `catchSync` returns `(req, res, next) => Promise<void>`. The `asHandler` wrapper was only needed for the old `unknown` return type; with `void` the assignment is type-safe without any cast.
