### PR TITLE
:bug:(message-manager): validate authContext shape in broker schema

### DIFF
--- a/docs/architecture/api/message-manager.md
+++ b/docs/architecture/api/message-manager.md
@@ -159,6 +159,18 @@ Body (validated by `UnsubscribeSchema`):
 | `AT_LEAST_ONCE` | Delivered at least once (retries with exponential backoff, up to 10 attempts) |
 | `EXACTLY_ONCE`  | Delivered exactly once (idempotent)                                           |
 
+## Security Metadata
+
+Messages can include an optional `security` block within metadata, containing:
+
+- **`authContext`** — Structured authentication context with:
+  - `subject` (string) — Authenticated user or service identifier
+  - `roles` (string[]) — Assigned role identifiers
+  - `tenantId` (string) — Tenant or partition identifier
+- **`signature`** (string, optional) — Message integrity signature
+
+Previously validated as `z.unknown()`, the `authContext` object is now strictly validated against this schema to align with the canonical `SecurityType` interface in `@trading-model/common/contracts/message.types`.
+
 ## Features
 
 - **TTL**: Message expiration based on time-to-live configured in metadata

--- a/services/message-manager/src/messaging/transport/validation/broker.schema.ts
+++ b/services/message-manager/src/messaging/transport/validation/broker.schema.ts
@@ -99,7 +99,13 @@ export const PublishMetadataSchema = z.object({
 
   security: z
     .object({
-      authContext: z.unknown().optional(),
+      authContext: z
+        .object({
+          subject: z.string(),
+          roles: z.array(z.string()),
+          tenantId: z.string(),
+        })
+        .optional(),
       signature: z.string().optional(),
     })
     .optional(),

--- a/services/message-manager/tests/unit/messaging/transport/validation/broker.schema.spec.ts
+++ b/services/message-manager/tests/unit/messaging/transport/validation/broker.schema.spec.ts
@@ -118,12 +118,33 @@ describe('Broker Schemas', () => {
           deduplicationId: 'dedup-789',
         },
         security: {
-          authContext: { user: 'test' },
+          authContext: {
+            subject: 'test-subject',
+            roles: ['admin', 'user'],
+            tenantId: 'tenant-1',
+          },
           signature: 'sig-abc',
         },
       });
 
       expect(result.success).toBe(true);
+    });
+
+    it('should reject authContext with invalid shape', () => {
+      const result = PublishMetadataSchema.safeParse({
+        schemaVersion: '1.0',
+        eventType: 'TestEvent',
+        topic: 'test.topic',
+        publisher: {
+          serviceName: ServiceInstanceName.FinancialScrapperService,
+          instanceId: 'instance-1',
+        },
+        security: {
+          authContext: { user: 'test' },
+        },
+      });
+
+      expect(result.success).toBe(false);
     });
 
     it('should reject missing schemaVersion', () => {


### PR DESCRIPTION
# Description

Fix type drift between the broker API validation layer and the canonical `SecurityType` in `@trading-model/common/contracts/message.types`. The `authContext` field in `PublishMetadataSchema` was typed as `z.unknown()` allowing any value through, while the canonical type defines `{ subject, roles, tenantId }`.

## Type of Change

- [ ] :sparkles: feat — New feature
- [x] :bug: fix — Bug fix
- [x] :memo: docs — Documentation
- [ ] :recycle: refactor — Code restructuring
- [ ] :white_check_mark: test — Tests
- [ ] :wrench: chore — Configuration / tooling
- [ ] :construction_worker: ci — CI/CD
- [ ] :lock: security — Security

## Changes

### :recycle: Modifications

- **`broker.schema.ts`**: Replace `z.unknown()` for `authContext` with proper `{ subject, roles, tenantId }` Zod schema, matching the canonical `SecurityType` interface
- **`broker.schema.spec.ts`**: Update test to use valid `authContext` shape; add new test verifying that invalid shapes are now rejected
- **`docs/architecture/api/message-manager.md`**: Add Security Metadata section documenting the validated `authContext` structure

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Tests

- [x] Existing tests pass
- [x] New tests added
- [ ] Manual tests performed

## Checklist

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — Success
- [x] `npm test` — All tests pass

## Closes Issues

Closes #103

## Additional Notes

- Canonical type: `packages/common/src/contracts/message.types.ts:69` (`SecurityType.authContext`)
- Broker schema: `services/message-manager/src/messaging/transport/validation/broker.schema.ts:102`
- Broker-message already had the correct Zod schema (`SecurityMetadataContextPredicate` in `message.schema.ts:13`)
