### PR TITLE
:recycle:(common): extract SRP sub-modules from create-secure-server

### DIFF
--- a/docs/architecture/api/common.md
+++ b/docs/architecture/api/common.md
@@ -91,6 +91,18 @@ Features:
 - `ResponseProtocole` as last middleware
 - `server.close()` returns a promise that resolves only after all in-flight connections have drained (uses Node.js callback form)
 
+### Internal Architecture
+
+`createSecureServer` delegates each concern to a focused sub-module:
+
+| Module                    | Responsibility                                                                    |
+| ------------------------- | --------------------------------------------------------------------------------- |
+| `configure-app.ts`        | Express app setup: Helmet, trust proxy, body parsers, rate limiter, `/ping` route |
+| `server-factory.ts`       | HTTPS server creation with mTLS (TLSv1.3) and `listen()`                          |
+| `create-secure-server.ts` | Orchestrator: composes app, mTLS middleware, user routes, error middleware        |
+
+This separation follows the Single Responsibility Principle — each module is independently testable and changes to one concern (e.g. rate limiting) do not risk breaking others (e.g. TLS configuration).
+
 ## Environment Validation
 
 Fail-fast validation of environment variables via Zod.

--- a/packages/common/src/server/configure-app.ts
+++ b/packages/common/src/server/configure-app.ts
@@ -1,0 +1,45 @@
+import express, { Application } from 'express';
+import { rateLimit } from 'express-rate-limit';
+import helmet from 'helmet';
+
+import { PING_PATH } from './constants';
+
+/** Configuration for the rate-limiting middleware. */
+export interface RateLimitConfig {
+  windowMs: number;
+  limit: number;
+  message?: string;
+}
+
+/** Configures the Express app, body parsers, rate limiter, and ping route. */
+export function configureApp(
+  config: {
+    rateLimit?: RateLimitConfig;
+    trustProxy?: boolean;
+  } = {}
+): Application {
+  const app = express();
+
+  app.use(helmet());
+
+  if (config.trustProxy !== false) {
+    app.set('trust proxy', 1);
+  }
+
+  app.use(express.json({ limit: '1mb' }));
+  app.use(express.urlencoded({ extended: false }));
+
+  const limiter = rateLimit({
+    windowMs: config.rateLimit?.windowMs ?? 15 * 60 * 1000,
+    limit: config.rateLimit?.limit ?? 100,
+    message: config.rateLimit?.message ?? 'Too many requests from this IP, please try again later.',
+  });
+
+  app.use(limiter);
+
+  app.get(PING_PATH, (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  return app;
+}

--- a/packages/common/src/server/create-secure-server.ts
+++ b/packages/common/src/server/create-secure-server.ts
@@ -1,29 +1,11 @@
-import fs from 'node:fs';
-import https from 'node:https';
-import path from 'node:path';
+import { Application } from 'express';
 
-import express, { Application } from 'express';
-import { rateLimit } from 'express-rate-limit';
-import helmet from 'helmet';
-
-import { PING_PATH } from './constants';
-import { logger } from '../config/logger';
+import { configureApp, RateLimitConfig } from './configure-app';
+import { createAndStartHttpsServer, HttpServer, TlsPaths } from './server-factory';
 import { MTLSAuthMiddleware } from '../middleware/mtls-auth';
 import { ResponseProtocole } from '../middleware/response-protocole';
 
-/** Filesystem paths to TLS certificate files. */
-export interface TlsPaths {
-  key: string;
-  cert: string;
-  ca: string;
-}
-
-/** Configuration for the rate-limiting middleware. */
-export interface RateLimitConfig {
-  windowMs: number;
-  limit: number;
-  message?: string;
-}
+export { HttpServer, TlsPaths, RateLimitConfig };
 
 /** Options for creating an mTLS-secured HTTPS server. */
 export interface SecureServerOptions {
@@ -34,35 +16,18 @@ export interface SecureServerOptions {
   trustProxy?: boolean;
 }
 
-/** Minimal abstraction over a running HTTP server. */
-export interface HttpServer {
-  close: () => Promise<void>;
-}
-
-/** Creates and starts an HTTPS server with mTLS, rate-limiting, and Helmet security. */
+/**
+ * Creates and starts an HTTPS server with mTLS, rate-limiting, and Helmet security.
+ * Composes the Express app from focused sub-modules:
+ *   - configureApp     — Helmet, trust proxy, body parsers, rate limiter, ping route
+ *   - MTLSAuthMiddleware — mTLS client certificate validation
+ *   - ResponseProtocole  — Global error normalisation middleware
+ *   - createAndStartHttpsServer — HTTPS listener with mTLS (TLSv1.3)
+ */
 export function createSecureServer(options: SecureServerOptions): HttpServer {
-  const app = express();
-
-  app.use(helmet());
-
-  if (options.trustProxy !== false) {
-    app.set('trust proxy', 1);
-  }
-
-  app.use(express.json({ limit: '1mb' }));
-  app.use(express.urlencoded({ extended: false }));
-
-  const limiter = rateLimit({
-    windowMs: options.rateLimit?.windowMs ?? 15 * 60 * 1000,
-    limit: options.rateLimit?.limit ?? 100,
-    message:
-      options.rateLimit?.message ?? 'Too many requests from this IP, please try again later.',
-  });
-
-  app.use(limiter);
-
-  app.get(PING_PATH, (_req, res) => {
-    res.json({ status: 'ok' });
+  const app = configureApp({
+    rateLimit: options.rateLimit,
+    trustProxy: options.trustProxy,
   });
 
   app.use(MTLSAuthMiddleware);
@@ -71,37 +36,5 @@ export function createSecureServer(options: SecureServerOptions): HttpServer {
 
   app.use(ResponseProtocole);
 
-  const httpsServer = https.createServer(
-    {
-      key: fs.readFileSync(path.resolve(options.tls.key)),
-      cert: fs.readFileSync(path.resolve(options.tls.cert)),
-      ca: fs.readFileSync(path.resolve(options.tls.ca)),
-      requestCert: true,
-      rejectUnauthorized: true,
-      minVersion: 'TLSv1.3',
-    },
-    app
-  );
-
-  httpsServer.listen(options.port, () => {
-    logger.info('HTTPS server listening', {
-      port: options.port,
-      mtls: true,
-    });
-  });
-
-  return {
-    /**
-     * Close the HTTPS server and wait for all in-flight connections to drain.
-     * Uses the Node.js callback form to guarantee the promise resolves only
-     * after the server has fully stopped.
-     */
-    close: () =>
-      new Promise<void>((resolve, reject) => {
-        httpsServer.close(err => {
-          if (err) reject(err);
-          else resolve();
-        });
-      }),
-  };
+  return createAndStartHttpsServer(app, { port: options.port, tls: options.tls });
 }

--- a/packages/common/src/server/server-factory.ts
+++ b/packages/common/src/server/server-factory.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import https from 'node:https';
+import path from 'node:path';
+
+import { Application } from 'express';
+
+import { logger } from '../config/logger';
+
+/** Filesystem paths to TLS certificate files. */
+export interface TlsPaths {
+  key: string;
+  cert: string;
+  ca: string;
+}
+
+/** Options for creating the HTTPS server. */
+export interface HttpsServerOptions {
+  port: number;
+  tls: TlsPaths;
+}
+
+/** Minimal abstraction over a running HTTP server. */
+export interface HttpServer {
+  close: () => Promise<void>;
+}
+
+/**
+ * Create an HTTPS server with mTLS (TLSv1.3, requestCert, rejectUnauthorized),
+ * start listening on the given port, and return an HttpServer handle.
+ *
+ * @param app - The configured Express Application to serve.
+ * @param options - Port and TLS certificate paths.
+ * @returns An HttpServer with a close method that drains connections.
+ */
+export function createAndStartHttpsServer(
+  app: Application,
+  options: HttpsServerOptions
+): HttpServer {
+  const httpsServer = https.createServer(
+    {
+      key: fs.readFileSync(path.resolve(options.tls.key)),
+      cert: fs.readFileSync(path.resolve(options.tls.cert)),
+      ca: fs.readFileSync(path.resolve(options.tls.ca)),
+      requestCert: true,
+      rejectUnauthorized: true,
+      minVersion: 'TLSv1.3',
+    },
+    app
+  );
+
+  httpsServer.listen(options.port, () => {
+    logger.info('HTTPS server listening', {
+      port: options.port,
+      mtls: true,
+    });
+  });
+
+  return {
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        httpsServer.close(err => {
+          if (err) reject(err);
+          else resolve();
+        });
+      }),
+  };
+}

--- a/packages/common/tests/unit/configure-app.spec.ts
+++ b/packages/common/tests/unit/configure-app.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+let mockApp: any;
+
+jest.mock('express', () => {
+  mockApp = {
+    use: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+    get: jest.fn().mockReturnThis(),
+  };
+  const expressFn: any = jest.fn(() => mockApp);
+  expressFn.json = jest.fn(() => 'jsonParser');
+  expressFn.urlencoded = jest.fn(() => 'urlencodedParser');
+  expressFn.Router = jest.fn(() => ({ use: jest.fn().mockReturnThis() }));
+  return expressFn;
+});
+
+jest.mock('helmet', () => jest.fn(() => 'helmetMiddleware'));
+
+jest.mock('express-rate-limit', () => ({
+  rateLimit: jest.fn(() => 'rateLimitMiddleware'),
+}));
+
+import { configureApp } from '../../src/server/configure-app';
+import express from 'express';
+import helmet from 'helmet';
+import { rateLimit } from 'express-rate-limit';
+
+describe('configureApp', () => {
+  it('should create app with helmet, body parsers, rate limiter, and ping route', () => {
+    const app = configureApp();
+
+    expect(express).toHaveBeenCalled();
+    expect(app).toBe(mockApp);
+    expect(mockApp.use).toHaveBeenCalledWith(helmet());
+    expect(mockApp.use).toHaveBeenCalledWith('jsonParser');
+    expect(mockApp.use).toHaveBeenCalledWith('urlencodedParser');
+    expect(mockApp.use).toHaveBeenCalledWith('rateLimitMiddleware');
+    expect(mockApp.get).toHaveBeenCalledWith('/ping', expect.any(Function));
+  });
+
+  it('should set trust proxy by default', () => {
+    mockApp.set.mockClear();
+    configureApp();
+    expect(mockApp.set).toHaveBeenCalledWith('trust proxy', 1);
+  });
+
+  it('should skip trust proxy when false', () => {
+    mockApp.set.mockClear();
+    configureApp({ trustProxy: false });
+    expect(mockApp.set).not.toHaveBeenCalled();
+  });
+
+  it('should apply custom rate limit config', () => {
+    configureApp({ rateLimit: { windowMs: 60000, limit: 50 } });
+    expect(rateLimit).toHaveBeenCalledWith(expect.objectContaining({ windowMs: 60000, limit: 50 }));
+  });
+
+  it('should use default rate limit config when not provided', () => {
+    configureApp();
+    expect(rateLimit).toHaveBeenCalledWith(
+      expect.objectContaining({ windowMs: 900000, limit: 100 })
+    );
+  });
+});


### PR DESCRIPTION
## Description

Refactor `create-secure-server.ts` to fix the Single Responsibility Principle violation — the function handled 7+ responsibilities (Express app setup, Helmet, trust proxy, body parsers, rate limiting, ping route, mTLS middleware, error middleware, HTTPS server creation, listening).

Each concern is now extracted into a focused, independently testable module.

## Type of Change

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] 📝 Documentation
- [x] ♻️ Refactor
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 🔧 Chore
- [ ] 👷 CI/CD
- [ ] 🔒 Security

## Changes

### ✅ Additions

- **`configure-app.ts`**: Express app configuration (Helmet, trust proxy, body parsers, rate limiter, `/ping` route)
- **`server-factory.ts`**: HTTPS server creation with mTLS (TLSv1.3) and `listen()`/`close()` lifecycle
- **`configure-app.spec.ts`**: Unit tests for the new module (app creation, trust proxy, rate limit config)
- **`docs/architecture/api/common.md`**: Internal Architecture section documenting the new module structure

### ♻️ Modifications

- **`create-secure-server.ts`**: Simplified to a 25-line orchestrator that composes the sub-modules

### 🔥 Removals

- Inline rate limiter setup, body parser config, Helmet config, ping route, TLS loading, and server creation logic from `create-secure-server.ts`

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Related Issues

Closes #105

## Checklist

- [x] Code follows [project standards](../docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [ ] JSDoc updated for public APIs
- [x] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)

## Test Plan

- `npm test` — 1207 tests pass (common: 198 tests, 5 new)
- `npm run lint` — 0 errors
- `npm run build` — Success (tsc strict mode)
- Coverage — 100% across all files including new modules

## Additional Notes

- Public API unchanged — `createSecureServer` is still exported from `@trading-model/common/server/create-secure-server`
- All existing consumers (discovery-server, financial-scraper, message-manager, trader-trainer) are unaffected
- Each sub-module is independently testable, making changes to one concern safe from breaking others

## Screenshots (if applicable)

N/A
