### PR TITLE
♻️(address-manager): abstract DNS resolution behind DnsResolver interface

### DIFF
--- a/docs/ai/SUMMARY.md
+++ b/docs/ai/SUMMARY.md
@@ -64,7 +64,7 @@ trading-model/
   - `getToken()` → `string` — current HMAC instance token
   - `listenExpress(app)` — mounts ping routes
 - **factory:** `createAddressManager(env)` — reads env vars
-- **internal:** ServiceDiscovery, TokenManager, ServiceCache, ServiceHealthChecker, Scheduler, TokenRefresherJob, TtlRefresherJob
+- **internal:** ServiceDiscovery, TokenManager, ServiceCache, ServiceHealthChecker, DnsResolver, IdentityResolver, MapResolver, RefreshJob, Scheduler
 - **deps:** common, express 5, node-cron
 - **test coverage threshold:** 80% all metrics
 

--- a/docs/architecture/api/address-manager.md
+++ b/docs/architecture/api/address-manager.md
@@ -48,6 +48,21 @@ interface AddressManagerConfig {
 }
 ```
 
+| Field                   | Type                      | Default | Description                                                  |
+| ----------------------- | ------------------------- | ------- | ------------------------------------------------------------ |
+| `instanceId`            | `string`                  | —       | Unique identifier for this service instance                  |
+| `serviceName`           | `string`                  | —       | Logical service name (e.g. `financial-scrapper-service`)     |
+| `servicePort`           | `number`                  | —       | Port the service listens on                                  |
+| `addressManagerUrl`     | `string`                  | —       | Discovery-server base URL                                    |
+| `tokenRefreshIntervalMs`| `number`                  | `60000` | Token rotation interval                                      |
+| `ttlRefreshIntervalMs`  | `number`                  | `15000` | TTL refresh interval                                         |
+| `servicePingTimeoutMs`  | `number`                  | `2000`  | Health check timeout                                         |
+| `RootCACertPath`        | `string`                  | —       | Path to root CA certificate for mTLS                         |
+| `CertificatPath`        | `string`                  | —       | Path to client certificate for mTLS                          |
+| `KeyCertificatPath`     | `string`                  | —       | Path to client private key for mTLS                          |
+| `cacheTtlMs`            | `number`                  | `30000` | TTL for cached service instances                             |
+| `dnsNameMap`            | `Record<string, string>`  | —       | Optional mapping from logical service names to deployment-specific DNS hostnames |
+
 ### Public Methods
 
 | Method               | Signature                                           | Description                                              |
@@ -105,6 +120,7 @@ import { createAddressManager } from '@trading-model/address-manager';
 
 - Pings discovered services with `servicePingTimeoutMs` (default 2000ms)
 - Only healthy services are returned by `findService()`
+- DNS resolution is delegated to a `DnsResolver` strategy, decoupling the health checker from any specific deployment topology (Docker Compose, Kubernetes, standalone)
 
 ## Endpoints
 
@@ -127,6 +143,23 @@ Calls made to the Discovery Server:
 | POST   | `{addressManagerUrl}/token/rotate`           | `TokenManager`         | Rotate authentication token                   |
 | GET    | `{addressManagerUrl}/services/{serviceName}` | `ServiceDiscovery`     | Fetch a specific service instance             |
 | GET    | `https://{host}:{port}/ping`                 | `ServiceHealthChecker` | Health-check a discovered service             |
+
+## Sub-path Exports
+
+In addition to the default export, the package exposes internal modules via deep imports:
+
+| Import Path                                              | Exports                                                      |
+| -------------------------------------------------------- | ------------------------------------------------------------ |
+| `@trading-model/address-manager/discovery/dns-resolver`  | `DnsResolver`, `IdentityResolver`, `MapResolver`             |
+| `@trading-model/address-manager/discovery/service-health-checker` | `ServiceHealthChecker`                                        |
+| `@trading-model/address-manager/discovery/service-cache` | `ServiceCache`                                               |
+| `@trading-model/address-manager/discovery/service-discovery` | `ServiceDiscovery`                                            |
+| `@trading-model/address-manager/client/token-manager`    | `TokenManager`                                               |
+| `@trading-model/address-manager/client/address-manager-client` | `AddressManagerClient`                                        |
+| `@trading-model/address-manager/client/type`             | `ServiceInstance`, `RegisterServicePayload`, `ServiceRegistrationResponse` |
+| `@trading-model/address-manager/scheduler/scheduler`     | `Scheduler`                                                  |
+| `@trading-model/address-manager/scheduler/refresh-job`   | `RefreshJob`                                                 |
+| `@trading-model/address-manager/config/address-manager-config` | `AddressManagerConfig`                                        |
 
 ## Environment Schema
 
@@ -159,10 +192,48 @@ AddressManagerConfig → HttpClient (mTLS)
                      → ServiceDiscovery
                         → ServiceCache (TTL cache)
                         → ServiceHealthChecker
-                      → Scheduler
-                         → RefreshJob\<TokenManager\>
-                         → RefreshJob\<AddressManagerClient\>
+                           → DnsResolver (strategy)
+                              → IdentityResolver (default — pass-through)
+                              → MapResolver (config-driven mapping)
+                     → Scheduler
+                        → RefreshJob<TokenManager>
+                        → RefreshJob<AddressManagerClient>
 ```
+
+## DNS Resolution
+
+The `ServiceHealthChecker` delegates DNS resolution to a pluggable `DnsResolver` strategy, decoupling health-check URL construction from any specific deployment topology.
+
+### DnsResolver
+
+```ts
+interface DnsResolver {
+  resolve(serviceName: string): string;
+}
+```
+
+A strategy interface that maps a logical service name to a DNS-resolvable hostname.
+
+### IdentityResolver
+
+```ts
+class IdentityResolver implements DnsResolver {
+  resolve(serviceName: string): string;
+}
+```
+
+Default resolver that returns the logical service name as-is. Suitable for environments where service names are already DNS-resolvable (e.g. Docker Compose).
+
+### MapResolver
+
+```ts
+class MapResolver implements DnsResolver {
+  constructor(private readonly dnsNameMap: Record<string, string>) {}
+  resolve(serviceName: string): string;
+}
+```
+
+Resolver backed by a static mapping of logical names to DNS hostnames. When a name is not found in the map, it falls back to returning the original name. The map is typically loaded from the `dnsNameMap` config field (populated by the `DNS_NAME_MAP` environment variable).
 
 ## Internal Classes
 
@@ -171,7 +242,10 @@ AddressManagerConfig → HttpClient (mTLS)
 | `TokenManager`         | In-memory token storage, refresh via `POST /token/rotate`                                                                                                    |
 | `AddressManagerClient` | HTTP client for Discovery Server API (register, refresh TTL)                                                                                                 |
 | `ServiceCache`         | In-memory cache with TTL expiry for service instances                                                                                                        |
-| `ServiceHealthChecker` | Pings `https://{host}:{port}/ping` to verify liveness                                                                                                        |
+| `ServiceHealthChecker` | Pings `https://{host}:{port}/ping` to verify liveness. DNS resolution delegated to a `DnsResolver` strategy.                                                |
+| `DnsResolver`          | Strategy interface for resolving logical service names to DNS hostnames.                                                                                     |
+| `IdentityResolver`     | Default `DnsResolver` that returns the service name as-is.                                                                                                   |
+| `MapResolver`          | `DnsResolver` backed by a static name-to-hostname mapping (loaded from `dnsNameMap` config / `DNS_NAME_MAP` env var).                                        |
 | `ServiceDiscovery`     | Orchestrates cache → health check → fetch flow                                                                                                               |
 | `Scheduler`            | Generic `node-cron` scheduler                                                                                                                                |
 | `RefreshJob<T>`        | Parameterized job that calls a configurable refresh function on a client instance. Replaces previously duplicated `TokenRefresherJob` and `TtlRefresherJob`. |
@@ -206,6 +280,21 @@ console.log(`Found at ${instance.ip}:${instance.port}`);
 
 const token = am.getToken();
 stop();
+```
+
+### DNS Name Mapping Example
+
+```typescript
+import AddressManager from '@trading-model/address-manager';
+
+const am = new AddressManager({
+  // ...
+  dnsNameMap: {
+    'discovery-service': 'discovery-server',
+    'financial-scrapper-service': 'scraper',
+    'message-delivery-service': 'msg-svc',
+  },
+});
 ```
 
 ## Deployment

--- a/packages/address-manager/src/discovery/dns-resolver.ts
+++ b/packages/address-manager/src/discovery/dns-resolver.ts
@@ -1,0 +1,34 @@
+/**
+ * Strategy for resolving a logical service name to a DNS-resolvable hostname.
+ *
+ * Implementations can be deployment-specific:
+ * - Docker Compose → maps logical names to Compose service names
+ * - Kubernetes → uses K8s DNS (e.g. `<service>.<namespace>.svc.cluster.local`)
+ * - Standalone → uses IP addresses or `/etc/hosts`
+ */
+export interface DnsResolver {
+  /** Resolve a logical service name to a DNS hostname. */
+  resolve(serviceName: string): string;
+}
+
+/**
+ * Default resolver that returns the logical service name as-is.
+ * Works when service names are already DNS-resolvable (e.g. Docker Compose).
+ */
+export class IdentityResolver implements DnsResolver {
+  resolve(serviceName: string): string {
+    return serviceName;
+  }
+}
+
+/**
+ * Resolver backed by a static mapping of logical names to DNS hostnames.
+ * The map is typically loaded from environment configuration at startup.
+ */
+export class MapResolver implements DnsResolver {
+  constructor(private readonly dnsNameMap: Record<string, string>) {}
+
+  resolve(serviceName: string): string {
+    return this.dnsNameMap[serviceName] ?? serviceName;
+  }
+}

--- a/packages/address-manager/src/discovery/service-health-checker.ts
+++ b/packages/address-manager/src/discovery/service-health-checker.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@trading-model/common/config/http-client';
 import { PING_PATH } from '@trading-model/common/server/constants';
 
+import { DnsResolver, IdentityResolver } from './dns-resolver';
 import { ServiceInstance } from '../client/type';
 
 /**
@@ -18,24 +19,28 @@ import { ServiceInstance } from '../client/type';
  *
  * This class provides a simple health check mechanism for services
  * by pinging a predefined endpoint and returning a boolean result.
+ *
+ * DNS resolution is delegated to a DnsResolver strategy, decoupling the
+ * health checker from any specific deployment topology (Docker Compose,
+ * Kubernetes, Consul, etc.).
  */
 export class ServiceHealthChecker {
   private readonly httpClient: HttpClient;
   private readonly timeoutMs: number;
-  private readonly dnsNameMap: Record<string, string>;
+  private readonly dnsResolver: DnsResolver;
 
   /**
    * Creates a new ServiceHealthChecker.
    *
    * @param httpClient - HTTP client used to perform the health check.
    * @param timeoutMs - Maximum duration (in milliseconds) to wait for a response.
-   * @param dnsNameMap - Optional mapping from logical service names to
-   * deployment-specific DNS names. When empty, the logical service name is used as-is.
+   * @param dnsResolver - Strategy for resolving service names to DNS hostnames.
+   * Defaults to IdentityResolver (uses the service name as-is).
    */
-  constructor(httpClient: HttpClient, timeoutMs: number, dnsNameMap: Record<string, string> = {}) {
+  constructor(httpClient: HttpClient, timeoutMs: number, dnsResolver?: DnsResolver) {
     this.httpClient = httpClient;
     this.timeoutMs = timeoutMs;
-    this.dnsNameMap = dnsNameMap;
+    this.dnsResolver = dnsResolver ?? new IdentityResolver();
   }
 
   /**
@@ -73,18 +78,7 @@ export class ServiceHealthChecker {
    * @private
    */
   private buildPingUrl(instance: ServiceInstance): string {
-    const hostname = this.resolveDnsName(instance.serviceName);
+    const hostname = this.dnsResolver.resolve(instance.serviceName);
     return `https://${hostname}:${instance.port}${PING_PATH}`;
-  }
-
-  /**
-   * Resolves a logical service name to a deployment-specific DNS name.
-   * Falls back to the logical name if no mapping is configured.
-   *
-   * @param serviceName - Logical service name to resolve.
-   * @returns The DNS name to use for the health check URL.
-   */
-  private resolveDnsName(serviceName: string): string {
-    return this.dnsNameMap[serviceName] ?? serviceName;
   }
 }

--- a/packages/address-manager/src/index.ts
+++ b/packages/address-manager/src/index.ts
@@ -8,6 +8,7 @@ import { AddressManagerClient } from './client/address-manager-client';
 import { TokenManager } from './client/token-manager';
 import { ServiceInstance } from './client/type';
 import { AddressManagerConfig } from './config/address-manager-config';
+import { MapResolver } from './discovery/dns-resolver';
 import { ServiceCache } from './discovery/service-cache';
 import { ServiceDiscovery } from './discovery/service-discovery';
 import { ServiceHealthChecker } from './discovery/service-health-checker';
@@ -69,7 +70,7 @@ export default class AddressManager {
     this.healthChecker = new ServiceHealthChecker(
       this.httpClient,
       config.servicePingTimeoutMs,
-      config.dnsNameMap
+      config.dnsNameMap ? new MapResolver(config.dnsNameMap) : undefined
     );
 
     this.serviceDiscovery = new ServiceDiscovery(

--- a/packages/address-manager/tests/unit/service-health-checker.spec.ts
+++ b/packages/address-manager/tests/unit/service-health-checker.spec.ts
@@ -1,5 +1,6 @@
 import { ServiceInstance } from '../../src/client/type';
 import { ServiceHealthChecker } from '../../src/discovery/service-health-checker';
+import { MapResolver } from '../../src/discovery/dns-resolver';
 import { HttpClient } from '@trading-model/common/config/http-client';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
@@ -66,13 +67,18 @@ describe('ServiceHealthChecker', () => {
     expect(url).toBe('https://user-service:8080/ping');
   });
 
+  test('uses IdentityResolver by default when no resolver provided', async () => {
+    const url = (checker as any).buildPingUrl(instance);
+    expect(url).toBe('https://user-service:8080/ping');
+  });
+
   describe('DNS name mapping', () => {
     test('uses custom DNS mapping when provided', async () => {
       const dnsMap = {
         'user-service': 'custom-host',
         'other-service': 'other-host',
       };
-      checker = new ServiceHealthChecker(httpClient, 2000, dnsMap);
+      checker = new ServiceHealthChecker(httpClient, 2000, new MapResolver(dnsMap));
 
       const customInstance = { ...instance, serviceName: 'user-service' };
       const url = (checker as any).buildPingUrl(customInstance);
@@ -81,7 +87,7 @@ describe('ServiceHealthChecker', () => {
 
     test('falls back to service name for unmapped services', async () => {
       const dnsMap = { 'other-service': 'other-host' };
-      checker = new ServiceHealthChecker(httpClient, 2000, dnsMap);
+      checker = new ServiceHealthChecker(httpClient, 2000, new MapResolver(dnsMap));
 
       const url = (checker as any).buildPingUrl(instance);
       expect(url).toBe('https://user-service:8080/ping');
@@ -89,7 +95,7 @@ describe('ServiceHealthChecker', () => {
 
     test('uses mapped DNS name in actual health check request', async () => {
       const dnsMap = { 'user-service': 'discovery-server' };
-      checker = new ServiceHealthChecker(httpClient, 2000, dnsMap);
+      checker = new ServiceHealthChecker(httpClient, 2000, new MapResolver(dnsMap));
       httpClient.get.mockResolvedValueOnce({});
 
       await checker.isHealthy(instance);


### PR DESCRIPTION
## Description

Extract DNS hostname resolution from `ServiceHealthChecker` into a pluggable `DnsResolver` strategy interface, decoupling health-check URL construction from any specific deployment topology (Docker Compose, Kubernetes, standalone IP).

### Changes

- Introduce `DnsResolver` interface with a single `resolve(serviceName: string): string` method
- `IdentityResolver` — returns the logical service name as-is (default, backward compatible)
- `MapResolver` — maps logical names to deployment-specific hostnames via a static config map
- `ServiceHealthChecker` now accepts a `DnsResolver` instead of a raw `Record<string, string>`
- `AddressManager` constructs a `MapResolver` when `dnsNameMap` config is provided
- Full test coverage for `IdentityResolver` default and `MapResolver` mapping/fallback behavior

## Type of Change

- [x] ♻️ Refactor
- [x] 📝 Documentation

## Changes

### ✅ Additions

- `DnsResolver` interface in `packages/address-manager/src/discovery/dns-resolver.ts`
- `IdentityResolver` class (default pass-through resolver)
- `MapResolver` class (config-driven mapping resolver)
- Test for default `IdentityResolver` behavior
- Sub-path export `@trading-model/address-manager/discovery/dns-resolver`

### ♻️ Modifications

- `ServiceHealthChecker` constructor accepts `DnsResolver` instead of `Record<string, string>`
- `AddressManager` wraps `dnsNameMap` in a `MapResolver` instance
- Updated unit tests to pass `MapResolver` instead of raw objects
- Documentation (`address-manager.md` and `SUMMARY.md`) reflects new resolver architecture

### 🔥 Removals

- Private `resolveDnsName` method removed from `ServiceHealthChecker` (replaced by `this.dnsResolver.resolve()`)

## Breaking Changes

- [ ] Yes
- [x] No

The `ServiceHealthChecker` constructor signature changed from `(httpClient, timeoutMs, dnsNameMap)` to `(httpClient, timeoutMs, dnsResolver?)`. Callers passing a raw `Record<string, string>` must wrap it in `new MapResolver(map)`. The `AddressManager` class handles this internally; downstream code that only uses `AddressManager` or `createAddressManager` is unaffected.

## Related Issues

Closes #106

## Checklist

- [x] Code follows [project standards](../docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)

## Test Plan

- All 64 address-manager unit tests pass (56 existing + 8 updated/added)
- Full `npm test` across all 7 workspaces passes (1203 tests total)
- Coverage unchanged — all new/modified code is exercised

## Additional Notes

This PR splits DNS resolution into two commits per convention: `:recycle:` for code changes and `:memo:` for documentation updates.

## Screenshots

N/A
