### PR TITLE
♻️(address-manager): replace DnsResolver with ServiceLocator in ServiceHealthChecker

### DIFF
--- a/docs/ai/SUMMARY.md
+++ b/docs/ai/SUMMARY.md
@@ -64,7 +64,7 @@ trading-model/
   - `getToken()` → `string` — current HMAC instance token
   - `listenExpress(app)` — mounts ping routes
 - **factory:** `createAddressManager(env)` — reads env vars
-- **internal:** ServiceDiscovery, TokenManager, ServiceCache, ServiceHealthChecker, DnsResolver, IdentityResolver, MapResolver, RefreshJob, Scheduler
+- **internal:** ServiceDiscovery, TokenManager, ServiceCache, ServiceHealthChecker, ServiceLocator, ServiceNameLocator, IpAddressLocator, MappingServiceLocator, RefreshJob, Scheduler
 - **deps:** common, express 5, node-cron
 - **test coverage threshold:** 80% all metrics
 

--- a/docs/architecture/api/address-manager.md
+++ b/docs/architecture/api/address-manager.md
@@ -120,7 +120,7 @@ import { createAddressManager } from '@trading-model/address-manager';
 
 - Pings discovered services with `servicePingTimeoutMs` (default 2000ms)
 - Only healthy services are returned by `findService()`
-- DNS resolution is delegated to a `DnsResolver` strategy, decoupling the health checker from any specific deployment topology (Docker Compose, Kubernetes, standalone)
+- Target hostname resolution is delegated to a `ServiceLocator` strategy, decoupling the health checker from any specific deployment topology (Docker Compose, Kubernetes, standalone)
 
 ## Endpoints
 
@@ -150,7 +150,7 @@ In addition to the default export, the package exposes internal modules via deep
 
 | Import Path                                              | Exports                                                      |
 | -------------------------------------------------------- | ------------------------------------------------------------ |
-| `@trading-model/address-manager/discovery/dns-resolver`  | `DnsResolver`, `IdentityResolver`, `MapResolver`             |
+| `@trading-model/address-manager/discovery/service-locator`  | `ServiceLocator`, `ServiceNameLocator`, `IpAddressLocator`, `MappingServiceLocator`             |
 | `@trading-model/address-manager/discovery/service-health-checker` | `ServiceHealthChecker`                                        |
 | `@trading-model/address-manager/discovery/service-cache` | `ServiceCache`                                               |
 | `@trading-model/address-manager/discovery/service-discovery` | `ServiceDiscovery`                                            |
@@ -191,49 +191,60 @@ AddressManagerConfig → HttpClient (mTLS)
                      → AddressManagerClient (registration)
                      → ServiceDiscovery
                         → ServiceCache (TTL cache)
-                        → ServiceHealthChecker
-                           → DnsResolver (strategy)
-                              → IdentityResolver (default — pass-through)
-                              → MapResolver (config-driven mapping)
+                         → ServiceHealthChecker
+                            → ServiceLocator (strategy)
+                               → ServiceNameLocator (default — service name)
+                               → IpAddressLocator (direct IP)
+                               → MappingServiceLocator (config-driven via DnsResolver)
                      → Scheduler
                         → RefreshJob<TokenManager>
                         → RefreshJob<AddressManagerClient>
 ```
 
-## DNS Resolution
+## Target Resolution
 
-The `ServiceHealthChecker` delegates DNS resolution to a pluggable `DnsResolver` strategy, decoupling health-check URL construction from any specific deployment topology.
+The `ServiceHealthChecker` delegates hostname resolution to a pluggable `ServiceLocator` strategy, decoupling health-check URL construction from any specific deployment topology.
 
-### DnsResolver
+### ServiceLocator
 
 ```ts
-interface DnsResolver {
-  resolve(serviceName: string): string;
+interface ServiceLocator {
+  locate(instance: ServiceInstance): string;
 }
 ```
 
-A strategy interface that maps a logical service name to a DNS-resolvable hostname.
+A strategy interface that determines the target hostname for a given service instance. Receives the full `ServiceInstance` object, giving implementations access to `ip`, `port`, `serviceName`, and other metadata.
 
-### IdentityResolver
+### ServiceNameLocator
 
 ```ts
-class IdentityResolver implements DnsResolver {
-  resolve(serviceName: string): string;
+class ServiceNameLocator implements ServiceLocator {
+  locate(instance: ServiceInstance): string;
 }
 ```
 
-Default resolver that returns the logical service name as-is. Suitable for environments where service names are already DNS-resolvable (e.g. Docker Compose).
+Default locator that returns `instance.serviceName` as the hostname. Suitable for environments where logical service names are already DNS-resolvable (e.g. Docker Compose).
 
-### MapResolver
+### IpAddressLocator
 
 ```ts
-class MapResolver implements DnsResolver {
-  constructor(private readonly dnsNameMap: Record<string, string>) {}
-  resolve(serviceName: string): string;
+class IpAddressLocator implements ServiceLocator {
+  locate(instance: ServiceInstance): string;
 }
 ```
 
-Resolver backed by a static mapping of logical names to DNS hostnames. When a name is not found in the map, it falls back to returning the original name. The map is typically loaded from the `dnsNameMap` config field (populated by the `DNS_NAME_MAP` environment variable).
+Locator that uses `instance.ip` directly. Suitable for environments with direct IP connectivity where DNS-based service names are unavailable.
+
+### MappingServiceLocator
+
+```ts
+class MappingServiceLocator implements ServiceLocator {
+  constructor(private readonly dnsResolver: DnsResolver) {}
+  locate(instance: ServiceInstance): string;
+}
+```
+
+Locator that delegates to an internal `DnsResolver` strategy for name-based mapping. The `DnsResolver` interface and its implementations (`IdentityResolver`, `MapResolver`) remain as internal utilities. When `dnsNameMap` config is provided, an `AddressManager` creates `new MappingServiceLocator(new MapResolver(dnsNameMap))`. The `DnsResolver` is loaded from the `dnsNameMap` config field (populated by the `DNS_NAME_MAP` environment variable).
 
 ## Internal Classes
 
@@ -242,10 +253,11 @@ Resolver backed by a static mapping of logical names to DNS hostnames. When a na
 | `TokenManager`         | In-memory token storage, refresh via `POST /token/rotate`                                                                                                    |
 | `AddressManagerClient` | HTTP client for Discovery Server API (register, refresh TTL)                                                                                                 |
 | `ServiceCache`         | In-memory cache with TTL expiry for service instances                                                                                                        |
-| `ServiceHealthChecker` | Pings `https://{host}:{port}/ping` to verify liveness. DNS resolution delegated to a `DnsResolver` strategy.                                                |
-| `DnsResolver`          | Strategy interface for resolving logical service names to DNS hostnames.                                                                                     |
-| `IdentityResolver`     | Default `DnsResolver` that returns the service name as-is.                                                                                                   |
-| `MapResolver`          | `DnsResolver` backed by a static name-to-hostname mapping (loaded from `dnsNameMap` config / `DNS_NAME_MAP` env var).                                        |
+| `ServiceHealthChecker` | Pings `https://{host}:{port}/ping` to verify liveness. Target resolution delegated to a `ServiceLocator` strategy.                                                |
+| `ServiceLocator`       | Strategy interface for determining the target hostname of a service instance.                                                                                     |
+| `ServiceNameLocator`   | Default `ServiceLocator` that uses `instance.serviceName` as the hostname.                                                                                        |
+| `IpAddressLocator`     | `ServiceLocator` that uses `instance.ip` directly.                                                                                                                |
+| `MappingServiceLocator`| `ServiceLocator` backed by an internal `DnsResolver` (loaded from `dnsNameMap` config / `DNS_NAME_MAP` env var).                                                  |
 | `ServiceDiscovery`     | Orchestrates cache → health check → fetch flow                                                                                                               |
 | `Scheduler`            | Generic `node-cron` scheduler                                                                                                                                |
 | `RefreshJob<T>`        | Parameterized job that calls a configurable refresh function on a client instance. Replaces previously duplicated `TokenRefresherJob` and `TtlRefresherJob`. |

--- a/packages/address-manager/src/discovery/service-health-checker.ts
+++ b/packages/address-manager/src/discovery/service-health-checker.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@trading-model/common/config/http-client';
 import { PING_PATH } from '@trading-model/common/server/constants';
 
-import { DnsResolver, IdentityResolver } from './dns-resolver';
+import { ServiceLocator, ServiceNameLocator } from './service-locator';
 import { ServiceInstance } from '../client/type';
 
 /**
@@ -20,27 +20,27 @@ import { ServiceInstance } from '../client/type';
  * This class provides a simple health check mechanism for services
  * by pinging a predefined endpoint and returning a boolean result.
  *
- * DNS resolution is delegated to a DnsResolver strategy, decoupling the
- * health checker from any specific deployment topology (Docker Compose,
- * Kubernetes, Consul, etc.).
+ * Target resolution is delegated to a ServiceLocator strategy, decoupling
+ * the health checker from any specific deployment topology (Docker Compose,
+ * Kubernetes, direct IP, etc.).
  */
 export class ServiceHealthChecker {
   private readonly httpClient: HttpClient;
   private readonly timeoutMs: number;
-  private readonly dnsResolver: DnsResolver;
+  private readonly serviceLocator: ServiceLocator;
 
   /**
    * Creates a new ServiceHealthChecker.
    *
    * @param httpClient - HTTP client used to perform the health check.
    * @param timeoutMs - Maximum duration (in milliseconds) to wait for a response.
-   * @param dnsResolver - Strategy for resolving service names to DNS hostnames.
-   * Defaults to IdentityResolver (uses the service name as-is).
+   * @param serviceLocator - Strategy for resolving the target hostname of a
+   * service instance. Defaults to ServiceNameLocator (uses the logical name).
    */
-  constructor(httpClient: HttpClient, timeoutMs: number, dnsResolver?: DnsResolver) {
+  constructor(httpClient: HttpClient, timeoutMs: number, serviceLocator?: ServiceLocator) {
     this.httpClient = httpClient;
     this.timeoutMs = timeoutMs;
-    this.dnsResolver = dnsResolver ?? new IdentityResolver();
+    this.serviceLocator = serviceLocator ?? new ServiceNameLocator();
   }
 
   /**
@@ -78,7 +78,7 @@ export class ServiceHealthChecker {
    * @private
    */
   private buildPingUrl(instance: ServiceInstance): string {
-    const hostname = this.dnsResolver.resolve(instance.serviceName);
+    const hostname = this.serviceLocator.locate(instance);
     return `https://${hostname}:${instance.port}${PING_PATH}`;
   }
 }

--- a/packages/address-manager/src/discovery/service-locator.ts
+++ b/packages/address-manager/src/discovery/service-locator.ts
@@ -1,0 +1,55 @@
+import { DnsResolver } from './dns-resolver';
+import { ServiceInstance } from '../client/type';
+
+/**
+ * Strategy for determining the target hostname to reach a service instance.
+ *
+ * Separating location from health checking allows each concern to vary
+ * independently — the locator resolves WHERE to connect, the health
+ * checker validates IF the service is alive.
+ *
+ * Implementations:
+ * - `ServiceNameLocator` — uses the logical service name (DNS-resolvable envs)
+ * - `IpAddressLocator` — uses the registered IP (direct connectivity)
+ * - `MappingServiceLocator` — delegates to a DnsResolver for name mapping
+ */
+export interface ServiceLocator {
+  /** Resolve the hostname for a service instance. */
+  locate(instance: ServiceInstance): string;
+}
+
+/**
+ * Resolves using the instance's logical service name.
+ *
+ * Suitable for environments where service names are DNS-resolvable
+ * (Docker Compose, Kubernetes with DNS).
+ */
+export class ServiceNameLocator implements ServiceLocator {
+  locate(instance: ServiceInstance): string {
+    return instance.serviceName;
+  }
+}
+
+/**
+ * Resolves using the instance's registered IP address.
+ *
+ * Suitable for direct IP-based connectivity or environments
+ * without DNS-based service discovery.
+ */
+export class IpAddressLocator implements ServiceLocator {
+  locate(instance: ServiceInstance): string {
+    return instance.ip;
+  }
+}
+
+/**
+ * Resolves using a DnsResolver strategy with a fallback to the
+ * logical service name when the resolver has no mapping.
+ */
+export class MappingServiceLocator implements ServiceLocator {
+  constructor(private readonly dnsResolver: DnsResolver) {}
+
+  locate(instance: ServiceInstance): string {
+    return this.dnsResolver.resolve(instance.serviceName);
+  }
+}

--- a/packages/address-manager/src/index.ts
+++ b/packages/address-manager/src/index.ts
@@ -12,6 +12,7 @@ import { MapResolver } from './discovery/dns-resolver';
 import { ServiceCache } from './discovery/service-cache';
 import { ServiceDiscovery } from './discovery/service-discovery';
 import { ServiceHealthChecker } from './discovery/service-health-checker';
+import { MappingServiceLocator } from './discovery/service-locator';
 import { pingRoutes } from './http/routes/ping.routes';
 import { RefreshJob } from './scheduler/refresh-job';
 import { Scheduler } from './scheduler/scheduler';
@@ -70,7 +71,7 @@ export default class AddressManager {
     this.healthChecker = new ServiceHealthChecker(
       this.httpClient,
       config.servicePingTimeoutMs,
-      config.dnsNameMap ? new MapResolver(config.dnsNameMap) : undefined
+      config.dnsNameMap ? new MappingServiceLocator(new MapResolver(config.dnsNameMap)) : undefined
     );
 
     this.serviceDiscovery = new ServiceDiscovery(

--- a/packages/address-manager/tests/unit/create-address-manager.spec.ts
+++ b/packages/address-manager/tests/unit/create-address-manager.spec.ts
@@ -48,7 +48,7 @@ describe('createAddressManager', () => {
       TLS_CERT_PATH: '/path/to/cert.pem',
       TLS_KEY_PATH: '/path/to/key.pem',
       TLS_CA_PATH: '/path/to/ca.pem',
-      DNS_NAME_MAP: { "discovery-service": "discovery-server" },
+      DNS_NAME_MAP: { 'discovery-service': 'discovery-server' },
     } as any;
 
     const am = createAddressManager(env);

--- a/packages/address-manager/tests/unit/service-health-checker.spec.ts
+++ b/packages/address-manager/tests/unit/service-health-checker.spec.ts
@@ -1,6 +1,7 @@
 import { ServiceInstance } from '../../src/client/type';
 import { ServiceHealthChecker } from '../../src/discovery/service-health-checker';
 import { MapResolver } from '../../src/discovery/dns-resolver';
+import { MappingServiceLocator, IpAddressLocator } from '../../src/discovery/service-locator';
 import { HttpClient } from '@trading-model/common/config/http-client';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
@@ -62,23 +63,28 @@ describe('ServiceHealthChecker', () => {
     );
   });
 
-  test('buildPingUrl generates correct URL with identity mapping', async () => {
+  test('uses ServiceNameLocator by default', async () => {
     const url = (checker as any).buildPingUrl(instance);
     expect(url).toBe('https://user-service:8080/ping');
   });
 
-  test('uses IdentityResolver by default when no resolver provided', async () => {
+  test('IpAddressLocator uses instance.ip for URL construction', async () => {
+    checker = new ServiceHealthChecker(httpClient, 2000, new IpAddressLocator());
     const url = (checker as any).buildPingUrl(instance);
-    expect(url).toBe('https://user-service:8080/ping');
+    expect(url).toBe('https://127.0.0.1:8080/ping');
   });
 
-  describe('DNS name mapping', () => {
+  describe('DNS name mapping via MappingServiceLocator', () => {
     test('uses custom DNS mapping when provided', async () => {
       const dnsMap = {
         'user-service': 'custom-host',
         'other-service': 'other-host',
       };
-      checker = new ServiceHealthChecker(httpClient, 2000, new MapResolver(dnsMap));
+      checker = new ServiceHealthChecker(
+        httpClient,
+        2000,
+        new MappingServiceLocator(new MapResolver(dnsMap))
+      );
 
       const customInstance = { ...instance, serviceName: 'user-service' };
       const url = (checker as any).buildPingUrl(customInstance);
@@ -87,7 +93,11 @@ describe('ServiceHealthChecker', () => {
 
     test('falls back to service name for unmapped services', async () => {
       const dnsMap = { 'other-service': 'other-host' };
-      checker = new ServiceHealthChecker(httpClient, 2000, new MapResolver(dnsMap));
+      checker = new ServiceHealthChecker(
+        httpClient,
+        2000,
+        new MappingServiceLocator(new MapResolver(dnsMap))
+      );
 
       const url = (checker as any).buildPingUrl(instance);
       expect(url).toBe('https://user-service:8080/ping');
@@ -95,7 +105,11 @@ describe('ServiceHealthChecker', () => {
 
     test('uses mapped DNS name in actual health check request', async () => {
       const dnsMap = { 'user-service': 'discovery-server' };
-      checker = new ServiceHealthChecker(httpClient, 2000, new MapResolver(dnsMap));
+      checker = new ServiceHealthChecker(
+        httpClient,
+        2000,
+        new MappingServiceLocator(new MapResolver(dnsMap))
+      );
       httpClient.get.mockResolvedValueOnce({});
 
       await checker.isHealthy(instance);

--- a/packages/address-manager/tests/unit/service-health-checker.spec.ts
+++ b/packages/address-manager/tests/unit/service-health-checker.spec.ts
@@ -1,6 +1,6 @@
 import { ServiceInstance } from '../../src/client/type';
 import { ServiceHealthChecker } from '../../src/discovery/service-health-checker';
-import { MapResolver } from '../../src/discovery/dns-resolver';
+import { IdentityResolver, MapResolver } from '../../src/discovery/dns-resolver';
 import { MappingServiceLocator, IpAddressLocator } from '../../src/discovery/service-locator';
 import { HttpClient } from '@trading-model/common/config/http-client';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
@@ -97,6 +97,17 @@ describe('ServiceHealthChecker', () => {
         httpClient,
         2000,
         new MappingServiceLocator(new MapResolver(dnsMap))
+      );
+
+      const url = (checker as any).buildPingUrl(instance);
+      expect(url).toBe('https://user-service:8080/ping');
+    });
+
+    test('uses IdentityResolver fallback when no mapping resolver provided', async () => {
+      checker = new ServiceHealthChecker(
+        httpClient,
+        2000,
+        new MappingServiceLocator(new IdentityResolver())
       );
 
       const url = (checker as any).buildPingUrl(instance);


### PR DESCRIPTION
## Description

Replace the `DnsResolver` dependency in `ServiceHealthChecker` with a `ServiceLocator` interface that receives the full `ServiceInstance` object, fixing the SRP violation described in issue #108. The health checker no longer performs DNS resolution — it delegates target hostname determination to a pluggable locator strategy.

## Type of Change

- [x] ♻️ Refactor
- [x] ✅ Test
- [x] 📝 Documentation

## Changes

### ✅ Additions

- `ServiceLocator` interface in `packages/address-manager/src/discovery/service-locator.ts` with `locate(instance: ServiceInstance): string`
- `ServiceNameLocator` — default, returns `instance.serviceName`
- `IpAddressLocator` — returns `instance.ip` for direct-IP environments
- `MappingServiceLocator` — delegates to internal `DnsResolver` for config-driven mappings
- Unit test for `IpAddressLocator` URL construction

### ♻️ Modifications

- `ServiceHealthChecker`: constructor now accepts `ServiceLocator` instead of `DnsResolver`; `buildPingUrl` uses `serviceLocator.locate(instance)`
- `AddressManager` (index.ts): composition root creates `MappingServiceLocator(new MapResolver(dnsNameMap))` instead of passing `MapResolver` directly
- Tests updated: `MappingServiceLocator` wraps `MapResolver`, test names/comments reflect `ServiceNameLocator`

### 🔥 Removals

- None — `DnsResolver` interface remains as internal utility for `MappingServiceLocator`

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

Backward compatible — `ServiceNameLocator` preserves the same default behavior as `IdentityResolver`, and `MappingServiceLocator` wraps the existing `MapResolver` unchanged.

## Related Issues

Closes #108

## Checklist

- [x] Code follows project standards (WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated (address-manager.md, SUMMARY.md)
- [x] Commit messages follow gitmoji convention (COMMIT.md)

## Test Plan

- All 64 address-manager unit tests pass (8 in service-health-checker.spec.ts)
- Full monorepo: 1393 tests across 7 packages/services all pass
- Lint: 0 errors
- Build: tsc succeeds with strict mode
- Coverage: `service-locator.ts` 100%, `service-health-checker.ts` 100%

## Additional Notes

The `DnsResolver` interface and its implementations (`IdentityResolver`, `MapResolver`) remain in the codebase as internal utilities used by `MappingServiceLocator`. External consumers should use `ServiceLocator` implementations directly.

## Screenshots

N/A