### PR TITLE
🐛(common): default identity unknown propagates instead of failing closed

### DIFF
--- a/docs/architecture/api/common.md
+++ b/docs/architecture/api/common.md
@@ -190,6 +190,8 @@ mTLS authentication middleware.
 
 - **Import**: `@trading-model/common/middleware/mtls-auth`
 - Checks `socket.authorized`, extracts client certificate identity
+- Identity resolution: prefers SAN (Subject Alternative Name), falls back to CN (Common Name)
+- Fails closed with **401 Unauthorized** if no SAN or CN is present on the certificate (no default identity leak)
 - Attaches `clientIdentity` to the request (declared via global Express `Request` augmentation — `declare global { namespace Express { interface Request { clientIdentity: string } } }`)
 - Rejects non-TLS connections (e.g. plain HTTP) with a Forbidden error to prevent unauthenticated access
 

--- a/packages/common/src/middleware/mtls-auth.ts
+++ b/packages/common/src/middleware/mtls-auth.ts
@@ -88,12 +88,25 @@ export const MTLSAuthMiddleware = catchSync((req, res, next) => {
    * Identity resolution convention:
    *  - Prefer Subject Alternative Name (SAN), if present (URI / DNS)
    *  - Fallback to Common Name (CN)
-   *  - Default to "unknown" if neither is available
+   *  - Fail closed with Unauthorized if neither is available
    *
    * This identity is considered a *logical client identifier* and
    * should map to a service, workload, or machine identity.
+   *
+   * A default identity (e.g., "unknown") is intentionally NOT provided
+   * to avoid propagating an unresolvable identity to downstream
+   * authorization gates (fail closed, not open).
    */
-  const raw = cert.subjectaltname ?? cert.subject?.CN ?? 'unknown';
+  const raw = cert.subjectaltname ?? cert.subject?.CN;
+
+  if (!raw) {
+    throw ResponseException(
+      JSON.stringify({
+        error: 'Client identity could not be resolved',
+        reason: 'Certificate has no SAN or CN',
+      })
+    ).Unauthorized();
+  }
   const identity = Array.isArray(raw) ? raw.join(', ') : raw;
 
   /**

--- a/packages/common/tests/unit/mtls-auth.spec.ts
+++ b/packages/common/tests/unit/mtls-auth.spec.ts
@@ -12,9 +12,12 @@ jest.mock('../../src/middleware/response-exception', () => ({
       });
     },
     Unauthorized: () => {
-      throw Object.assign(new Error(JSON.stringify({ error: 'Client certificate required' })), {
-        status: 401,
-      });
+      throw Object.assign(
+        new Error(JSON.stringify(data ?? { error: 'Client certificate required' })),
+        {
+          status: 401,
+        }
+      );
     },
   }),
 }));
@@ -111,7 +114,7 @@ describe('MTLSAuthMiddleware', () => {
     expect(next).toHaveBeenCalled();
   });
 
-  it('should default to "unknown" when neither SAN nor CN is available', () => {
+  it('should throw Unauthorized when neither SAN nor CN is available', () => {
     const cert = {
       subjectaltname: undefined,
       subject: { CN: undefined },
@@ -122,9 +125,7 @@ describe('MTLSAuthMiddleware', () => {
       getPeerCertificate: jest.fn(() => cert),
     };
 
-    MTLSAuthMiddleware(req, res, next);
-
-    expect(req.clientIdentity).toBe('unknown');
-    expect(next).toHaveBeenCalled();
+    expect(() => MTLSAuthMiddleware(req, res, next)).toThrow();
+    expect(next).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description

In `mtls-auth.ts`, when a client certificate has no SAN (Subject Alternative Name) and no CN (Common Name), the identity previously defaulted to the string `'unknown'`. This unresolved identity could propagate downstream to authorization gates, effectively failing **OPEN**.

This PR fails **CLOSED**: the middleware now throws a **401 Unauthorized** error when the client identity cannot be resolved from the certificate, preventing any downstream authorization bypass.

## Type of Change

- [x] 🐛 Bug fix

## Changes

### ✅ Additions

- Guard clause in `mtls-auth.ts`: throws `ResponseException(...).Unauthorized()` when neither SAN nor CN is present
- Updated JSDoc to document the fail-closed policy
- Documentation in `docs/architecture/api/common.md` updated with identity resolution rules

### ♻️ Modifications

- `mtls-auth.ts` line 96: removed `?? 'unknown'` default, replaced with `if (!raw) throw ...`
- Test: "should default to unknown" renamed to "should throw Unauthorized when neither SAN nor CN is available"
- Test mock: `Unauthorized` handler now uses the `data` payload from the caller instead of hardcoding the message

### 🔥 Removals

- Implicit `'unknown'` default identity string that could bypass authorization gates

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

The change is backward compatible. Every valid certificate (with SAN or CN) continues to work as before. The only behavioral difference is that invalid/misconfigured certificates now fail closed with an explicit error instead of silently propagating `'unknown'`.

## Related Issues

Closes #111

## Checklist

- [x] Code follows project standards (WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated (identity resolution documented in common.md)
- [x] Commit messages follow gitmoji convention (COMMIT.md)

## Test Plan

- 7 mtls-auth tests pass (updated one to expect Unauthorized)
- Full monorepo: 1398 tests across 7 packages/services all pass
- Lint: 0 errors
- Coverage: `mtls-auth.ts` 100% all metrics (statements, branches, functions, lines)
- Build: tsc succeeds with strict mode

## Additional Notes

The fix is minimal and focused. It changes only the identity resolution guard without touching the overall middleware flow (TLS socket validation, certificate presence check, identity extraction from SAN/CN).

## Screenshots

N/A
