### PR TITLE
🐛(scraper): non-deterministic JSON.stringify used for message signature

### DIFF
--- a/docs/architecture/api/common.md
+++ b/docs/architecture/api/common.md
@@ -299,6 +299,14 @@ TradingModelError (abstract)
 sleep(ms: number): Promise<void>
 ```
 
+- **Import**: `@trading-model/common/utils/deterministic-stringify`
+
+```ts
+deterministicStringify(value: unknown): string
+```
+
+Deterministic JSON serialisation for cryptographic signing. Recursively sorts object keys in lexicographic order so the same logical value always produces the same string, regardless of insertion order. Preserves array order, handles primitives, nulls, and nested objects.
+
 ## Deployment
 
 This package is **not deployed independently**. It is built as a workspace dependency and consumed at build time by other packages and services. The compiled output goes to `dist/` via `npm run build` (tsc, CommonJS output).

--- a/packages/common/src/utils/deterministic-stringify.ts
+++ b/packages/common/src/utils/deterministic-stringify.ts
@@ -1,0 +1,33 @@
+/**
+ * Deterministic JSON serialization for cryptographic signing.
+ *
+ * `JSON.stringify` does not guarantee property ordering across engines,
+ * which makes it unsuitable for producing reproducible message digests.
+ * This function recursively serializes an object with sorted keys so
+ * that the same logical value always produces the same string, regardless
+ * of the insertion order used to construct the object.
+ *
+ * - Primitives and arrays are serialised as usual.
+ * - Object keys are sorted lexicographically (recursively).
+ * - Prototype properties are ignored (only own enumerable keys).
+ * - Cyclic references throw the standard TypeError.
+ *
+ * @param value - The value to serialize.
+ * @returns A JSON string with deterministically ordered keys.
+ */
+export function deterministicStringify(value: unknown): string {
+  return JSON.stringify(value, deterministicReplacer);
+}
+
+const deterministicReplacer = (_key: string, value: unknown): unknown => {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    const keys = Object.keys(value).sort();
+    const sorted: Record<string, unknown> = {};
+    for (const key of keys) {
+      sorted[key] = (value as Record<string, unknown>)[key];
+    }
+    return sorted;
+  }
+
+  return value;
+};

--- a/packages/common/tests/unit/deterministic-stringify.spec.ts
+++ b/packages/common/tests/unit/deterministic-stringify.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { deterministicStringify } from '../../src/utils/deterministic-stringify';
+
+describe('deterministicStringify', () => {
+  it('should produce same output for same logical object regardless of key order', () => {
+    const a = { b: 2, a: 1, c: 3 };
+    const b = { a: 1, b: 2, c: 3 };
+
+    expect(deterministicStringify(a)).toBe(deterministicStringify(b));
+  });
+
+  it('should sort keys in lexicographic order', () => {
+    const result = deterministicStringify({ z: 1, a: 2, m: 3 });
+    expect(result).toBe('{"a":2,"m":3,"z":1}');
+  });
+
+  it('should handle nested objects recursively', () => {
+    const result = deterministicStringify({ c: { z: 1, a: 2 }, b: 3 });
+    expect(result).toBe('{"b":3,"c":{"a":2,"z":1}}');
+  });
+
+  it('should preserve array order', () => {
+    const result = deterministicStringify({ items: [3, 1, 2] });
+    expect(result).toBe('{"items":[3,1,2]}');
+  });
+
+  it('should handle null values', () => {
+    const result = deterministicStringify({ a: null, b: 1 });
+    expect(result).toBe('{"a":null,"b":1}');
+  });
+
+  it('should handle primitive values', () => {
+    expect(deterministicStringify(42)).toBe('42');
+    expect(deterministicStringify('hello')).toBe('"hello"');
+    expect(deterministicStringify(true)).toBe('true');
+    expect(deterministicStringify(null)).toBe('null');
+  });
+
+  it('should handle empty objects and arrays', () => {
+    expect(deterministicStringify({})).toBe('{}');
+    expect(deterministicStringify([])).toBe('[]');
+  });
+
+  it('should handle mixed nested structures', () => {
+    const obj = {
+      roles: ['admin', 'user'],
+      meta: { version: 2, enabled: true },
+      name: 'test',
+    };
+    const result = deterministicStringify(obj);
+    expect(result).toBe(
+      '{"meta":{"enabled":true,"version":2},"name":"test","roles":["admin","user"]}'
+    );
+  });
+
+  it('should match a known deterministic hash input', () => {
+    const authContext = {
+      roles: ['Data', 'Financial', 'Scrapper'],
+      subject: 'financial-scrapper-service',
+      tenantId: 'instance-1',
+    };
+    const serialised = deterministicStringify(authContext);
+    expect(serialised).toBe(
+      '{"roles":["Data","Financial","Scrapper"],"subject":"financial-scrapper-service","tenantId":"instance-1"}'
+    );
+  });
+
+  it('should be idempotent for the same input', () => {
+    const obj = { x: 10, y: { z: 20, w: 30 }, arr: [1, 2] };
+    const first = deterministicStringify(obj);
+    const second = deterministicStringify(obj);
+    expect(first).toBe(second);
+  });
+});

--- a/services/financial-scraper/src/job/worker/binance.worker.ts
+++ b/services/financial-scraper/src/job/worker/binance.worker.ts
@@ -18,6 +18,7 @@ import { helper } from '@trading-model/broker-message';
 import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
 import { EnumEventMessage } from '@trading-model/common/config/event.types';
 import { ServiceInstanceName } from '@trading-model/common/config/services.types';
+import { deterministicStringify } from '@trading-model/common/utils/deterministic-stringify';
 
 import {
   getOrderBook,
@@ -98,12 +99,15 @@ export class BinanceWorker {
       tenantId: env.INSTANCE_ID,
     };
 
-    const signature = createHash('sha256').update(JSON.stringify(authContext)).digest('base64url');
+    const signature = createHash('sha256')
+      .update(deterministicStringify(authContext))
+      .digest('base64url');
 
-    builderMetadata.setDelivery({
-      mode: DeliveryMode.AT_LEAST_ONCE,
-      deduplicationId: uuid(),
-    })
+    builderMetadata
+      .setDelivery({
+        mode: DeliveryMode.AT_LEAST_ONCE,
+        deduplicationId: uuid(),
+      })
       .setEventType('FetchCandlestick')
       .setTopic(EnumEventMessage.fetchCandlestickSeries)
       .setSecurity({
@@ -121,9 +125,9 @@ export class BinanceWorker {
 
     MessageManager.post.indirect(response.candles, builderMetadata.toJSON());
 
-    builderMetadata.setTopic(EnumEventMessage.fetchOrderBookSnapshot).setEventType(
-      'FetchOrderbook'
-    );
+    builderMetadata
+      .setTopic(EnumEventMessage.fetchOrderBookSnapshot)
+      .setEventType('FetchOrderbook');
 
     MessageManager.post.indirect(response.orderBook, builderMetadata.toJSON());
 
@@ -131,15 +135,15 @@ export class BinanceWorker {
 
     MessageManager.post.indirect(response.ticker24h, builderMetadata.toJSON());
 
-    builderMetadata.setTopic(EnumEventMessage.fetchOrderBookTickerSnapshot).setEventType(
-      'FetchBookTicker'
-    );
+    builderMetadata
+      .setTopic(EnumEventMessage.fetchOrderBookTickerSnapshot)
+      .setEventType('FetchBookTicker');
 
     MessageManager.post.indirect(response.bookTicker, builderMetadata.toJSON());
 
-    builderMetadata.setTopic(EnumEventMessage.fetchPriceTickerSnapshot).setEventType(
-      'FetchPriceTicker'
-    );
+    builderMetadata
+      .setTopic(EnumEventMessage.fetchPriceTickerSnapshot)
+      .setEventType('FetchPriceTicker');
 
     MessageManager.post.indirect(response.priceTicker, builderMetadata.toJSON());
 


### PR DESCRIPTION
## Description

Replace `JSON.stringify(authContext)` with a deterministic serialisation utility in the scraper's message signing path. `JSON.stringify` does not guarantee property ordering across JS engines, making it unsuitable for producing reproducible SHA-256 message digests.

A new `deterministicStringify` utility is added to `@trading-model/common/utils/deterministic-stringify` that recursively sorts object keys in lexicographic order before serialising, ensuring the same logical value always produces the same string.

## Type of Change

- [x] 🐛 Bug fix

## Changes

### ✅ Additions

- `packages/common/src/utils/deterministic-stringify.ts` — recursive sorted-key JSON serialiser
- 10 unit tests covering: key ordering, nested objects, arrays, nulls, primitives, edge cases
- Documentation in `docs/architecture/api/common.md`

### ♻️ Modifications

- `services/financial-scraper/src/job/worker/binance.worker.ts` — uses `deterministicStringify(authContext)` instead of `JSON.stringify(authContext)` for SHA-256 message signature

### 🔥 Removals

- Non-deterministic `JSON.stringify` in the message signing code path

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

The signature is computed and verified within the same codebase. Both sides will use the same deterministic serialisation after this change.

## Related Issues

Closes #113

## Checklist

- [x] Code follows project standards (WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [x] Docs updated (common.md utils section)
- [x] Commit messages follow gitmoji convention (COMMIT.md)

## Test Plan

- 10 deterministic-stringify tests: sorting, nesting, arrays, primitives, idempotency
- 6 worker tests still pass (signature mock unaffected)
- Full monorepo: 1411 tests across all packages pass
- Coverage: 100% all metrics (deterministic-stringify.ts, binance.worker.ts)
- Build: tsc succeeds with strict mode

## Additional Notes

The utility handles:
- Flat and nested objects with sorted key order
- Arrays (order preserved)
- Primitive values passed directly
- Null and empty containers
- Cyclic references throw the standard TypeError (same as JSON.stringify)

## Screenshots

N/A
