### PR TITLE
:bug:(address-manager): log scheduler job execution errors instead of swallowing silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.3.1] - 2026-06-07
+
+### @trading-model/address-manager (1.1.0 → 1.1.1)
+
+#### Fix
+
+- :bug:(address-manager): log scheduler job execution errors instead of swallowing them silently (#114)
+
+#### Test
+
+- :white_check_mark:(address-manager): add test for error logging when job.execute throws
+
 ## [1.3.0] - 2026-06-06
 
 ### @trading-model/common (1.0.0 → 1.1.0)

--- a/docs/architecture/api/address-manager.md
+++ b/docs/architecture/api/address-manager.md
@@ -48,20 +48,20 @@ interface AddressManagerConfig {
 }
 ```
 
-| Field                   | Type                      | Default | Description                                                  |
-| ----------------------- | ------------------------- | ------- | ------------------------------------------------------------ |
-| `instanceId`            | `string`                  | —       | Unique identifier for this service instance                  |
-| `serviceName`           | `string`                  | —       | Logical service name (e.g. `financial-scrapper-service`)     |
-| `servicePort`           | `number`                  | —       | Port the service listens on                                  |
-| `addressManagerUrl`     | `string`                  | —       | Discovery-server base URL                                    |
-| `tokenRefreshIntervalMs`| `number`                  | `60000` | Token rotation interval                                      |
-| `ttlRefreshIntervalMs`  | `number`                  | `15000` | TTL refresh interval                                         |
-| `servicePingTimeoutMs`  | `number`                  | `2000`  | Health check timeout                                         |
-| `RootCACertPath`        | `string`                  | —       | Path to root CA certificate for mTLS                         |
-| `CertificatPath`        | `string`                  | —       | Path to client certificate for mTLS                          |
-| `KeyCertificatPath`     | `string`                  | —       | Path to client private key for mTLS                          |
-| `cacheTtlMs`            | `number`                  | `30000` | TTL for cached service instances                             |
-| `dnsNameMap`            | `Record<string, string>`  | —       | Optional mapping from logical service names to deployment-specific DNS hostnames |
+| Field                    | Type                     | Default | Description                                                                      |
+| ------------------------ | ------------------------ | ------- | -------------------------------------------------------------------------------- |
+| `instanceId`             | `string`                 | —       | Unique identifier for this service instance                                      |
+| `serviceName`            | `string`                 | —       | Logical service name (e.g. `financial-scrapper-service`)                         |
+| `servicePort`            | `number`                 | —       | Port the service listens on                                                      |
+| `addressManagerUrl`      | `string`                 | —       | Discovery-server base URL                                                        |
+| `tokenRefreshIntervalMs` | `number`                 | `60000` | Token rotation interval                                                          |
+| `ttlRefreshIntervalMs`   | `number`                 | `15000` | TTL refresh interval                                                             |
+| `servicePingTimeoutMs`   | `number`                 | `2000`  | Health check timeout                                                             |
+| `RootCACertPath`         | `string`                 | —       | Path to root CA certificate for mTLS                                             |
+| `CertificatPath`         | `string`                 | —       | Path to client certificate for mTLS                                              |
+| `KeyCertificatPath`      | `string`                 | —       | Path to client private key for mTLS                                              |
+| `cacheTtlMs`             | `number`                 | `30000` | TTL for cached service instances                                                 |
+| `dnsNameMap`             | `Record<string, string>` | —       | Optional mapping from logical service names to deployment-specific DNS hostnames |
 
 ### Public Methods
 
@@ -148,18 +148,18 @@ Calls made to the Discovery Server:
 
 In addition to the default export, the package exposes internal modules via deep imports:
 
-| Import Path                                              | Exports                                                      |
-| -------------------------------------------------------- | ------------------------------------------------------------ |
-| `@trading-model/address-manager/discovery/service-locator`  | `ServiceLocator`, `ServiceNameLocator`, `IpAddressLocator`, `MappingServiceLocator`             |
-| `@trading-model/address-manager/discovery/service-health-checker` | `ServiceHealthChecker`                                        |
-| `@trading-model/address-manager/discovery/service-cache` | `ServiceCache`                                               |
-| `@trading-model/address-manager/discovery/service-discovery` | `ServiceDiscovery`                                            |
-| `@trading-model/address-manager/client/token-manager`    | `TokenManager`                                               |
-| `@trading-model/address-manager/client/address-manager-client` | `AddressManagerClient`                                        |
-| `@trading-model/address-manager/client/type`             | `ServiceInstance`, `RegisterServicePayload`, `ServiceRegistrationResponse` |
-| `@trading-model/address-manager/scheduler/scheduler`     | `Scheduler`                                                  |
-| `@trading-model/address-manager/scheduler/refresh-job`   | `RefreshJob`                                                 |
-| `@trading-model/address-manager/config/address-manager-config` | `AddressManagerConfig`                                        |
+| Import Path                                                       | Exports                                                                             |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `@trading-model/address-manager/discovery/service-locator`        | `ServiceLocator`, `ServiceNameLocator`, `IpAddressLocator`, `MappingServiceLocator` |
+| `@trading-model/address-manager/discovery/service-health-checker` | `ServiceHealthChecker`                                                              |
+| `@trading-model/address-manager/discovery/service-cache`          | `ServiceCache`                                                                      |
+| `@trading-model/address-manager/discovery/service-discovery`      | `ServiceDiscovery`                                                                  |
+| `@trading-model/address-manager/client/token-manager`             | `TokenManager`                                                                      |
+| `@trading-model/address-manager/client/address-manager-client`    | `AddressManagerClient`                                                              |
+| `@trading-model/address-manager/client/type`                      | `ServiceInstance`, `RegisterServicePayload`, `ServiceRegistrationResponse`          |
+| `@trading-model/address-manager/scheduler/scheduler`              | `Scheduler`                                                                         |
+| `@trading-model/address-manager/scheduler/refresh-job`            | `RefreshJob`                                                                        |
+| `@trading-model/address-manager/config/address-manager-config`    | `AddressManagerConfig`                                                              |
 
 ## Environment Schema
 
@@ -248,19 +248,19 @@ Locator that delegates to an internal `DnsResolver` strategy for name-based mapp
 
 ## Internal Classes
 
-| Class                  | Description                                                                                                                                                  |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `TokenManager`         | In-memory token storage, refresh via `POST /token/rotate`                                                                                                    |
-| `AddressManagerClient` | HTTP client for Discovery Server API (register, refresh TTL)                                                                                                 |
-| `ServiceCache`         | In-memory cache with TTL expiry for service instances                                                                                                        |
-| `ServiceHealthChecker` | Pings `https://{host}:{port}/ping` to verify liveness. Target resolution delegated to a `ServiceLocator` strategy.                                                |
-| `ServiceLocator`       | Strategy interface for determining the target hostname of a service instance.                                                                                     |
-| `ServiceNameLocator`   | Default `ServiceLocator` that uses `instance.serviceName` as the hostname.                                                                                        |
-| `IpAddressLocator`     | `ServiceLocator` that uses `instance.ip` directly.                                                                                                                |
-| `MappingServiceLocator`| `ServiceLocator` backed by an internal `DnsResolver` (loaded from `dnsNameMap` config / `DNS_NAME_MAP` env var).                                                  |
-| `ServiceDiscovery`     | Orchestrates cache → health check → fetch flow                                                                                                               |
-| `Scheduler`            | Generic `node-cron` scheduler                                                                                                                                |
-| `RefreshJob<T>`        | Parameterized job that calls a configurable refresh function on a client instance. Replaces previously duplicated `TokenRefresherJob` and `TtlRefresherJob`. |
+| Class                   | Description                                                                                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `TokenManager`          | In-memory token storage, refresh via `POST /token/rotate`                                                                                                    |
+| `AddressManagerClient`  | HTTP client for Discovery Server API (register, refresh TTL)                                                                                                 |
+| `ServiceCache`          | In-memory cache with TTL expiry for service instances                                                                                                        |
+| `ServiceHealthChecker`  | Pings `https://{host}:{port}/ping` to verify liveness. Target resolution delegated to a `ServiceLocator` strategy.                                           |
+| `ServiceLocator`        | Strategy interface for determining the target hostname of a service instance.                                                                                |
+| `ServiceNameLocator`    | Default `ServiceLocator` that uses `instance.serviceName` as the hostname.                                                                                   |
+| `IpAddressLocator`      | `ServiceLocator` that uses `instance.ip` directly.                                                                                                           |
+| `MappingServiceLocator` | `ServiceLocator` backed by an internal `DnsResolver` (loaded from `dnsNameMap` config / `DNS_NAME_MAP` env var).                                             |
+| `ServiceDiscovery`      | Orchestrates cache → health check → fetch flow                                                                                                               |
+| `Scheduler`             | Generic `node-cron` scheduler. Logs job execution errors via `logger.error` instead of swallowing them.                                                      |
+| `RefreshJob<T>`         | Parameterized job that calls a configurable refresh function on a client instance. Replaces previously duplicated `TokenRefresherJob` and `TtlRefresherJob`. |
 
 ## Usage Example
 

--- a/packages/address-manager/src/scheduler/scheduler.ts
+++ b/packages/address-manager/src/scheduler/scheduler.ts
@@ -1,5 +1,7 @@
 import cron, { ScheduledTask } from 'node-cron';
 
+import { logger } from '@trading-model/common/config/logger';
+
 /**
  * Minimal contract that a scheduled job must implement.
  * The Scheduler only knows this contract and interacts through it.
@@ -60,12 +62,9 @@ export class Scheduler {
    * Starts all registered jobs.
    *
    * Each job is scheduled according to its `schedule` property.
-   * Errors thrown by jobs are NOT handled by the scheduler; jobs must manage their own robustness.
-   *
-   * @example
-   * ```ts
-   * scheduler.start();
-   * ```
+   * Errors thrown by jobs are logged via the global logger but do NOT halt the scheduler.
+   * Jobs are expected to manage their own robustness; the logged error provides visibility
+   * into unexpected failures.
    */
   start(): void {
     if (this.started) {
@@ -76,11 +75,11 @@ export class Scheduler {
       const task = cron.schedule(job.schedule, async () => {
         try {
           await job.execute();
-        } catch {
-          /**
-           * Scheduler does NOT handle business errors.
-           * Each job is responsible for its own error handling.
-           */
+        } catch (err) {
+          logger.error('[Scheduler] Job execution failed', {
+            schedule: job.schedule,
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
       });
 
@@ -94,11 +93,6 @@ export class Scheduler {
    * Stops all scheduled jobs gracefully.
    *
    * Clears all internal references to allow proper cleanup.
-   *
-   * @example
-   * ```ts
-   * scheduler.stop();
-   * ```
    */
   stop(): void {
     for (const task of this.tasks) {

--- a/packages/address-manager/tests/unit/scheduler.spec.ts
+++ b/packages/address-manager/tests/unit/scheduler.spec.ts
@@ -6,6 +6,13 @@ jest.mock('node-cron', () => ({
   schedule: jest.fn(),
 }));
 
+jest.mock('@trading-model/common/config/logger', () => ({
+  logger: { error: jest.fn() },
+}));
+
+import { logger } from '@trading-model/common/config/logger';
+const mockLoggerError = jest.mocked(logger.error);
+
 describe('Scheduler', () => {
   let scheduler: Scheduler;
   let mockJob: jest.Mocked<ScheduledJob>;
@@ -77,7 +84,7 @@ describe('Scheduler', () => {
     expect(mockJob.execute).toHaveBeenCalledTimes(1);
   });
 
-  test('start should ignore errors thrown by job.execute', async () => {
+  test('start should log errors thrown by job.execute without propagating', async () => {
     const errorJob: ScheduledJob = {
       schedule: '*/1 * * * *',
       execute: jest
@@ -92,6 +99,23 @@ describe('Scheduler', () => {
     const callback = (cron.schedule as jest.Mock).mock.calls[0][1] as () => Promise<void>;
 
     await expect(callback()).resolves.toBeUndefined();
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      '[Scheduler] Job execution failed',
+      expect.objectContaining({
+        schedule: '*/1 * * * *',
+        error: 'fail',
+      })
+    );
+  });
+
+  test('start should not log when job.execute succeeds', async () => {
+    scheduler.register(mockJob);
+    scheduler.start();
+
+    const callback = (cron.schedule as jest.Mock).mock.calls[0][1] as () => Promise<void>;
+
+    await callback();
+    expect(mockLoggerError).not.toHaveBeenCalled();
   });
 
   test('calling start multiple times should not reschedule jobs', () => {


### PR DESCRIPTION
## Description

Replace the empty catch block in `Scheduler.start()` with a `logger.error()` call that logs job schedule and error context. This provides visibility into unexpected job failures instead of silently discarding them.

## Type of Change

- [x] :bug: Bug fix
- [x] :white_check_mark: Test
- [x] :memo: Documentation

## Changes

### :recycle: Modifications

- **scheduler.ts**: Replace empty catch block (that silently swallowed errors) with `logger.error()` logging job schedule and error message
- **JSDoc**: Remove trivial @example blocks from `start()` and `stop()` per JSDOC_STANDARD.md (one-liner methods)

### :white_check_mark: Additions

- **scheduler.spec.ts**: Add test verifying errors are logged via `logger.error` with correct schedule and error context
- **scheduler.spec.ts**: Add test verifying `logger.error` is not called when job succeeds
- **scheduler.spec.ts**: Fix mock TDZ issue by inlining `jest.fn()` in the mock factory

### :memo: Documentation

- **CHANGELOG.md**: Add v1.3.1 entry for fix, test, and docs changes
- **address-manager.md**: Update Scheduler class description to mention error logging

## Breaking Changes

- [ ] Yes
- [x] No

## Related Issues

Closes #114

## Test Plan

- [x] Existing tests pass (1230 tests across all workspaces)
- [x] New tests added for error logging behavior
- [x] Coverage thresholds met (scheduler.ts 100% lines, 83.33% branches > 80% threshold)

## Checklist

- [x] Code follows project standards
- [x] Tests added/updated and all pass
- [x] Lint passes
- [x] Build passes
- [x] JSDoc updated for public APIs
- [x] Docs updated if needed
- [x] Commit messages follow gitmoji convention

## Additional Notes

This PR is part of the code quality audit initiative (refactor/code-quality-audit). Commits are separated by type per COMMIT.md:

1. `:bug:(address-manager): log scheduler job execution errors instead of swallowing silently`
2. `:white_check_mark:(address-manager): add tests for scheduler error logging`
3. `:memo:(address-manager): document scheduler error logging behavior`

## Screenshots (if applicable)
