### PR TITLE
:bug:(address-manager): add configurable timeout to findService HTTP calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@
 #### Fix
 
 - :bug:(address-manager): log scheduler job execution errors instead of swallowing them silently (#114)
+- :bug:(address-manager): preserve original error type via cause property in AddressManagerError (#115)
+- :bug:(address-manager): add configurable timeout to findService HTTP calls to prevent indefinite hangs (#116)
 
 #### Test
 
 - :white_check_mark:(address-manager): add test for error logging when job.execute throws
+- :white_check_mark:(address-manager): add tests verifying original error is preserved via cause property
+- :white_check_mark:(address-manager): add test verifying timeout option is passed to HttpClient.get
 
 ## [1.3.0] - 2026-06-06
 

--- a/docs/architecture/api/address-manager.md
+++ b/docs/architecture/api/address-manager.md
@@ -166,22 +166,23 @@ In addition to the default export, the package exposes internal modules via deep
 - **Import**: `@trading-model/common/validation/env`
 - **Schema**: `AddressManagerEnvSchema`
 
-| Variable                          | Default     | Description               |
-| --------------------------------- | ----------- | ------------------------- |
-| `APP_NAME`                        | —           | Application name          |
-| `APP_VERSION`                     | `'1.0.0'`   | Version                   |
-| `SERVICE_NAME`                    | —           | Service identifier        |
-| `INSTANCE_ID`                     | —           | Instance UUID             |
-| `CACHE_TTL_MS`                    | `30000`     | Discovery cache TTL       |
-| `SERVICE_PING_TIMEOUT_MS`         | `2000`      | Health check timeout      |
-| `TOKEN_REFRESH_INTERVAL_MS`       | `60000`     | Token rotation interval   |
-| `TTL_REFRESH_INTERVAL_MS`         | `15000`     | TTL refresh interval      |
-| `ADDRESS_MANAGER_URL`             | —           | Discovery-server URL      |
-| `DNS_NAME_MAP`                    | `'{}'`      | Custom DNS mapping (JSON) |
-| `ERROR_URL_WEBHOOK`               | `''`        | Error webhook             |
-| `MESSAGE_BUS_INIT_TIMEOUT_MS`     | `2000`      | Bus init timeout          |
-| `MESSAGE_BUS_SHUTDOWN_TIMEOUT_MS` | `2000`      | Bus shutdown timeout      |
-| `MESSAGE_CALLBACK_PATH`           | `'message'` | Message callback path     |
+| Variable                          | Default     | Description                 |
+| --------------------------------- | ----------- | --------------------------- |
+| `APP_NAME`                        | —           | Application name            |
+| `APP_VERSION`                     | `'1.0.0'`   | Version                     |
+| `SERVICE_NAME`                    | —           | Service identifier          |
+| `INSTANCE_ID`                     | —           | Instance UUID               |
+| `CACHE_TTL_MS`                    | `30000`     | Discovery cache TTL         |
+| `DISCOVERY_TIMEOUT_MS`            | `5000`      | Discovery HTTP call timeout |
+| `SERVICE_PING_TIMEOUT_MS`         | `2000`      | Health check timeout        |
+| `TOKEN_REFRESH_INTERVAL_MS`       | `60000`     | Token rotation interval     |
+| `TTL_REFRESH_INTERVAL_MS`         | `15000`     | TTL refresh interval        |
+| `ADDRESS_MANAGER_URL`             | —           | Discovery-server URL        |
+| `DNS_NAME_MAP`                    | `'{}'`      | Custom DNS mapping (JSON)   |
+| `ERROR_URL_WEBHOOK`               | `''`        | Error webhook               |
+| `MESSAGE_BUS_INIT_TIMEOUT_MS`     | `2000`      | Bus init timeout            |
+| `MESSAGE_BUS_SHUTDOWN_TIMEOUT_MS` | `2000`      | Bus shutdown timeout        |
+| `MESSAGE_CALLBACK_PATH`           | `'message'` | Message callback path       |
 
 ## Internal Architecture
 
@@ -258,7 +259,7 @@ Locator that delegates to an internal `DnsResolver` strategy for name-based mapp
 | `ServiceNameLocator`    | Default `ServiceLocator` that uses `instance.serviceName` as the hostname.                                                                                   |
 | `IpAddressLocator`      | `ServiceLocator` that uses `instance.ip` directly.                                                                                                           |
 | `MappingServiceLocator` | `ServiceLocator` backed by an internal `DnsResolver` (loaded from `dnsNameMap` config / `DNS_NAME_MAP` env var).                                             |
-| `ServiceDiscovery`      | Orchestrates cache → health check → fetch flow                                                                                                               |
+| `ServiceDiscovery`      | Orchestrates cache → health check → fetch flow. Uses configurable `discoveryTimeoutMs` for HTTP calls to prevent indefinite hangs.                           |
 | `Scheduler`             | Generic `node-cron` scheduler. Logs job execution errors via `logger.error` instead of swallowing them.                                                      |
 | `RefreshJob<T>`         | Parameterized job that calls a configurable refresh function on a client instance. Replaces previously duplicated `TokenRefresherJob` and `TtlRefresherJob`. |
 

--- a/packages/address-manager/src/config/address-manager-config.ts
+++ b/packages/address-manager/src/config/address-manager-config.ts
@@ -8,6 +8,7 @@ interface AddressManagerConfig {
   tokenRefreshIntervalMs: number;
   ttlRefreshIntervalMs: number;
   servicePingTimeoutMs: number;
+  discoveryTimeoutMs: number;
 
   RootCACertPath: string;
   CertificatPath: string;

--- a/packages/address-manager/src/create-address-manager.ts
+++ b/packages/address-manager/src/create-address-manager.ts
@@ -4,6 +4,7 @@ import AddressManager from './index';
 export interface AddressManagerEnv {
   ADDRESS_MANAGER_URL: string;
   CACHE_TTL_MS: number;
+  DISCOVERY_TIMEOUT_MS: number;
   INSTANCE_ID: string;
   SERVICE_NAME: string;
   SERVICE_PING_TIMEOUT_MS: number;
@@ -23,6 +24,7 @@ export function createAddressManager(env: AddressManagerEnv) {
   return new AddressManager({
     addressManagerUrl: env.ADDRESS_MANAGER_URL,
     cacheTtlMs: env.CACHE_TTL_MS,
+    discoveryTimeoutMs: env.DISCOVERY_TIMEOUT_MS,
     instanceId: env.INSTANCE_ID,
     serviceName: env.SERVICE_NAME,
     servicePingTimeoutMs: env.SERVICE_PING_TIMEOUT_MS,

--- a/packages/address-manager/src/discovery/service-discovery.ts
+++ b/packages/address-manager/src/discovery/service-discovery.ts
@@ -22,12 +22,14 @@ import { AddressManagerConfig } from '../config/address-manager-config';
  * returned instances are healthy and valid.
  */
 export class ServiceDiscovery {
+  private readonly discoveryTimeoutMs: number;
+
   /**
    * Creates a new ServiceDiscovery instance.
    *
    * @example
    * ```ts
-   * const discovery = new ServiceDiscovery(client, cache, healthChecker);
+   * const discovery = new ServiceDiscovery(client, cache, healthChecker, config);
    * ```
    */
   constructor(
@@ -35,7 +37,9 @@ export class ServiceDiscovery {
     private readonly serviceCache: ServiceCache,
     private readonly config: AddressManagerConfig,
     private readonly healthChecker: ServiceHealthChecker
-  ) {}
+  ) {
+    this.discoveryTimeoutMs = config.discoveryTimeoutMs;
+  }
 
   /**
    * Returns a healthy instance of the requested service.
@@ -89,7 +93,8 @@ export class ServiceDiscovery {
 
     try {
       instances = await this.httpClient.get<unknown>(
-        `${this.config.addressManagerUrl}/services/${serviceName}`
+        `${this.config.addressManagerUrl}/services/${serviceName}`,
+        { timeoutMs: this.discoveryTimeoutMs }
       );
     } catch (error) {
       throw new ServiceNotFoundError(`Service "${serviceName}" not found`, error);

--- a/packages/address-manager/tests/unit/address-manager.spec.ts
+++ b/packages/address-manager/tests/unit/address-manager.spec.ts
@@ -84,6 +84,7 @@ describe('AddressManager', () => {
     tokenRefreshIntervalMs: 300000,
     ttlRefreshIntervalMs: 300000,
     servicePingTimeoutMs: 2000,
+    discoveryTimeoutMs: 5000,
     cacheTtlMs: 60000,
     RootCACertPath: '/path/to/ca.pem',
     CertificatPath: '/path/to/cert.pem',

--- a/packages/address-manager/tests/unit/create-address-manager.spec.ts
+++ b/packages/address-manager/tests/unit/create-address-manager.spec.ts
@@ -19,6 +19,7 @@ describe('createAddressManager', () => {
     const env = {
       ADDRESS_MANAGER_URL: 'http://localhost:8443',
       CACHE_TTL_MS: 60000,
+      DISCOVERY_TIMEOUT_MS: 5000,
       INSTANCE_ID: 'instance-1',
       SERVICE_NAME: 'test-service',
       SERVICE_PING_TIMEOUT_MS: 2000,
@@ -39,6 +40,7 @@ describe('createAddressManager', () => {
     const env = {
       ADDRESS_MANAGER_URL: 'http://localhost:8443',
       CACHE_TTL_MS: 60000,
+      DISCOVERY_TIMEOUT_MS: 5000,
       INSTANCE_ID: 'instance-1',
       SERVICE_NAME: 'test-service',
       SERVICE_PING_TIMEOUT_MS: 2000,

--- a/packages/address-manager/tests/unit/service-discovery.spec.ts
+++ b/packages/address-manager/tests/unit/service-discovery.spec.ts
@@ -46,6 +46,7 @@ describe('ServiceDiscovery', () => {
       cache,
       {
         addressManagerUrl: 'ee',
+        discoveryTimeoutMs: 5000,
       } as AddressManagerConfig,
       healthChecker
     );
@@ -95,6 +96,19 @@ describe('ServiceDiscovery', () => {
     await expect(discovery.findService(serviceName)).rejects.toThrow(ServiceNotFoundError);
 
     expect(cache.invalidate).not.toHaveBeenCalled();
+  });
+
+  test('passes timeout option to HttpClient.get', async () => {
+    cache.get.mockReturnValue(null);
+    httpClient.get.mockResolvedValueOnce(instance);
+    healthChecker.isHealthy.mockResolvedValue(true);
+
+    await discovery.findService(serviceName);
+
+    expect(httpClient.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ timeoutMs: 5000 })
+    );
   });
 
   test('handles array response from AddressManager by taking first element', async () => {

--- a/packages/common/src/validation/env.ts
+++ b/packages/common/src/validation/env.ts
@@ -26,6 +26,7 @@ export const AddressManagerEnvSchema = z.object({
   INSTANCE_ID: z.string().min(1),
   CACHE_TTL_MS: z.coerce.number().int().positive().default(30000),
   SERVICE_PING_TIMEOUT_MS: z.coerce.number().int().positive().default(2000),
+  DISCOVERY_TIMEOUT_MS: z.coerce.number().int().positive().default(5000),
   TOKEN_REFRESH_INTERVAL_MS: z.coerce.number().int().positive().default(60000),
   TTL_REFRESH_INTERVAL_MS: z.coerce.number().int().positive().default(15000),
   ADDRESS_MANAGER_URL: z.url(),


### PR DESCRIPTION
## Description

Add a configurable timeout to the HTTP call in `ServiceDiscovery.resolveAndValidateService()` to prevent indefinite hangs when the Address Manager is slow or unresponsive. The timeout defaults to 5000ms via the `DISCOVERY_TIMEOUT_MS` environment variable.

## Type of Change

- [x] :bug: Bug fix
- [x] :white_check_mark: Test
- [x] :memo: Documentation

## Changes

### :recycle: Modifications

- **address-manager-config.ts**: Add `discoveryTimeoutMs: number` field
- **service-discovery.ts**: Store `discoveryTimeoutMs` from config and pass `{ timeoutMs }` to `httpClient.get()`
- **env.ts**: Add `DISCOVERY_TIMEOUT_MS` with default `5000` to `AddressManagerEnvSchema`
- **create-address-manager.ts**: Add `DISCOVERY_TIMEOUT_MS` to `AddressManagerEnv` and wire to config

### :white_check_mark: Additions

- **service-discovery.spec.ts**: Add test verifying `timeoutMs` option is passed to `HttpClient.get`
- **address-manager.spec.ts**, **create-address-manager.spec.ts**: Add `discoveryTimeoutMs` to test configs for type correctness

### :memo: Documentation

- **CHANGELOG.md**: Add v1.3.1 entry for fix, test, and docs changes
- **address-manager.md**: Add `DISCOVERY_TIMEOUT_MS` to env schema table; update ServiceDiscovery description

## Breaking Changes

- [ ] Yes
- [x] No

## Related Issues

Closes #116

## Test Plan

- [x] Existing tests pass (1229 tests across all workspaces)
- [x] New test verifying timeout option is passed to HttpClient.get
- [x] Coverage thresholds met (service-discovery.ts 100% lines, 100% branches)

## Checklist

- [x] Code follows project standards
- [x] Tests added/updated and all pass
- [x] Lint passes
- [x] Build passes
- [x] JSDoc updated for public APIs
- [x] Docs updated if needed
- [x] Commit messages follow gitmoji convention

## Additional Notes

This PR is part of the code quality audit initiative (refactor/code-quality-audit). Commits are separated by type per COMMIT.md:

1. `:bug:(address-manager): add configurable timeout to findService HTTP calls`
2. `:memo:(address-manager): document discovery timeout and update changelog`

## Screenshots (if applicable)
