### PR TITLE
:bug:(trainer): add input length validation to loss functions (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.3.3] - 2026-06-07
+
+### trader-service (1.3.2 → 1.3.3)
+
+#### Fix
+
+- :bug:(trainer): add input length validation to all loss functions to prevent silent NaN propagation on output/target mismatch (#118)
+
+#### Test
+
+- :white_check_mark:(trainer): add validation tests for length mismatch in all loss and gradient functions
+
 ## [1.3.2] - 2026-06-07
 
 ### trader-service (1.3.1 → 1.3.2)

--- a/services/trader-trainer/src/core/neural-network/losses.ts
+++ b/services/trader-trainer/src/core/neural-network/losses.ts
@@ -2,9 +2,36 @@ import { LossFunctionType, NeuralNetworkConfig } from './type';
 
 const EPSILON = 1e-10;
 
+/** Throws if output and target arrays differ in length. */
+function validateLengths(output: Float32Array, target: Float32Array): void {
+  if (output.length !== target.length) {
+    throw new RangeError(
+      `Loss function input/output length mismatch: output.length=${output.length}, target.length=${target.length}`
+    );
+  }
+}
+
 export interface LossDefinition {
+  /**
+   * Compute the loss value between network output and expected target.
+   * Throws if output and target lengths differ.
+   *
+   * @param output - Network output activations.
+   * @param target - Expected target values.
+   * @param config - Network configuration.
+   * @returns The scalar loss value.
+   */
   loss(output: Float32Array, target: Float32Array, config: Required<NeuralNetworkConfig>): number;
 
+  /**
+   * Compute the gradient of the loss with respect to the network output.
+   * Throws if output and target lengths differ.
+   *
+   * @param output - Network output activations.
+   * @param target - Expected target values.
+   * @param config - Network configuration.
+   * @returns Gradient array of the same length as output.
+   */
   gradient(
     output: Float32Array,
     target: Float32Array,
@@ -15,6 +42,7 @@ export interface LossDefinition {
 export const LOSSES: Record<LossFunctionType, LossDefinition> = {
   'mean-squared-error': {
     loss: (output, target) => {
+      validateLengths(output, target);
       const n = output.length;
 
       let sum = 0;
@@ -27,6 +55,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
       return sum / n;
     },
     gradient: (output, target) => {
+      validateLengths(output, target);
       const n = output.length;
       const out = new Float32Array(n);
 
@@ -43,6 +72,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
 
   'mean-absolute-error': {
     loss(output, target) {
+      validateLengths(output, target);
       const n = output.length;
 
       let sum = 0;
@@ -56,6 +86,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
     },
 
     gradient(output, target) {
+      validateLengths(output, target);
       const n = output.length;
       const out = new Float32Array(n);
 
@@ -73,6 +104,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
 
   'root-mean-squared-error': {
     loss(output, target) {
+      validateLengths(output, target);
       const n = output.length;
 
       let sum = 0;
@@ -86,6 +118,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
     },
 
     gradient(output, target) {
+      validateLengths(output, target);
       const n = output.length;
       const out = new Float32Array(n);
 
@@ -112,6 +145,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
 
   'mean-biais-error': {
     loss(output, target) {
+      validateLengths(output, target);
       const n = output.length;
 
       let sum = 0;
@@ -124,6 +158,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
     },
 
     gradient(output, target) {
+      validateLengths(output, target);
       const n = output.length;
       const out = new Float32Array(n);
 
@@ -139,6 +174,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
 
   'huber-loss': {
     loss(output, target, config) {
+      validateLengths(output, target);
       const n = output.length;
 
       let sum = 0;
@@ -156,6 +192,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
     },
 
     gradient(output, target, config) {
+      validateLengths(output, target);
       const n = output.length;
       const out = new Float32Array(n);
 
@@ -174,6 +211,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
 
   'log-cosh-loss': {
     loss(output, target) {
+      validateLengths(output, target);
       const n = output.length;
 
       let sum = 0;
@@ -186,6 +224,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
     },
 
     gradient(output, target) {
+      validateLengths(output, target);
       const n = output.length;
       const out = new Float32Array(n);
 
@@ -201,6 +240,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
 
   'cross-entropy': {
     loss(output, target) {
+      validateLengths(output, target);
       const n = output.length;
 
       let sum = 0;
@@ -215,6 +255,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
     },
 
     gradient(output, target) {
+      validateLengths(output, target);
       const n = output.length;
       const out = new Float32Array(n);
 
@@ -230,6 +271,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
 
   'binary-cross-entropy': {
     loss(output, target) {
+      validateLengths(output, target);
       const n = output.length;
 
       let sum = 0;
@@ -245,6 +287,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
     },
 
     gradient(output, target) {
+      validateLengths(output, target);
       const n = output.length;
       const out = new Float32Array(n);
 
@@ -263,6 +306,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
 
   'hinge-loss': {
     loss(output, target) {
+      validateLengths(output, target);
       const n = output.length;
 
       let sum = 0;
@@ -277,6 +321,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
     },
 
     gradient(output, target) {
+      validateLengths(output, target);
       const n = output.length;
       const out = new Float32Array(n);
 
@@ -295,6 +340,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
 
   'Kullback-Leibler-divergence': {
     loss(output, target) {
+      validateLengths(output, target);
       const n = output.length;
 
       let sum = 0;
@@ -309,6 +355,7 @@ export const LOSSES: Record<LossFunctionType, LossDefinition> = {
     },
 
     gradient(output, target) {
+      validateLengths(output, target);
       const n = output.length;
       const out = new Float32Array(n);
 

--- a/services/trader-trainer/tests/unit/neural-network/losses.spec.ts
+++ b/services/trader-trainer/tests/unit/neural-network/losses.spec.ts
@@ -231,3 +231,34 @@ describe('Loss Functions', () => {
     });
   });
 });
+
+describe('Loss function input validation', () => {
+  const output = makeOutput([0.2, 0.5, 0.8]);
+  const longTarget = makeTarget([1, 0, 1, 0]);
+  const shortTarget = makeTarget([1]);
+  const cfg = makeConfig();
+
+  const lossNames = Object.keys(LOSSES) as Array<keyof typeof LOSSES>;
+
+  for (const name of lossNames) {
+    describe(name, () => {
+      test('loss should throw on output longer than target', () => {
+        expect(() => LOSSES[name].loss(output, shortTarget, cfg)).toThrow(RangeError);
+      });
+
+      test('loss should throw on output shorter than target', () => {
+        const short = makeOutput([0.2]);
+        expect(() => LOSSES[name].loss(short, longTarget, cfg)).toThrow(RangeError);
+      });
+
+      test('gradient should throw on output longer than target', () => {
+        expect(() => LOSSES[name].gradient(output, shortTarget, cfg)).toThrow(RangeError);
+      });
+
+      test('gradient should throw on output shorter than target', () => {
+        const short = makeOutput([0.2]);
+        expect(() => LOSSES[name].gradient(short, longTarget, cfg)).toThrow(RangeError);
+      });
+    });
+  }
+});


### PR DESCRIPTION
# Description

Add input length validation to all 9 loss functions in `losses.ts`. Each `loss()` and `gradient()` now validates that `output.length === target.length`, throwing a `RangeError` on mismatch. This prevents silent NaN propagation when mismatched arrays are passed to the loss computation.

Also adds JSDoc to the `LossDefinition` interface documenting the validation behavior.

## Type of Change

- [x] :bug: fix — Bug fix
- [x] :white_check_mark: test — Tests
- [ ] :memo: docs — Documentation

## Changes

### ✅ Additions

- `losses.ts`: Added `validateLengths()` helper function that throws `RangeError` when `output.length !== target.length`
- `losses.spec.ts`: Added validation tests for all 9 loss function pairs (36 test cases total)

### :recycle: Modifications

- `losses.ts`: Called `validateLengths(output, target)` at the start of every `loss()` and `gradient()` method across all 9 loss functions (18 call sites)
- `losses.ts`: Added JSDoc to `LossDefinition` interface documenting the throw condition on both `loss()` and `gradient()`
- `CHANGELOG.md`: Added v1.3.3 entry

## Related Issues

Closes #118

## Checklist

- [x] Code follows [project standards](../docs/standards/WRITING.md)
- [x] Tests added/updated and all pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Build passes (`npm run build`)
- [x] JSDoc updated for public APIs
- [ ] Docs updated if needed (standards, deployment, architecture)
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Test Plan

- 543 tests pass (503 existing + 36 new validation tests + 4 from #117 PR)
- `losses.ts` coverage: 100% across all metrics (statements, branches, functions, lines)
- Each of the 9 loss functions is tested for both `loss()` and `gradient()` with:
  - output longer than target
  - output shorter than target

## Screenshots (if applicable)

N/A
