### PR TITLE
:recycle:(trainer): return TrainingResult from train()

### DIFF
--- a/services/trader-trainer/src/core/trainer.ts
+++ b/services/trader-trainer/src/core/trainer.ts
@@ -37,6 +37,23 @@ export type BestAgentSummary = {
   };
 };
 
+/** Indicates that training completed successfully with the resulting best genome. */
+export type TrainingSuccess = {
+  success: true;
+  symbol: string;
+  bestGenome: DeepReadonly<LamarckGenome>;
+};
+
+/** Indicates that training failed with an error. */
+export type TrainingFailure = {
+  success: false;
+  symbol: string;
+  error: Error;
+};
+
+/** Discriminated result of a training cycle. */
+export type TrainingResult = TrainingSuccess | TrainingFailure;
+
 /** Orchestrates GA training cycles: feeds market data, runs generations, tracks best genome. */
 export class Trainer {
   private runner: GeneticAlgorithmRunner | null = null;
@@ -62,15 +79,24 @@ export class Trainer {
     return this.runner?.getGeneration() ?? 0;
   }
 
-  /** Run a full GA training cycle for the given symbol. Skips if already training or insufficient data. */
-  async train(symbol: string): Promise<void> {
-    if (this.training) return;
+  /**
+   * Run a full GA training cycle for the given symbol.
+   * Skips if already training or insufficient data.
+   *
+   * @param symbol - Market symbol to train on.
+   * @returns TrainingResult indicating success or failure.
+   */
+  async train(symbol: string): Promise<TrainingResult> {
+    if (this.training) return { success: false, symbol, error: new Error('Already training') };
 
     const windowSet = this.dataBuffer.getAllWindows(symbol, env.TRAINER_VALIDATION_SPLIT);
 
     if (!windowSet || windowSet.train.length < 10) {
-      console.warn(`[Trainer] Not enough data for ${symbol}, need at least 10 steps`);
-      return;
+      return {
+        success: false,
+        symbol,
+        error: new Error(`Not enough data for ${symbol}, need at least 10 steps`),
+      };
     }
 
     this.currentSymbol = symbol;
@@ -112,8 +138,11 @@ export class Trainer {
         `[Trainer] Training complete for ${symbol}. ` +
           `Best fitness: ${(result.fitness ?? 0).toFixed(4)}`
       );
+      return { success: true, symbol, bestGenome: result };
     } catch (err) {
-      console.error(`[Trainer] Training failed for ${symbol}:`, err);
+      const error = err instanceof Error ? err : new Error(String(err));
+      console.error(`[Trainer] Training failed for ${symbol}:`, error);
+      return { success: false, symbol, error };
     } finally {
       this.training = false;
     }

--- a/services/trader-trainer/tests/unit/core/trainer.spec.ts
+++ b/services/trader-trainer/tests/unit/core/trainer.spec.ts
@@ -179,13 +179,14 @@ describe('Trainer', () => {
   });
 
   describe('train with insufficient data', () => {
-    it('should not start training with fewer than 10 steps', async () => {
+    it('should return failure result with fewer than 10 steps', async () => {
       const { Trainer } = await import('../../../src/core/trainer');
       const trainer = new Trainer(dataBuffer);
       feedCandles(dataBuffer, 'BTCUSDT', 5);
 
-      await trainer.train('BTCUSDT');
+      const result = await trainer.train('BTCUSDT');
 
+      expect(result.success).toBe(false);
       expect(trainer.isTraining()).toBe(false);
       expect(trainer.getBestAgentSummary()).toBeNull();
     });
@@ -195,33 +196,40 @@ describe('Trainer', () => {
       const trainer = new Trainer(dataBuffer);
       feedCandles(dataBuffer, 'BTCUSDT', 11);
 
-      await trainer.train('BTCUSDT');
+      const result = await trainer.train('BTCUSDT');
 
+      expect(result.success).toBe(false);
       expect(trainer.isTraining()).toBe(false);
       expect(trainer.getBestAgentSummary()).toBeNull();
     });
 
-    it('should return immediately if already training', async () => {
+    it('should return failure result if already training', async () => {
       const { Trainer } = await import('../../../src/core/trainer');
       const trainer = new Trainer(dataBuffer);
       feedCandles(dataBuffer, 'BTCUSDT', 100);
 
       Object.defineProperty(trainer, 'training', { value: true, writable: false });
 
-      await trainer.train('BTCUSDT');
+      const result = await trainer.train('BTCUSDT');
 
+      expect(result.success).toBe(false);
       expect(trainer.isTraining()).toBe(true);
     });
   });
 
   describe('train with sufficient data', () => {
-    it('should start training with enough data', async () => {
+    it('should return success result with enough data', async () => {
       const { Trainer } = await import('../../../src/core/trainer');
       const trainer = new Trainer(dataBuffer);
       feedCandles(dataBuffer, 'BTCUSDT', 100);
 
-      await trainer.train('BTCUSDT');
+      const result = await trainer.train('BTCUSDT');
 
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.symbol).toBe('BTCUSDT');
+        expect(result.bestGenome).toBeDefined();
+      }
       expect(trainer.isTraining()).toBe(false);
     });
 
@@ -250,14 +258,15 @@ describe('Trainer', () => {
       const trainer = new Trainer(dataBuffer);
       feedCandles(dataBuffer, 'BTCUSDT', 100);
 
-      await trainer.train('BTCUSDT');
+      const result = await trainer.train('BTCUSDT');
 
+      expect(result.success).toBe(true);
       const summary = trainer.getBestAgentSummary();
       expect(summary).not.toBeNull();
       expect(summary!.id).toBe('mock-result');
     });
 
-    it('should handle training failure gracefully', async () => {
+    it('should return failure result with error details when training throws', async () => {
       mockRunImpl = async () => {
         throw new Error('training error');
       };
@@ -265,8 +274,13 @@ describe('Trainer', () => {
       const trainer = new Trainer(dataBuffer);
       feedCandles(dataBuffer, 'BTCUSDT', 100);
 
-      await trainer.train('BTCUSDT');
+      const result = await trainer.train('BTCUSDT');
 
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.symbol).toBe('BTCUSDT');
+        expect(result.error.message).toBe('training error');
+      }
       expect(trainer.isTraining()).toBe(false);
     });
 
@@ -276,8 +290,9 @@ describe('Trainer', () => {
       const trainer = new Trainer(dataBuffer);
       feedCandles(dataBuffer, 'BTCUSDT', 100);
 
-      await trainer.train('BTCUSDT');
+      const result = await trainer.train('BTCUSDT');
 
+      expect(result.success).toBe(true);
       expect(trainer.isTraining()).toBe(false);
     });
   });


### PR DESCRIPTION
## Description

Change `Trainer.train()` return type from `Promise<void>` to `Promise<TrainingResult>` so callers can distinguish success from failure without relying on side effects or error catching.

## Type of Change

- [x] :recycle: refactor — Code restructuring

## Changes

### ✅ Additions

- `TrainingSuccess` type — discriminated union branch for successful completion, carries `bestGenome`
- `TrainingFailure` type — discriminated union branch for failure, carries `error`
- `TrainingResult` type — `TrainingSuccess | TrainingFailure` union

### :recycle: Modifications

- `train()` signature: `Promise<void>` → `Promise<TrainingResult>`
- Early-exit paths (`already training`, `insufficient data`) now return `{ success: false, symbol, error }`
- Success path returns `{ success: true, symbol, bestGenome }`
- Catch block returns `{ success: false, symbol, error }` with proper `Error` coercion
- All tests updated to assert on `result.success` and narrowed type branches

### :fire: Removals

- `console.warn` in insufficient-data path (replaced by returned error)
- Bare `console.error(err)` in catch (now coerces to `Error` first)

## Related Issues

Closes #120

## Checklist

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — Success
- [x] `npm test` — All tests pass

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Test Plan

- 27 existing tests pass, all green
- Both `result.success === true` and `result.success === false` branches are tested
- Error message and symbol verified in failure results

## Screenshots (if applicable)

N/A
