### PR TITLE
:recycle:(*): add sendResponse helper and migrate to AppError typed error codes

### DIFF
--- a/packages/address-manager/src/client/address-manager-client.ts
+++ b/packages/address-manager/src/client/address-manager-client.ts
@@ -1,7 +1,7 @@
 import { networkInterfaces } from 'os';
 
 import { HttpClient } from '@trading-model/common/config/http-client';
-import { AddressManagerError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 
 import { TokenManager } from './token-manager';
 import { RegisterServicePayload, ServiceRegistrationResponse } from './type';
@@ -65,7 +65,11 @@ export class AddressManagerClient {
         payload
       );
     } catch (error) {
-      throw new AddressManagerError('Failed to register service to Address Manager', error);
+      throw new AppError(
+        'Failed to register service to Address Manager',
+        ErrorCodes.ADDRESS_MANAGER_ERROR,
+        { cause: error }
+      );
     }
   }
 
@@ -95,7 +99,9 @@ export class AddressManagerClient {
         }
       );
     } catch (error) {
-      throw new AddressManagerError('Failed to refresh service TTL', error);
+      throw new AppError('Failed to refresh service TTL', ErrorCodes.ADDRESS_MANAGER_ERROR, {
+        cause: error,
+      });
     }
   }
 }

--- a/packages/address-manager/src/client/token-manager.ts
+++ b/packages/address-manager/src/client/token-manager.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@trading-model/common/config/http-client';
-import { AuthenticationError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 
 import { AddressManagerConfig } from '../config/address-manager-config';
 
@@ -52,7 +52,10 @@ export class TokenManager {
    */
   getToken(): string {
     if (!this.token) {
-      throw new AuthenticationError('Token is not available. Did you call refreshToken()?');
+      throw new AppError(
+        'Token is not available. Did you call refreshToken()?',
+        ErrorCodes.AUTHENTICATION_ERROR
+      );
     }
 
     return this.token;
@@ -94,13 +97,20 @@ export class TokenManager {
       );
 
       if (!response || !response.token) {
-        throw new AuthenticationError('Invalid token response from Address Manager');
+        throw new AppError(
+          'Invalid token response from Address Manager',
+          ErrorCodes.AUTHENTICATION_ERROR
+        );
       }
 
       this.token = response.token;
     } catch (e) {
-      if (e instanceof AuthenticationError) throw e;
-      throw new AuthenticationError('Failed to refresh authentication token', e);
+      if (e instanceof AppError && e.code === ErrorCodes.AUTHENTICATION_ERROR) throw e;
+      throw new AppError(
+        'Failed to refresh authentication token',
+        ErrorCodes.AUTHENTICATION_ERROR,
+        { cause: e }
+      );
     }
   }
 }

--- a/packages/address-manager/src/discovery/service-discovery.ts
+++ b/packages/address-manager/src/discovery/service-discovery.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@trading-model/common/config/http-client';
-import { ServiceNotFoundError, ServiceUnreachableError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 
 import { ServiceCache } from './service-cache';
 import { ServiceHealthChecker } from './service-health-checker';
@@ -97,7 +97,9 @@ export class ServiceDiscovery {
         { timeoutMs: this.discoveryTimeoutMs }
       );
     } catch (error) {
-      throw new ServiceNotFoundError(`Service "${serviceName}" not found`, error);
+      throw new AppError(`Service "${serviceName}" not found`, ErrorCodes.SERVICE_NOT_FOUND, {
+        cause: error,
+      });
     }
 
     const instance = Array.isArray(instances)
@@ -105,7 +107,10 @@ export class ServiceDiscovery {
       : (instances as ServiceInstance);
 
     if (!instance) {
-      throw new ServiceNotFoundError(`Service "${serviceName}" has no registered instances`);
+      throw new AppError(
+        `Service "${serviceName}" has no registered instances`,
+        ErrorCodes.SERVICE_NOT_FOUND
+      );
     }
 
     const isHealthy = await this.healthChecker.isHealthy(instance);
@@ -113,7 +118,7 @@ export class ServiceDiscovery {
     if (!isHealthy) {
       this.serviceCache.invalidate(serviceName);
 
-      throw new ServiceUnreachableError(`Service "${serviceName}" is unreachable`);
+      throw new AppError(`Service "${serviceName}" is unreachable`, ErrorCodes.SERVICE_UNREACHABLE);
     }
 
     this.serviceCache.set(serviceName, instance);

--- a/packages/address-manager/src/http/ping.controller.ts
+++ b/packages/address-manager/src/http/ping.controller.ts
@@ -1,10 +1,10 @@
 import { Request, Response } from 'express';
 
-import { ResponseException } from '@trading-model/common/middleware/response-exception';
+import { sendResponse } from '@trading-model/common/middleware/response-exception';
 
 /** Handles GET /ping requests. Returns a "pong" response to indicate the service is alive. */
 export const pingController = (_: Request, res: Response) => {
-  const response = ResponseException('pong').OK();
+  const response = sendResponse('pong', 201);
 
   return res.status(response.status).json(response.data);
 };

--- a/packages/address-manager/tests/unit/address-manager-client.spec.ts
+++ b/packages/address-manager/tests/unit/address-manager-client.spec.ts
@@ -4,7 +4,7 @@ import { ServiceRegistrationResponse } from '../../src/client/type';
 import { AddressManagerClient } from '../../src/client/address-manager-client';
 import { HttpClient } from '@trading-model/common/config/http-client';
 import { AddressManagerConfig } from '../../src/config/address-manager-config';
-import { AddressManagerError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
 jest.mock('os');
@@ -113,8 +113,8 @@ describe('AddressManagerClient', () => {
 
       httpClient.post.mockRejectedValueOnce(error);
       const err = await client.registerService().catch(e => e);
-      expect(err).toBeInstanceOf(AddressManagerError);
-      expect(err.cause).toBe(error);
+      expect(err).toBeInstanceOf(AppError);
+      expect((err as AppError).cause).toBe(error);
     });
   });
 
@@ -136,8 +136,8 @@ describe('AddressManagerClient', () => {
 
       httpClient.post.mockRejectedValueOnce(error);
       const err = await client.refreshTTL().catch(e => e);
-      expect(err).toBeInstanceOf(AddressManagerError);
-      expect(err.cause).toBe(error);
+      expect(err).toBeInstanceOf(AppError);
+      expect((err as AppError).cause).toBe(error);
     });
   });
 });

--- a/packages/address-manager/tests/unit/service-discovery.spec.ts
+++ b/packages/address-manager/tests/unit/service-discovery.spec.ts
@@ -4,7 +4,7 @@ import { ServiceInstance } from '../../src/client/type';
 import { ServiceHealthChecker } from '../../src/discovery/service-health-checker';
 import { HttpClient } from '@trading-model/common/config/http-client';
 import { AddressManagerConfig } from '../../src/config/address-manager-config';
-import { ServiceNotFoundError, ServiceUnreachableError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
 describe('ServiceDiscovery', () => {
@@ -93,7 +93,7 @@ describe('ServiceDiscovery', () => {
     cache.get.mockReturnValue(null);
     httpClient.get.mockRejectedValue('');
 
-    await expect(discovery.findService(serviceName)).rejects.toThrow(ServiceNotFoundError);
+    await expect(discovery.findService(serviceName)).rejects.toThrow(AppError);
 
     expect(cache.invalidate).not.toHaveBeenCalled();
   });
@@ -126,7 +126,7 @@ describe('ServiceDiscovery', () => {
     cache.get.mockReturnValue(null);
     httpClient.get.mockResolvedValueOnce(null);
 
-    await expect(discovery.findService(serviceName)).rejects.toThrow(ServiceNotFoundError);
+    await expect(discovery.findService(serviceName)).rejects.toThrow(AppError);
     await expect(discovery.findService(serviceName)).rejects.toMatchObject({
       message: 'Service "user-service" has no registered instances',
     });
@@ -139,7 +139,7 @@ describe('ServiceDiscovery', () => {
     httpClient.get.mockResolvedValueOnce(instance);
     healthChecker.isHealthy.mockResolvedValue(false);
 
-    await expect(discovery.findService(serviceName)).rejects.toThrow(ServiceUnreachableError);
+    await expect(discovery.findService(serviceName)).rejects.toThrow(AppError);
 
     expect(cache.invalidate).toHaveBeenCalledWith(serviceName);
     expect(cache.set).not.toHaveBeenCalled();

--- a/packages/address-manager/tests/unit/token-manager.spec.ts
+++ b/packages/address-manager/tests/unit/token-manager.spec.ts
@@ -1,7 +1,7 @@
 import { TokenManager } from '../../src/client/token-manager';
 import { HttpClient } from '@trading-model/common/config/http-client';
 import { AddressManagerConfig } from '../../src/config/address-manager-config';
-import { AuthenticationError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
 describe('TokenManager', () => {
@@ -28,7 +28,7 @@ describe('TokenManager', () => {
 
   describe('getToken', () => {
     test('should throw AuthenticationError if token is not available', () => {
-      expect(() => manager.getToken()).toThrow(AuthenticationError);
+      expect(() => manager.getToken()).toThrow(AppError);
       expect(() => manager.getToken()).toThrow(
         'Token is not available. Did you call refreshToken()?'
       );
@@ -79,7 +79,7 @@ describe('TokenManager', () => {
       httpClient.post.mockResolvedValueOnce({});
       manager.setToken('initial-token');
 
-      await expect(manager.refreshToken()).rejects.toThrow(AuthenticationError);
+      await expect(manager.refreshToken()).rejects.toThrow(AppError);
       await expect(manager.refreshToken()).rejects.toThrow(
         'Invalid token response from Address Manager'
       );
@@ -89,7 +89,7 @@ describe('TokenManager', () => {
       const error = new Error('Network failure');
       httpClient.post.mockRejectedValueOnce(error);
       manager.setToken('initial-token');
-      await expect(manager.refreshToken()).rejects.toThrow(AuthenticationError);
+      await expect(manager.refreshToken()).rejects.toThrow(AppError);
 
       httpClient.post.mockRejectedValueOnce(error);
       manager.setToken('initial-token');

--- a/packages/broker-message/src/client/message-manager-client.ts
+++ b/packages/broker-message/src/client/message-manager-client.ts
@@ -3,7 +3,7 @@ import { EventEnumMap } from '@trading-model/common/config/event.types';
 import { HttpClient } from '@trading-model/common/config/http-client';
 import { ServiceInstanceName } from '@trading-model/common/config/services.types';
 import { MessageMetadata } from '@trading-model/common/contracts/message.types';
-import { MessageManagerError, ServiceUnreachableError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 
 import { MessageManagerConfig } from '../shared/types/config';
 import { SubscribesTopicsPayload, UnSubscribesTopicsPayload } from '../shared/types/payloads';
@@ -32,7 +32,11 @@ export class MessageManagerClient {
     try {
       return await this.httpClient.post(targetUrl, payload);
     } catch (error) {
-      throw new MessageManagerError('Failed to subscribe topic to Message Manager', error);
+      throw new AppError(
+        'Failed to subscribe topic to Message Manager',
+        ErrorCodes.MESSAGE_MANAGER_ERROR,
+        { cause: error }
+      );
     }
   }
 
@@ -46,7 +50,11 @@ export class MessageManagerClient {
     try {
       return await this.httpClient.delete(targetUrl, payload);
     } catch (error) {
-      throw new MessageManagerError('Failed to unsubscribe topic to Message Manager', error);
+      throw new AppError(
+        'Failed to unsubscribe topic to Message Manager',
+        ErrorCodes.MESSAGE_MANAGER_ERROR,
+        { cause: error }
+      );
     }
   }
 
@@ -60,16 +68,21 @@ export class MessageManagerClient {
       const target = await this.addressManagerClient.findService(
         ServiceInstanceName.MessageDeliveryService
       );
-      if (!target) throw new ServiceUnreachableError('Unable to contact the message manager');
+      if (!target)
+        throw new AppError('Unable to contact the message manager', ErrorCodes.SERVICE_UNREACHABLE);
 
       for (const topic of topics) {
         await this.SubscribesToASingleTopic(topic, `https://${target.ip}:${target.port}/subscribe`);
       }
     } catch (e) {
-      if (e instanceof ServiceUnreachableError) throw e;
-      if (e instanceof MessageManagerError) return;
+      if (e instanceof AppError && e.code === ErrorCodes.SERVICE_UNREACHABLE) throw e;
+      if (e instanceof AppError && e.code === ErrorCodes.MESSAGE_MANAGER_ERROR) return;
 
-      throw new MessageManagerError('Failed to subscribe topic to Message Manager', e);
+      throw new AppError(
+        'Failed to subscribe topic to Message Manager',
+        ErrorCodes.MESSAGE_MANAGER_ERROR,
+        { cause: e }
+      );
     }
   }
 
@@ -83,7 +96,8 @@ export class MessageManagerClient {
       const target = await this.addressManagerClient.findService(
         ServiceInstanceName.MessageDeliveryService
       );
-      if (!target) throw new ServiceUnreachableError('Unable to contact the message manager');
+      if (!target)
+        throw new AppError('Unable to contact the message manager', ErrorCodes.SERVICE_UNREACHABLE);
 
       for (const topic of topics) {
         await this.UnSubscribesToASingleTopic(
@@ -92,10 +106,14 @@ export class MessageManagerClient {
         );
       }
     } catch (e) {
-      if (e instanceof ServiceUnreachableError) throw e;
-      if (e instanceof MessageManagerError) return;
+      if (e instanceof AppError && e.code === ErrorCodes.SERVICE_UNREACHABLE) throw e;
+      if (e instanceof AppError && e.code === ErrorCodes.MESSAGE_MANAGER_ERROR) return;
 
-      throw new MessageManagerError('Failed to unsubscribe topic to Message Manager', e);
+      throw new AppError(
+        'Failed to unsubscribe topic to Message Manager',
+        ErrorCodes.MESSAGE_MANAGER_ERROR,
+        { cause: e }
+      );
     }
   }
 
@@ -110,7 +128,8 @@ export class MessageManagerClient {
       const target = await this.addressManagerClient.findService(
         ServiceInstanceName.MessageDeliveryService
       );
-      if (!target) throw new ServiceUnreachableError('Unable to contact the message manager');
+      if (!target)
+        throw new AppError('Unable to contact the message manager', ErrorCodes.SERVICE_UNREACHABLE);
 
       const Messagepayload = {
         payload,
@@ -122,9 +141,13 @@ export class MessageManagerClient {
         Messagepayload
       );
     } catch (error) {
-      if (error instanceof ServiceUnreachableError) throw error;
+      if (error instanceof AppError && error.code === ErrorCodes.SERVICE_UNREACHABLE) throw error;
 
-      throw new MessageManagerError('Failed to publish message to Message Manager', error);
+      throw new AppError(
+        'Failed to publish message to Message Manager',
+        ErrorCodes.MESSAGE_MANAGER_ERROR,
+        { cause: error }
+      );
     }
   }
 
@@ -142,7 +165,11 @@ export class MessageManagerClient {
   ): Promise<void> {
     try {
       const target = await this.addressManagerClient.findService(service);
-      if (!target) throw new ServiceUnreachableError('Unable to contact the service: ' + service);
+      if (!target)
+        throw new AppError(
+          'Unable to contact the service: ' + service,
+          ErrorCodes.SERVICE_UNREACHABLE
+        );
 
       const Messagepayload = {
         payload,
@@ -154,9 +181,13 @@ export class MessageManagerClient {
         Messagepayload
       );
     } catch (error) {
-      if (error instanceof ServiceUnreachableError) throw error;
+      if (error instanceof AppError && error.code === ErrorCodes.SERVICE_UNREACHABLE) throw error;
 
-      throw new MessageManagerError('Failed to publish message to ' + service, error);
+      throw new AppError(
+        'Failed to publish message to ' + service,
+        ErrorCodes.MESSAGE_MANAGER_ERROR,
+        { cause: error }
+      );
     }
   }
 }

--- a/packages/broker-message/src/shared/helper/messages/message.ts
+++ b/packages/broker-message/src/shared/helper/messages/message.ts
@@ -5,7 +5,7 @@ import {
   RoutingType,
   SecurityType,
 } from '@trading-model/common/contracts/message.types';
-import { MetadataBuilderError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 
 import {
   SecurityMetadataContextPredicate,
@@ -199,9 +199,12 @@ export class MessageMetadata {
       security,
     } = this;
 
-    if (!topic) throw new MetadataBuilderError("You haven't defined a topic");
-    if (!eventType) throw new MetadataBuilderError("You haven't defined a eventType");
-    if (!publisher) throw new MetadataBuilderError("You haven't defined a publisher");
+    if (!topic)
+      throw new AppError("You haven't defined a topic", ErrorCodes.METADATA_BUILDER_ERROR);
+    if (!eventType)
+      throw new AppError("You haven't defined a eventType", ErrorCodes.METADATA_BUILDER_ERROR);
+    if (!publisher)
+      throw new AppError("You haven't defined a publisher", ErrorCodes.METADATA_BUILDER_ERROR);
 
     return {
       eventType,

--- a/packages/broker-message/tests/unit/message-manager-client.spec.ts
+++ b/packages/broker-message/tests/unit/message-manager-client.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { MessageManagerClient } from '../../src/client/message-manager-client';
-import { MessageManagerError, ServiceUnreachableError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 import { ServiceInstanceName } from '@trading-model/common/config/services.types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -61,9 +61,7 @@ describe('MessageManagerClient', () => {
     it('should throw ServiceUnreachableError when service not found', async () => {
       addressManagerClient.findService.mockResolvedValue(null);
 
-      await expect(client.SubscribeToTopics(['example.debug.create'])).rejects.toThrow(
-        ServiceUnreachableError
-      );
+      await expect(client.SubscribeToTopics(['example.debug.create'])).rejects.toThrow(AppError);
     });
 
     it('should swallow MessageManagerError on subscription failure', async () => {
@@ -77,9 +75,7 @@ describe('MessageManagerClient', () => {
     it('should throw MessageManagerError on generic error in subscribe', async () => {
       addressManagerClient.findService.mockRejectedValue(new Error('Generic error'));
 
-      await expect(client.SubscribeToTopics(['example.debug.create'])).rejects.toThrow(
-        MessageManagerError
-      );
+      await expect(client.SubscribeToTopics(['example.debug.create'])).rejects.toThrow(AppError);
     });
   });
 
@@ -96,9 +92,7 @@ describe('MessageManagerClient', () => {
     it('should rethrow ServiceUnreachableError when service not found', async () => {
       addressManagerClient.findService.mockResolvedValue(null);
 
-      await expect(client.UnSubscribeToTopic(['example.debug.create'])).rejects.toThrow(
-        ServiceUnreachableError
-      );
+      await expect(client.UnSubscribeToTopic(['example.debug.create'])).rejects.toThrow(AppError);
     });
 
     it('should swallow MessageManagerError on unsubscribe failure', async () => {
@@ -112,9 +106,7 @@ describe('MessageManagerClient', () => {
     it('should throw MessageManagerError on generic error in unsubscribe', async () => {
       addressManagerClient.findService.mockRejectedValue(new Error('Generic error'));
 
-      await expect(client.UnSubscribeToTopic(['example.debug.create'])).rejects.toThrow(
-        MessageManagerError
-      );
+      await expect(client.UnSubscribeToTopic(['example.debug.create'])).rejects.toThrow(AppError);
     });
   });
 
@@ -140,16 +132,14 @@ describe('MessageManagerClient', () => {
     it('should rethrow ServiceUnreachableError when service not found', async () => {
       addressManagerClient.findService.mockResolvedValue(null);
 
-      await expect(client.publishAsyncMessage({}, {} as any)).rejects.toThrow(
-        ServiceUnreachableError
-      );
+      await expect(client.publishAsyncMessage({}, {} as any)).rejects.toThrow(AppError);
     });
 
     it('should throw MessageManagerError on publish failure', async () => {
       addressManagerClient.findService.mockResolvedValue(mockServiceInstance);
       httpClient.post.mockRejectedValue(new Error('Publish failed'));
 
-      await expect(client.publishAsyncMessage({}, {} as any)).rejects.toThrow(MessageManagerError);
+      await expect(client.publishAsyncMessage({}, {} as any)).rejects.toThrow(AppError);
     });
   });
 
@@ -178,7 +168,7 @@ describe('MessageManagerClient', () => {
 
       await expect(
         client.publishDirectMessage(ServiceInstanceName.MessageDeliveryService, {}, {} as any)
-      ).rejects.toThrow(ServiceUnreachableError);
+      ).rejects.toThrow(AppError);
     });
 
     it('should throw MessageManagerError on direct publish failure', async () => {
@@ -187,7 +177,7 @@ describe('MessageManagerClient', () => {
 
       await expect(
         client.publishDirectMessage(ServiceInstanceName.MessageDeliveryService, {}, {} as any)
-      ).rejects.toThrow(MessageManagerError);
+      ).rejects.toThrow(AppError);
     });
   });
 });

--- a/packages/broker-message/tests/unit/message-metadata.spec.ts
+++ b/packages/broker-message/tests/unit/message-metadata.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { MessageMetadata } from '../../src/shared/helper/messages/message';
-import { MetadataBuilderError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 import { ServiceInstanceName } from '@trading-model/common/config/services.types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -81,7 +81,7 @@ describe('MessageMetadata', () => {
         serviceName: ServiceInstanceName.DiscoveryService,
         instanceId: '550e8400-e29b-41d4-a716-446655440000',
       });
-      expect(() => m.toJSON()).toThrow(MetadataBuilderError);
+      expect(() => m.toJSON()).toThrow(AppError);
     });
 
     it('should throw if eventType not set', () => {
@@ -89,12 +89,12 @@ describe('MessageMetadata', () => {
         serviceName: ServiceInstanceName.DiscoveryService,
         instanceId: '550e8400-e29b-41d4-a716-446655440000',
       });
-      expect(() => m.toJSON()).toThrow(MetadataBuilderError);
+      expect(() => m.toJSON()).toThrow(AppError);
     });
 
     it('should throw if publisher not set', () => {
       const m = new MessageMetadata().setTopic('test.event.created').setEventType('Test');
-      expect(() => m.toJSON()).toThrow(MetadataBuilderError);
+      expect(() => m.toJSON()).toThrow(AppError);
     });
 
     it('should return complete metadata', () => {

--- a/packages/common/src/middleware/catch-error.ts
+++ b/packages/common/src/middleware/catch-error.ts
@@ -1,9 +1,14 @@
 import { NextFunction, Request, Response } from 'express';
 
+import { ResponseObject } from './response-exception';
+
 /**
  * Wraps an asynchronous Express handler and forwards any thrown errors
  * to the `next()` function. This avoids the need for manual try/catch
  * blocks inside each async route.
+ *
+ * If the handler returns a {@link ResponseObject}, it is sent directly
+ * as the HTTP response instead of using exceptions for normal control flow.
  *
  * @param errorFunction - The asynchronous route handler to wrap.
  * @returns A new function compatible with Express (req, res, next)
@@ -19,9 +24,23 @@ import { NextFunction, Request, Response } from 'express';
  * );
  */
 export const catchSync =
-  (errorFunction: (req: Request, res: Response, next: NextFunction) => void) =>
+  (
+    errorFunction: (
+      req: Request,
+      res: Response,
+      next: NextFunction
+    ) => void | ResponseObject | Promise<ResponseObject | void>
+  ) =>
   async (req: Request, res: Response, next: NextFunction) => {
-    // Ensures that both synchronous and asynchronous errors
-    // are caught and passed to Express' default error handler.
-    Promise.resolve(errorFunction(req, res, next)).catch(next);
+    try {
+      const result = await Promise.resolve(errorFunction(req, res, next));
+      if (result && typeof result === 'object' && 'status' in result) {
+        res
+          .status(result.status)
+          .type('json')
+          .send((result as ResponseObject).data);
+      }
+    } catch (err) {
+      next(err);
+    }
   };

--- a/packages/common/src/middleware/response-exception.ts
+++ b/packages/common/src/middleware/response-exception.ts
@@ -198,6 +198,14 @@ export class ClassResponseExceptions extends Error {
 }
 
 /**
+ * Response object type returned by all response helpers.
+ */
+export type ResponseObject = {
+  status: number;
+  data: unknown;
+};
+
+/**
  * Factory function to create a new instance of ClassResponseExceptions.
  *
  * This provides a convenient way to generate standardized response objects
@@ -212,3 +220,16 @@ export class ClassResponseExceptions extends Error {
  * // returns: { status: 401, data: "Invalid token" }
  */
 export const ResponseException = (reason: unknown = '') => new ClassResponseExceptions(reason);
+
+/**
+ * Create a response object without throwing an exception.
+ * Use this in controllers instead of `throw ResponseException(...).Method()`.
+ *
+ * @param data - Response payload (JSON-serializable).
+ * @param status - HTTP status code.
+ * @returns A response object compatible with catchSync.
+ */
+export const sendResponse = (data: unknown, status: number): ResponseObject => ({
+  status,
+  data,
+});

--- a/packages/common/src/middleware/response-protocol.ts
+++ b/packages/common/src/middleware/response-protocol.ts
@@ -1,18 +1,9 @@
 import { NextFunction, Request, Response } from 'express';
 
-import { ClassResponseExceptions } from './response-exception';
+import { ClassResponseExceptions, ResponseObject } from './response-exception';
 import { logger } from '../config/logger';
-import {
-  AuthenticationError,
-  ServiceNotFoundError,
-  ServiceUnreachableError,
-  AddressManagerBaseError,
-} from '../utils/errors';
+import { AppError, ErrorCodes } from '../utils/errors';
 
-type ResponseObject = {
-  status: number;
-  data: string;
-};
 type ErrorInput = Error | ResponseObject;
 
 /**
@@ -24,32 +15,25 @@ type ErrorInput = Error | ResponseObject;
 function mapErrorToResponse(err: Error): ResponseObject {
   const response = new ClassResponseExceptions(err.message);
 
-  /**
-   * Address Manager / Service Discovery errors
-   */
-  if (err instanceof ServiceNotFoundError) {
-    return response.NotFound();
+  if (err instanceof AppError) {
+    switch (err.code) {
+      case ErrorCodes.SERVICE_NOT_FOUND:
+        return response.NotFound();
+      case ErrorCodes.SERVICE_UNREACHABLE:
+        return response.Gone();
+      case ErrorCodes.AUTHENTICATION_ERROR:
+        return response.InvalidToken();
+      default:
+        if (
+          err.code === ErrorCodes.ADDRESS_MANAGER_ERROR ||
+          err.code.startsWith('ADDRESS_MANAGER_')
+        ) {
+          return response.UnknownError();
+        }
+        break;
+    }
   }
 
-  if (err instanceof ServiceUnreachableError) {
-    // Service exists but is temporarily unavailable
-    return response.Gone(); // 410
-  }
-
-  if (err instanceof AuthenticationError) {
-    return response.InvalidToken(); // 498
-  }
-
-  /**
-   * Known module-level errors without explicit mapping
-   */
-  if (err instanceof AddressManagerBaseError) {
-    return response.UnknownError();
-  }
-
-  /**
-   * Fallback for any untyped or unexpected error
-   */
   return response.UnknownError();
 }
 

--- a/packages/common/src/utils/errors.ts
+++ b/packages/common/src/utils/errors.ts
@@ -1,119 +1,31 @@
-/** Base error class for all domain-specific errors in the trading model. */
-export abstract class TradingModelError extends Error {
+export const ErrorCodes = {
+  SERVICE_NOT_FOUND: 'SERVICE_NOT_FOUND',
+  SERVICE_UNREACHABLE: 'SERVICE_UNREACHABLE',
+  AUTHENTICATION_ERROR: 'AUTHENTICATION_ERROR',
+  ADDRESS_MANAGER_ERROR: 'ADDRESS_MANAGER_ERROR',
+  MESSAGE_MANAGER_ERROR: 'MESSAGE_MANAGER_ERROR',
+  METADATA_BUILDER_ERROR: 'METADATA_BUILDER_ERROR',
+  TIMEOUT_ERROR: 'TIMEOUT_ERROR',
+  NACK_ERROR: 'NACK_ERROR',
+  DEAD_LETTER_ERROR: 'DEAD_LETTER_ERROR',
+  AGENT_ERROR: 'AGENT_ERROR',
+  CONFIGURATION_ERROR: 'CONFIGURATION_ERROR',
+} as const;
+
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];
+
+/** Single application error class with a discriminant `code` property. */
+export class AppError extends Error {
+  public readonly code: ErrorCode;
   public readonly cause?: unknown;
+  public readonly reason?: string;
 
-  /**
-   * @param message - Human-readable error description.
-   * @param cause - Optional underlying cause of the error.
-   */
-  protected constructor(message: string, cause?: unknown) {
+  constructor(message: string, code: ErrorCode, options?: { cause?: unknown; reason?: string }) {
     super(message);
-    this.name = this.constructor.name;
-    this.cause = cause;
+    this.name = 'AppError';
+    this.code = code;
+    this.cause = options?.cause;
+    this.reason = options?.reason;
     Object.setPrototypeOf(this, new.target.prototype);
-  }
-}
-
-/** Base class for address / service-discovery related errors. */
-export abstract class AddressManagerBaseError extends TradingModelError {
-  protected constructor(message: string, cause?: unknown) {
-    super(message, cause);
-  }
-}
-
-/** Thrown when a requested service cannot be found in the registry. */
-export class ServiceNotFoundError extends AddressManagerBaseError {
-  constructor(message: string, cause?: unknown) {
-    super(message, cause);
-  }
-}
-
-/** Thrown when a service is known but cannot be reached. */
-export class ServiceUnreachableError extends AddressManagerBaseError {
-  constructor(message: string, cause?: unknown) {
-    super(message, cause);
-  }
-}
-
-/** Thrown when authentication with a service or registry fails. */
-export class AuthenticationError extends AddressManagerBaseError {
-  constructor(message: string, cause?: unknown) {
-    super(message, cause);
-  }
-}
-
-/** Generic error for address manager failures. */
-export class AddressManagerError extends AddressManagerBaseError {
-  constructor(message: string, cause?: unknown) {
-    super(message, cause);
-  }
-}
-
-/** Base class for message bus / queue related errors. */
-export abstract class MessageManagerBaseError extends TradingModelError {
-  protected constructor(message: string, cause?: unknown) {
-    super(message, cause);
-  }
-}
-
-/** Generic error for message manager failures. */
-export class MessageManagerError extends MessageManagerBaseError {
-  constructor(message: string, cause?: unknown) {
-    super(message, cause);
-  }
-}
-
-/** Thrown when message metadata construction fails. */
-export class MetadataBuilderError extends MessageManagerBaseError {
-  constructor(message: string, cause?: unknown) {
-    super(message, cause);
-  }
-}
-
-/** Thrown when a message operation exceeds its allowed timeout. */
-export class TimeoutError extends MessageManagerBaseError {
-  constructor(message: string, cause?: unknown) {
-    super(message, cause);
-  }
-}
-
-/** Thrown when a message is negatively acknowledged by the consumer. */
-export class NackError extends MessageManagerBaseError {
-  constructor(
-    public readonly reason?: string,
-    cause?: unknown
-  ) {
-    super(reason ?? 'Message negatively acknowledged', cause);
-  }
-}
-
-/** Thrown when a message is routed to the dead-letter queue. */
-export class DeadLetterError extends MessageManagerBaseError {
-  constructor(
-    public readonly reason?: string,
-    cause?: unknown
-  ) {
-    super(reason ?? 'Message sent to dead letter queue', cause);
-  }
-}
-
-/** Base class for agent / trading algorithm errors. */
-export abstract class AgentBaseError extends TradingModelError {
-  protected constructor(message: string, cause?: unknown) {
-    super(message, cause);
-  }
-}
-
-/** Generic error for agent-level failures. */
-export class AgentError extends AgentBaseError {
-  constructor(message: string, cause?: unknown) {
-    super(message, cause);
-  }
-}
-
-/** Thrown when environment configuration validation fails. */
-export class ConfigurationError extends TradingModelError {
-  constructor(message: string, cause?: unknown) {
-    super(message, cause);
   }
 }

--- a/packages/common/src/validation/env.ts
+++ b/packages/common/src/validation/env.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { ConfigurationError } from '../utils/errors';
+import { AppError, ErrorCodes } from '../utils/errors';
 
 /** Zod schema for base environment variables shared across all services. */
 export const BaseEnvSchema = z.object({
@@ -78,7 +78,9 @@ export function validateEnv<T extends z.ZodType>(schema: T): z.infer<T> {
       }
     }
     console.error('Invalid environment configuration', { errors });
-    throw new ConfigurationError('Environment validation failed', parsed.error);
+    throw new AppError('Environment validation failed', ErrorCodes.CONFIGURATION_ERROR, {
+      cause: parsed.error,
+    });
   }
 
   return parsed.data;

--- a/packages/common/tests/unit/catch-error.spec.ts
+++ b/packages/common/tests/unit/catch-error.spec.ts
@@ -16,22 +16,23 @@ describe('catchSync', () => {
 
   it('should call the wrapped function with req, res, next', async () => {
     const handler = jest.fn();
-    const wrapped = catchSync(handler);
+    const wrapped = catchSync(handler as any);
 
     await wrapped(req, res, next);
 
     expect(handler).toHaveBeenCalledWith(req, res, next);
   });
 
-  it('should reject the promise on synchronous errors', async () => {
+  it('should forward synchronous errors to next', async () => {
     const error = new Error('sync error');
     const handler = () => {
       throw error;
     };
     const wrapped = catchSync(handler as any);
 
-    await expect(wrapped(req as any, res as any, next)).rejects.toThrow(error);
-    expect(next).not.toHaveBeenCalled();
+    await wrapped(req as any, res as any, next);
+
+    expect(next).toHaveBeenCalledWith(error);
   });
 
   it('should catch asynchronous errors and pass to next', async () => {
@@ -39,7 +40,7 @@ describe('catchSync', () => {
     const handler = async () => {
       throw error;
     };
-    const wrapped = catchSync(handler);
+    const wrapped = catchSync(handler as any);
 
     await wrapped(req, res, next);
 
@@ -48,10 +49,27 @@ describe('catchSync', () => {
 
   it('should not call next if handler succeeds', async () => {
     const handler = jest.fn();
-    const wrapped = catchSync(handler);
+    const wrapped = catchSync(handler as any);
 
     await wrapped(req, res, next);
 
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should send response object via res when handler returns ResponseObject', async () => {
+    const mockRes = {
+      status: jest.fn().mockReturnThis(),
+      type: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    };
+    const handler = () => ({ status: 201, data: { id: 'abc' } });
+    const wrapped = catchSync(handler as any);
+
+    await wrapped(req, mockRes as any, next);
+
+    expect(mockRes.status).toHaveBeenCalledWith(201);
+    expect(mockRes.send).toHaveBeenCalledWith({ id: 'abc' });
     expect(next).not.toHaveBeenCalled();
   });
 });

--- a/packages/common/tests/unit/deterministic-stringify.spec.ts
+++ b/packages/common/tests/unit/deterministic-stringify.spec.ts
@@ -56,13 +56,13 @@ describe('deterministicStringify', () => {
 
   it('should match a known deterministic hash input', () => {
     const authContext = {
-      roles: ['Data', 'Financial', 'Scrapper'],
+      roles: ['Data', 'Financial', 'Scraper'],
       subject: 'financial-scrapper-service',
       tenantId: 'instance-1',
     };
     const serialised = deterministicStringify(authContext);
     expect(serialised).toBe(
-      '{"roles":["Data","Financial","Scrapper"],"subject":"financial-scrapper-service","tenantId":"instance-1"}'
+      '{"roles":["Data","Financial","Scraper"],"subject":"financial-scrapper-service","tenantId":"instance-1"}'
     );
   });
 

--- a/packages/common/tests/unit/env.spec.ts
+++ b/packages/common/tests/unit/env.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
 import { validateEnv, BaseEnvSchema, AddressManagerEnvSchema } from '../../src/validation/env';
-import { ConfigurationError } from '../../src/utils/errors';
+import { AppError, ErrorCodes } from '../../src/utils/errors';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -37,7 +37,7 @@ describe('validateEnv', () => {
     delete process.env.TLS_CERT_PATH;
     delete process.env.TLS_CA_PATH;
 
-    expect(() => validateEnv(BaseEnvSchema)).toThrow(ConfigurationError);
+    expect(() => validateEnv(BaseEnvSchema)).toThrow(AppError);
   });
 
   it('should apply default values', () => {
@@ -96,7 +96,7 @@ describe('validateEnv', () => {
     delete process.env.TLS_CERT_PATH;
     delete process.env.TLS_CA_PATH;
 
-    expect(() => validateEnv(BaseEnvSchema)).toThrow(ConfigurationError);
+    expect(() => validateEnv(BaseEnvSchema)).toThrow(AppError);
   });
 
   it('should handle invalid env when treeifyError is not a function', () => {
@@ -109,7 +109,7 @@ describe('validateEnv', () => {
     delete process.env.TLS_CERT_PATH;
     delete process.env.TLS_CA_PATH;
 
-    expect(() => validateEnv(BaseEnvSchema)).toThrow(ConfigurationError);
+    expect(() => validateEnv(BaseEnvSchema)).toThrow(AppError);
 
     zod.z.treeifyError = origTreeifyError;
   });

--- a/packages/common/tests/unit/errors.spec.ts
+++ b/packages/common/tests/unit/errors.spec.ts
@@ -1,181 +1,122 @@
 import { describe, it, expect } from '@jest/globals';
-import {
-  AddressManagerBaseError,
-  ServiceNotFoundError,
-  ServiceUnreachableError,
-  AuthenticationError,
-  AddressManagerError,
-  MessageManagerBaseError,
-  MessageManagerError,
-  MetadataBuilderError,
-  TimeoutError,
-  NackError,
-  DeadLetterError,
-  AgentBaseError,
-  AgentError,
-} from '../../src/utils/errors';
+import { AppError, ErrorCodes } from '../../src/utils/errors';
 
-describe('Error classes', () => {
-  describe('AddressManagerBaseError', () => {
-    it('should be constructable via subclass', () => {
-      const error = new ServiceNotFoundError('test');
-      expect(error).toBeInstanceOf(Error);
-      expect(error).toBeInstanceOf(AddressManagerBaseError);
-      expect(error.name).toBe('ServiceNotFoundError');
-    });
-
-    it('should store cause', () => {
-      const cause = new Error('root');
-      const error = new ServiceNotFoundError('test', cause);
-      expect(error.cause).toBe(cause);
-    });
-
-    it('should store cause when undefined', () => {
-      const error = new ServiceNotFoundError('test');
-      expect(error.cause).toBeUndefined();
-    });
+describe('AppError', () => {
+  it('should be constructable with message and code', () => {
+    const error = new AppError('test', ErrorCodes.SERVICE_NOT_FOUND);
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(AppError);
+    expect(error.message).toBe('test');
+    expect(error.code).toBe('SERVICE_NOT_FOUND');
   });
 
-  describe('ServiceNotFoundError', () => {
-    it('should have correct name and message', () => {
-      const error = new ServiceNotFoundError('Service X not found');
-      expect(error.name).toBe('ServiceNotFoundError');
-      expect(error.message).toBe('Service X not found');
-    });
+  it('should store cause', () => {
+    const cause = new Error('root');
+    const error = new AppError('test', ErrorCodes.SERVICE_NOT_FOUND, { cause });
+    expect(error.cause).toBe(cause);
   });
 
-  describe('ServiceUnreachableError', () => {
-    it('should have correct name', () => {
-      const error = new ServiceUnreachableError('Cannot reach');
-      expect(error.name).toBe('ServiceUnreachableError');
-    });
-
-    it('should be instanceof AddressManagerBaseError', () => {
-      const error = new ServiceUnreachableError('down');
-      expect(error).toBeInstanceOf(AddressManagerBaseError);
-    });
+  it('should have cause undefined when not provided', () => {
+    const error = new AppError('test', ErrorCodes.SERVICE_NOT_FOUND);
+    expect(error.cause).toBeUndefined();
   });
 
-  describe('AuthenticationError', () => {
-    it('should have correct name', () => {
-      const error = new AuthenticationError('Invalid token');
-      expect(error.name).toBe('AuthenticationError');
-    });
+  it('should set constructor name for correct error chain', () => {
+    const error = new AppError('Service X not found', ErrorCodes.SERVICE_NOT_FOUND);
+    expect(error.name).toBe('AppError');
   });
 
-  describe('AddressManagerError', () => {
-    it('should have correct name', () => {
-      const error = new AddressManagerError('Generic error');
-      expect(error.name).toBe('AddressManagerError');
-    });
+  it('should have correct code for SERVICE_NOT_FOUND', () => {
+    const error = new AppError('Service X not found', ErrorCodes.SERVICE_NOT_FOUND);
+    expect(error.code).toBe('SERVICE_NOT_FOUND');
   });
 
-  describe('MessageManagerBaseError', () => {
-    it('should be constructable via subclass', () => {
-      const error = new MessageManagerError('msg');
-      expect(error).toBeInstanceOf(MessageManagerBaseError);
-    });
-
-    it('should store cause', () => {
-      const cause = new Error('root cause');
-      const error = new MessageManagerError('msg', cause);
-      expect(error.cause).toBe(cause);
-    });
+  it('should have correct code for SERVICE_UNREACHABLE', () => {
+    const error = new AppError('Cannot reach', ErrorCodes.SERVICE_UNREACHABLE);
+    expect(error.code).toBe('SERVICE_UNREACHABLE');
   });
 
-  describe('MessageManagerError', () => {
-    it('should have correct name', () => {
-      const error = new MessageManagerError('Failed');
-      expect(error.name).toBe('MessageManagerError');
-    });
+  it('should have correct code for AUTHENTICATION_ERROR', () => {
+    const error = new AppError('Invalid token', ErrorCodes.AUTHENTICATION_ERROR);
+    expect(error.code).toBe('AUTHENTICATION_ERROR');
   });
 
-  describe('MetadataBuilderError', () => {
-    it('should have correct name', () => {
-      const error = new MetadataBuilderError('Missing field');
-      expect(error.name).toBe('MetadataBuilderError');
-    });
-
-    it('should be instanceof MessageManagerBaseError', () => {
-      const error = new MetadataBuilderError('err');
-      expect(error).toBeInstanceOf(MessageManagerBaseError);
-    });
+  it('should have correct code for ADDRESS_MANAGER_ERROR', () => {
+    const error = new AppError('Generic error', ErrorCodes.ADDRESS_MANAGER_ERROR);
+    expect(error.code).toBe('ADDRESS_MANAGER_ERROR');
   });
 
-  describe('TimeoutError', () => {
-    it('should have correct name', () => {
-      const error = new TimeoutError('timed out');
-      expect(error.name).toBe('TimeoutError');
-    });
-
-    it('should be instanceof MessageManagerBaseError', () => {
-      const error = new TimeoutError('timeout');
-      expect(error).toBeInstanceOf(MessageManagerBaseError);
-    });
+  it('should have correct code for MESSAGE_MANAGER_ERROR', () => {
+    const error = new AppError('Failed', ErrorCodes.MESSAGE_MANAGER_ERROR);
+    expect(error.code).toBe('MESSAGE_MANAGER_ERROR');
   });
 
-  describe('NackError', () => {
-    it('should have correct name and reason', () => {
-      const error = new NackError('custom reason');
-      expect(error.name).toBe('NackError');
-      expect(error.reason).toBe('custom reason');
-      expect(error.message).toBe('custom reason');
-    });
-
-    it('should use default message when reason is undefined', () => {
-      const error = new NackError();
-      expect(error.reason).toBeUndefined();
-      expect(error.message).toBe('Message negatively acknowledged');
-    });
-
-    it('should store cause', () => {
-      const cause = new Error('root');
-      const error = new NackError('reason', cause);
-      expect(error.cause).toBe(cause);
-    });
+  it('should have correct code for METADATA_BUILDER_ERROR', () => {
+    const error = new AppError('Missing field', ErrorCodes.METADATA_BUILDER_ERROR);
+    expect(error.code).toBe('METADATA_BUILDER_ERROR');
   });
 
-  describe('DeadLetterError', () => {
-    it('should have correct name and reason', () => {
-      const error = new DeadLetterError('custom reason');
-      expect(error.name).toBe('DeadLetterError');
-      expect(error.reason).toBe('custom reason');
-      expect(error.message).toBe('custom reason');
-    });
-
-    it('should use default message when reason is undefined', () => {
-      const error = new DeadLetterError();
-      expect(error.reason).toBeUndefined();
-      expect(error.message).toBe('Message sent to dead letter queue');
-    });
-
-    it('should store cause', () => {
-      const cause = new Error('root');
-      const error = new DeadLetterError('reason', cause);
-      expect(error.cause).toBe(cause);
-    });
+  it('should have correct code for TIMEOUT_ERROR', () => {
+    const error = new AppError('timed out', ErrorCodes.TIMEOUT_ERROR);
+    expect(error.code).toBe('TIMEOUT_ERROR');
   });
 
-  describe('AgentBaseError', () => {
-    it('should be constructable via subclass', () => {
-      const error = new AgentError('agent error');
-      expect(error).toBeInstanceOf(Error);
-      expect(error).toBeInstanceOf(AgentBaseError);
-      expect(error.name).toBe('AgentError');
-    });
-
-    it('should store cause', () => {
-      const cause = new Error('root');
-      const error = new AgentError('msg', cause);
-      expect(error.cause).toBe(cause);
-    });
+  it('should support reason via options', () => {
+    const error = new AppError('custom reason', ErrorCodes.NACK_ERROR, { reason: 'custom reason' });
+    expect(error.code).toBe('NACK_ERROR');
+    expect(error.reason).toBe('custom reason');
+    expect(error.message).toBe('custom reason');
   });
 
-  describe('AgentError', () => {
-    it('should have correct name', () => {
-      const error = new AgentError('ML failure');
-      expect(error.name).toBe('AgentError');
-      expect(error.message).toBe('ML failure');
+  it('should support NACK_ERROR without reason', () => {
+    const error = new AppError('Message negatively acknowledged', ErrorCodes.NACK_ERROR);
+    expect(error.reason).toBeUndefined();
+    expect(error.message).toBe('Message negatively acknowledged');
+  });
+
+  it('should store cause with NACK_ERROR', () => {
+    const cause = new Error('root');
+    const error = new AppError('reason', ErrorCodes.NACK_ERROR, { reason: 'reason', cause });
+    expect(error.cause).toBe(cause);
+    expect(error.reason).toBe('reason');
+  });
+
+  it('should support DEAD_LETTER_ERROR with reason', () => {
+    const error = new AppError('custom reason', ErrorCodes.DEAD_LETTER_ERROR, {
+      reason: 'custom reason',
     });
+    expect(error.code).toBe('DEAD_LETTER_ERROR');
+    expect(error.reason).toBe('custom reason');
+    expect(error.message).toBe('custom reason');
+  });
+
+  it('should support DEAD_LETTER_ERROR without reason', () => {
+    const error = new AppError('Message sent to dead letter queue', ErrorCodes.DEAD_LETTER_ERROR);
+    expect(error.reason).toBeUndefined();
+    expect(error.message).toBe('Message sent to dead letter queue');
+  });
+
+  it('should store cause with DEAD_LETTER_ERROR', () => {
+    const cause = new Error('root');
+    const error = new AppError('reason', ErrorCodes.DEAD_LETTER_ERROR, { reason: 'reason', cause });
+    expect(error.cause).toBe(cause);
+    expect(error.reason).toBe('reason');
+  });
+
+  it('should have correct code for AGENT_ERROR', () => {
+    const error = new AppError('agent error', ErrorCodes.AGENT_ERROR);
+    expect(error.code).toBe('AGENT_ERROR');
+  });
+
+  it('should store cause with AGENT_ERROR', () => {
+    const cause = new Error('root');
+    const error = new AppError('msg', ErrorCodes.AGENT_ERROR, { cause });
+    expect(error.cause).toBe(cause);
+  });
+
+  it('should have correct message and code for AGENT_ERROR', () => {
+    const error = new AppError('ML failure', ErrorCodes.AGENT_ERROR);
+    expect(error.code).toBe('AGENT_ERROR');
+    expect(error.message).toBe('ML failure');
   });
 });

--- a/packages/common/tests/unit/response-exception.spec.ts
+++ b/packages/common/tests/unit/response-exception.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from '@jest/globals';
 import {
   ClassResponseExceptions,
   ResponseException,
+  sendResponse,
   HTTP_CODE,
   ResponseCodes,
 } from '../../src/middleware/response-exception';
@@ -149,6 +150,18 @@ describe('ClassResponseExceptions', () => {
     it('should default to empty string', () => {
       const result = ResponseException().Success();
       expect(result.data).toBe('');
+    });
+  });
+
+  describe('sendResponse', () => {
+    it('should return ResponseObject with given data and status', () => {
+      const result = sendResponse({ id: 1 }, 201);
+      expect(result).toEqual({ status: 201, data: { id: 1 } });
+    });
+
+    it('should return ResponseObject with null data', () => {
+      const result = sendResponse(null, 204);
+      expect(result).toEqual({ status: 204, data: null });
     });
   });
 });

--- a/packages/common/tests/unit/response-protocol.spec.ts
+++ b/packages/common/tests/unit/response-protocol.spec.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { ResponseProtocole } from '../../src/middleware/response-protocol';
-import {
-  ServiceNotFoundError,
-  ServiceUnreachableError,
-  AuthenticationError,
-  AddressManagerError,
-} from '../../src/utils/errors';
+import { AppError, ErrorCodes } from '../../src/utils/errors';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -25,32 +20,38 @@ describe('ResponseProtocole', () => {
     next = jest.fn();
   });
 
-  it('should map ServiceNotFoundError to 404', () => {
-    const err = new ServiceNotFoundError('Service not found');
+  it('should map SERVICE_NOT_FOUND to 404', () => {
+    const err = new AppError('Service not found', ErrorCodes.SERVICE_NOT_FOUND);
     ResponseProtocole(err, req, res, next);
     expect(res.status).toHaveBeenCalledWith(404);
   });
 
-  it('should map ServiceUnreachableError to 410', () => {
-    const err = new ServiceUnreachableError('Service down');
+  it('should map SERVICE_UNREACHABLE to 410', () => {
+    const err = new AppError('Service down', ErrorCodes.SERVICE_UNREACHABLE);
     ResponseProtocole(err, req, res, next);
     expect(res.status).toHaveBeenCalledWith(410);
   });
 
-  it('should map AuthenticationError to 498', () => {
-    const err = new AuthenticationError('Invalid token');
+  it('should map AUTHENTICATION_ERROR to 498', () => {
+    const err = new AppError('Invalid token', ErrorCodes.AUTHENTICATION_ERROR);
     ResponseProtocole(err, req, res, next);
     expect(res.status).toHaveBeenCalledWith(498);
   });
 
-  it('should map AddressManagerError to 500', () => {
-    const err = new AddressManagerError('Generic error');
+  it('should map ADDRESS_MANAGER_ERROR to 500', () => {
+    const err = new AppError('Generic error', ErrorCodes.ADDRESS_MANAGER_ERROR);
     ResponseProtocole(err, req, res, next);
     expect(res.status).toHaveBeenCalledWith(500);
   });
 
   it('should map unknown errors to 500', () => {
     const err = new Error('Unknown');
+    ResponseProtocole(err, req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it('should map AppError with unknown code to 500', () => {
+    const err = new AppError('Config error', ErrorCodes.CONFIGURATION_ERROR);
     ResponseProtocole(err, req, res, next);
     expect(res.status).toHaveBeenCalledWith(500);
   });

--- a/services/discovery-server/src/controllers/heartbeat.controller.ts
+++ b/services/discovery-server/src/controllers/heartbeat.controller.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from 'express';
 
 import { catchSync } from '@trading-model/common/middleware/catch-error';
-import { ResponseException } from '@trading-model/common/middleware/response-exception';
+import { sendResponse } from '@trading-model/common/middleware/response-exception';
 import { isNonEmptyString, isObject } from '@trading-model/common/validation/primitives';
 
 import { validateInstanceToken } from './helpers';
@@ -16,40 +16,40 @@ export function createHeartbeatController(registry: ServiceRegistry): HeartbeatC
   /** Extend a service instance's lease by recording a heartbeat. */
   const heartbeat: RequestHandler = catchSync(async req => {
     if (!isObject(req.body)) {
-      throw ResponseException('Invalid request body').BadRequest();
+      return sendResponse({ error: 'Invalid request body' }, 400);
     }
 
     const { serviceName, instanceId } = req.body as Record<string, unknown>;
 
     if (!isNonEmptyString(serviceName))
-      throw ResponseException('serviceName is required').BadRequest();
+      return sendResponse({ error: 'serviceName is required' }, 400);
 
     if (!isNonEmptyString(instanceId))
-      throw ResponseException('instanceId is required').BadRequest();
+      return sendResponse({ error: 'instanceId is required' }, 400);
 
     validateInstanceToken(registry, req.headers['x-instance-token'], instanceId);
 
     const ttl = registry.updateHeartbeat(serviceName, instanceId);
 
-    if (!ttl) throw ResponseException('Instance not found').NotFound();
+    if (!ttl) return sendResponse({ error: 'Instance not found' }, 404);
 
-    throw ResponseException({ ttl }).Success();
+    return sendResponse({ ttl }, 200);
   });
 
   /** Issue a new authentication token for a service instance, invalidating the previous one. */
   const rotateToken: RequestHandler = catchSync(async req => {
-    if (!isObject(req.body)) throw ResponseException('Invalid request body').BadRequest();
+    if (!isObject(req.body)) return sendResponse({ error: 'Invalid request body' }, 400);
 
     const { instanceId } = req.body as Record<string, unknown>;
 
     if (!isNonEmptyString(instanceId))
-      throw ResponseException('instanceId is required').BadRequest();
+      return sendResponse({ error: 'instanceId is required' }, 400);
 
     validateInstanceToken(registry, req.headers['x-instance-token'], instanceId);
 
     const newToken = registry.updateToken(instanceId);
 
-    throw ResponseException({ token: newToken }).Success();
+    return sendResponse({ token: newToken }, 200);
   });
 
   return { heartbeat, rotateToken };

--- a/services/discovery-server/src/controllers/register.controller.ts
+++ b/services/discovery-server/src/controllers/register.controller.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from 'express';
 
 import { catchSync } from '@trading-model/common/middleware/catch-error';
-import { ResponseException } from '@trading-model/common/middleware/response-exception';
+import { sendResponse } from '@trading-model/common/middleware/response-exception';
 import {
   isNonEmptyString,
   isObject,
@@ -22,24 +22,24 @@ interface RegisterController {
 export function createRegisterController(registry: ServiceRegistry): RegisterController {
   /** Register a new service instance or update an existing one in the registry. */
   const register: RequestHandler = catchSync(async req => {
-    if (!isObject(req.body)) throw ResponseException('Invalid request body').BadRequest();
+    if (!isObject(req.body)) return sendResponse({ error: 'Invalid request body' }, 400);
 
     const { serviceName, instanceId, ip, port } = req.body as Record<string, unknown>;
 
     if (!isNonEmptyString(serviceName))
-      throw ResponseException('serviceName is required').BadRequest();
+      return sendResponse({ error: 'serviceName is required' }, 400);
 
     if (!registry.verifyInstanceName(serviceName))
-      throw ResponseException('Invalid service name').BadRequest();
+      return sendResponse({ error: 'Invalid service name' }, 400);
 
-    if (!isValidIP(ip)) throw ResponseException('Invalid IP address').BadRequest();
+    if (!isValidIP(ip)) return sendResponse({ error: 'Invalid IP address' }, 400);
 
-    if (!isValidPort(port)) throw ResponseException('Invalid port').BadRequest();
+    if (!isValidPort(port)) return sendResponse({ error: 'Invalid port' }, 400);
 
     let safeInstanceId: string;
 
     if (instanceId !== undefined) {
-      if (!isNonEmptyString(instanceId)) throw ResponseException('Invalid instanceId').BadRequest();
+      if (!isNonEmptyString(instanceId)) return sendResponse({ error: 'Invalid instanceId' }, 400);
       safeInstanceId = instanceId;
     } else {
       safeInstanceId = registry.generateInstanceId(serviceName, ip, port);
@@ -58,12 +58,12 @@ export function createRegisterController(registry: ServiceRegistry): RegisterCon
 
     const registered = registry.registerInstance(instance);
 
-    throw ResponseException(registered).OK();
+    return sendResponse(registered, 201);
   });
 
   /** Return the list of all registered service names. */
   const listServices: RequestHandler = catchSync(async () => {
-    throw ResponseException(registry.listServiceNames()).Success();
+    return sendResponse(registry.listServiceNames(), 200);
   });
 
   /** Return all registered instances for a given service name. */
@@ -71,12 +71,12 @@ export function createRegisterController(registry: ServiceRegistry): RegisterCon
     const { serviceName } = req.params;
 
     if (!isNonEmptyString(serviceName))
-      throw ResponseException('serviceName is required').BadRequest();
+      return sendResponse({ error: 'serviceName is required' }, 400);
 
     if (!registry.verifyInstanceName(serviceName))
-      throw ResponseException('Unknown service').NotFound();
+      return sendResponse({ error: 'Unknown service' }, 404);
 
-    throw ResponseException(registry.getInstances(serviceName)).Success();
+    return sendResponse(registry.getInstances(serviceName), 200);
   });
 
   /** Return metadata for a specific service instance by service name and instance ID. */
@@ -84,13 +84,13 @@ export function createRegisterController(registry: ServiceRegistry): RegisterCon
     const { serviceName, instanceId } = req.params;
 
     if (!isNonEmptyString(serviceName) || !isNonEmptyString(instanceId))
-      throw ResponseException('Invalid route parameters').BadRequest();
+      return sendResponse({ error: 'Invalid route parameters' }, 400);
 
     const instance = registry.getInstance(serviceName, instanceId);
 
-    if (!instance) throw ResponseException('Instance not found').NotFound();
+    if (!instance) return sendResponse({ error: 'Instance not found' }, 404);
 
-    throw ResponseException(instance).Success();
+    return sendResponse(instance, 200);
   });
 
   return { register, listServices, getServiceInstances, getInstance };

--- a/services/discovery-server/tests/unit/controllers/heartbeat.controller.spec.ts
+++ b/services/discovery-server/tests/unit/controllers/heartbeat.controller.spec.ts
@@ -6,6 +6,7 @@ jest.mock('@trading-model/common/middleware/catch-error', () => ({
 }));
 
 jest.mock('@trading-model/common/middleware/response-exception', () => ({
+  sendResponse: (data: any, status: number) => ({ status, data }),
   ResponseException: jest.fn((body: any) => ({
     BadRequest: () => ({ type: 'BadRequest' as const, error: body }),
     Unauthorized: () => ({ type: 'Unauthorized' as const, error: body }),
@@ -35,25 +36,25 @@ describe('Heartbeat.controller', () => {
   describe('heartbeat', () => {
     it('should reject non-object body with BadRequest', async () => {
       const req = createReq({ body: 'invalid' });
-      await expect(controller.heartbeat(req, createRes(), jest.fn())).rejects.toMatchObject({
-        type: 'BadRequest',
-        error: 'Invalid request body',
+      await expect(controller.heartbeat(req, createRes(), jest.fn())).resolves.toMatchObject({
+        status: 400,
+        data: { error: 'Invalid request body' },
       });
     });
 
     it('should reject missing serviceName with BadRequest', async () => {
       const req = createReq({ body: { instanceId: 'i1' } });
-      await expect(controller.heartbeat(req, createRes(), jest.fn())).rejects.toMatchObject({
-        type: 'BadRequest',
-        error: 'serviceName is required',
+      await expect(controller.heartbeat(req, createRes(), jest.fn())).resolves.toMatchObject({
+        status: 400,
+        data: { error: 'serviceName is required' },
       });
     });
 
     it('should reject missing instanceId with BadRequest', async () => {
       const req = createReq({ body: { serviceName: 'svc' } });
-      await expect(controller.heartbeat(req, createRes(), jest.fn())).rejects.toMatchObject({
-        type: 'BadRequest',
-        error: 'instanceId is required',
+      await expect(controller.heartbeat(req, createRes(), jest.fn())).resolves.toMatchObject({
+        status: 400,
+        data: { error: 'instanceId is required' },
       });
     });
 
@@ -91,9 +92,9 @@ describe('Heartbeat.controller', () => {
         body: { serviceName: 'financial-scrapper-service', instanceId: 'i1' },
         headers: { 'x-instance-token': registered.token },
       });
-      await expect(controller.heartbeat(req, createRes(), jest.fn())).rejects.toMatchObject({
-        type: 'Success',
-        ttl: 30000,
+      await expect(controller.heartbeat(req, createRes(), jest.fn())).resolves.toMatchObject({
+        status: 200,
+        data: { ttl: 30000 },
       });
     });
 
@@ -112,9 +113,9 @@ describe('Heartbeat.controller', () => {
         body: { serviceName: 'other-service', instanceId: 'i1' },
         headers: { 'x-instance-token': registered.token },
       });
-      await expect(controller.heartbeat(req, createRes(), jest.fn())).rejects.toMatchObject({
-        type: 'NotFound',
-        error: 'Instance not found',
+      await expect(controller.heartbeat(req, createRes(), jest.fn())).resolves.toMatchObject({
+        status: 404,
+        data: { error: 'Instance not found' },
       });
     });
   });
@@ -122,17 +123,17 @@ describe('Heartbeat.controller', () => {
   describe('rotateToken', () => {
     it('should reject non-object body with BadRequest', async () => {
       const req = createReq({ body: null });
-      await expect(controller.rotateToken(req, createRes(), jest.fn())).rejects.toMatchObject({
-        type: 'BadRequest',
-        error: 'Invalid request body',
+      await expect(controller.rotateToken(req, createRes(), jest.fn())).resolves.toMatchObject({
+        status: 400,
+        data: { error: 'Invalid request body' },
       });
     });
 
     it('should reject missing instanceId with BadRequest', async () => {
       const req = createReq({ body: {} });
-      await expect(controller.rotateToken(req, createRes(), jest.fn())).rejects.toMatchObject({
-        type: 'BadRequest',
-        error: 'instanceId is required',
+      await expect(controller.rotateToken(req, createRes(), jest.fn())).resolves.toMatchObject({
+        status: 400,
+        data: { error: 'instanceId is required' },
       });
     });
 
@@ -170,9 +171,9 @@ describe('Heartbeat.controller', () => {
         body: { instanceId: 'i1' },
         headers: { 'x-instance-token': registered.token },
       });
-      await expect(controller.rotateToken(req, createRes(), jest.fn())).rejects.toMatchObject({
-        type: 'Success',
-        token: expect.any(String),
+      await expect(controller.rotateToken(req, createRes(), jest.fn())).resolves.toMatchObject({
+        status: 200,
+        data: { token: expect.any(String) },
       });
     });
   });

--- a/services/discovery-server/tests/unit/controllers/register.controller.spec.ts
+++ b/services/discovery-server/tests/unit/controllers/register.controller.spec.ts
@@ -7,13 +7,14 @@ jest.mock('@trading-model/common/middleware/catch-error', () => ({
 }));
 
 jest.mock('@trading-model/common/middleware/response-exception', () => {
+  const sendResponse = (data: any, status: number) => ({ status, data });
   const ResponseException = jest.fn((body: any) => ({
     BadRequest: () => ({ type: 'BadRequest' as const, error: body }),
     NotFound: () => ({ type: 'NotFound' as const, error: body }),
     OK: () => ({ type: 'OK' as const, ...body }),
     Success: () => ({ type: 'Success' as const, ...body }),
   }));
-  return { ResponseException };
+  return { sendResponse, ResponseException };
 });
 
 jest.mock('@trading-model/common/validation/primitives', () => ({
@@ -40,7 +41,7 @@ describe('Register.controller', () => {
     it('should reject null body with BadRequest', async () => {
       await expect(
         controller.register(createReq({ body: null }), createRes(), createNext)
-      ).rejects.toMatchObject({ type: 'BadRequest', error: 'Invalid request body' });
+      ).resolves.toMatchObject({ status: 400, data: { error: 'Invalid request body' } });
     });
 
     it('should reject missing serviceName with BadRequest', async () => {
@@ -50,14 +51,14 @@ describe('Register.controller', () => {
           createRes(),
           createNext
         )
-      ).rejects.toMatchObject({ type: 'BadRequest', error: 'serviceName is required' });
+      ).resolves.toMatchObject({ status: 400, data: { error: 'serviceName is required' } });
     });
 
     it('should reject invalid service name with BadRequest', async () => {
       const invalidPayload = { ...validRegisterPayload, serviceName: 'unknown-service' };
       await expect(
         controller.register(createReq({ body: invalidPayload }), createRes(), createNext)
-      ).rejects.toMatchObject({ type: 'BadRequest', error: 'Invalid service name' });
+      ).resolves.toMatchObject({ status: 400, data: { error: 'Invalid service name' } });
     });
 
     it('should reject invalid IP with BadRequest', async () => {
@@ -67,7 +68,7 @@ describe('Register.controller', () => {
           createRes(),
           createNext
         )
-      ).rejects.toMatchObject({ type: 'BadRequest', error: 'Invalid IP address' });
+      ).resolves.toMatchObject({ status: 400, data: { error: 'Invalid IP address' } });
     });
 
     it('should reject invalid port with BadRequest', async () => {
@@ -77,15 +78,15 @@ describe('Register.controller', () => {
           createRes(),
           createNext
         )
-      ).rejects.toMatchObject({ type: 'BadRequest', error: 'Invalid port' });
+      ).resolves.toMatchObject({ status: 400, data: { error: 'Invalid port' } });
     });
 
     it('should register a new instance and return OK with generated instanceId', async () => {
       await expect(
         controller.register(createReq({ body: validRegisterPayload }), createRes(), createNext)
-      ).rejects.toMatchObject({
-        type: 'OK',
-        serviceName: validRegisterPayload.serviceName,
+      ).resolves.toMatchObject({
+        status: 201,
+        data: { serviceName: validRegisterPayload.serviceName },
       });
     });
 
@@ -93,9 +94,9 @@ describe('Register.controller', () => {
       const body = { ...validRegisterPayload, instanceId: 'custom-id' };
       await expect(
         controller.register(createReq({ body }), createRes(), createNext)
-      ).rejects.toMatchObject({
-        type: 'OK',
-        instanceId: 'custom-id',
+      ).resolves.toMatchObject({
+        status: 201,
+        data: { instanceId: 'custom-id' },
       });
     });
 
@@ -106,7 +107,7 @@ describe('Register.controller', () => {
           createRes(),
           createNext
         )
-      ).rejects.toMatchObject({ type: 'BadRequest', error: 'Invalid instanceId' });
+      ).resolves.toMatchObject({ status: 400, data: { error: 'Invalid instanceId' } });
     });
   });
 
@@ -114,7 +115,7 @@ describe('Register.controller', () => {
     it('should return list of service names', async () => {
       await expect(
         controller.listServices(createReq(), createRes(), createNext)
-      ).rejects.toMatchObject({ type: 'Success' });
+      ).resolves.toMatchObject({ status: 200 });
     });
 
     it('should return registered service names', async () => {
@@ -131,7 +132,7 @@ describe('Register.controller', () => {
 
       await expect(
         controller.listServices(createReq(), createRes(), createNext)
-      ).rejects.toMatchObject({ type: 'Success' });
+      ).resolves.toMatchObject({ status: 200 });
     });
   });
 
@@ -139,7 +140,7 @@ describe('Register.controller', () => {
     it('should reject missing serviceName with BadRequest', async () => {
       await expect(
         controller.getServiceInstances(createReq({ params: {} }), createRes(), createNext)
-      ).rejects.toMatchObject({ type: 'BadRequest' });
+      ).resolves.toMatchObject({ status: 400 });
     });
 
     it('should reject unknown service name with NotFound', async () => {
@@ -149,7 +150,7 @@ describe('Register.controller', () => {
           createRes(),
           createNext
         )
-      ).rejects.toMatchObject({ type: 'NotFound', error: 'Unknown service' });
+      ).resolves.toMatchObject({ status: 404, data: { error: 'Unknown service' } });
     });
 
     it('should return instances for known service', async () => {
@@ -170,7 +171,7 @@ describe('Register.controller', () => {
           createRes(),
           createNext
         )
-      ).rejects.toMatchObject({ type: 'Success' });
+      ).resolves.toMatchObject({ status: 200 });
     });
   });
 
@@ -182,7 +183,7 @@ describe('Register.controller', () => {
           createRes(),
           createNext
         )
-      ).rejects.toMatchObject({ type: 'BadRequest' });
+      ).resolves.toMatchObject({ status: 400 });
     });
 
     it('should reject unknown instance with NotFound', async () => {
@@ -192,7 +193,7 @@ describe('Register.controller', () => {
           createRes(),
           createNext
         )
-      ).rejects.toMatchObject({ type: 'NotFound' });
+      ).resolves.toMatchObject({ status: 404 });
     });
 
     it('should return instance when found', async () => {
@@ -215,7 +216,7 @@ describe('Register.controller', () => {
           createRes(),
           createNext
         )
-      ).rejects.toMatchObject({ type: 'Success' });
+      ).resolves.toMatchObject({ status: 200 });
     });
   });
 });

--- a/services/financial-scraper/ARCHITECTURE.md
+++ b/services/financial-scraper/ARCHITECTURE.md
@@ -71,7 +71,7 @@ const response = await binance.get(url, { weight: 5 });
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `endpoints.ts`      | Pure functions that construct Binance REST API URLs for 9 endpoints                                                                                              |
 | `weights.ts`        | Pure functions that compute Binance API weight costs for each endpoint                                                                                           |
-| `binance.client.ts` | 9 async functions (`getOrderBook`, `getRecentTrades`, `CandlestickData`, etc.) each calling the Axios instance with the correct weight                           |
+| `binance.client.ts` | 9 async functions (`getOrderBook`, `getRecentTrades`, `getCandlestickData`, etc.) each calling the Axios instance with the correct weight                        |
 | `normalizer.ts`     | `BinanceNormalizer` class (static methods) converting raw API shapes to internal entity types (`OrderBookEntity`, `TradeEntity`, `CandleEntity`, `TickerEntity`) |
 
 ### 3. Worker & Cron (`src/job/`)

--- a/services/financial-scraper/src/clients/binance/binance.client.ts
+++ b/services/financial-scraper/src/clients/binance/binance.client.ts
@@ -72,7 +72,7 @@ export async function getHistoricalTrades(
  * @param startTime {number} - timestamp in ms to start from (inclusive)
  * @returns {Promise<BinanceCandlestickDataResponse>}
  */
-export async function CandlestickData(
+export async function getCandlestickData(
   symbol: string,
   limit = 500,
   interval:

--- a/services/financial-scraper/src/clients/http/controller.ts
+++ b/services/financial-scraper/src/clients/http/controller.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 
 import { catchSync } from '@trading-model/common/middleware/catch-error';
-import { ResponseException } from '@trading-model/common/middleware/response-exception';
+import { sendResponse } from '@trading-model/common/middleware/response-exception';
 
 import { selectCandlesBy } from '../../infra/market-data/schema/candles-schema';
 import { selectOrderBookBy } from '../../infra/market-data/schema/order-book.schema';
@@ -27,13 +27,13 @@ const orderBookTimestampSchema = z.object({
 function createController<T>(schema: z.ZodSchema<T>, fetcher: (params: T) => Promise<unknown>) {
   return catchSync(async req => {
     const parsed = schema.safeParse(req.params);
-    if (!parsed.success) throw ResponseException(parsed.error.message).BadRequest();
+    if (!parsed.success) return sendResponse({ error: parsed.error.message }, 400);
 
     try {
-      throw ResponseException(JSON.stringify(await fetcher(parsed.data))).Success();
+      return sendResponse(JSON.stringify(await fetcher(parsed.data)), 200);
     } catch (e) {
       if (e instanceof Error && e.message.includes('No result returned'))
-        throw ResponseException('No data found').NotFound();
+        return sendResponse({ error: 'No data found' }, 404);
       throw e;
     }
   });

--- a/services/financial-scraper/src/job/worker/binance.worker.ts
+++ b/services/financial-scraper/src/job/worker/binance.worker.ts
@@ -14,6 +14,8 @@
 
 import { createHash } from 'node:crypto';
 
+import { v4 as uuidv4 } from 'uuid';
+
 import { helper } from '@trading-model/broker-message';
 import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
 import { EnumEventMessage } from '@trading-model/common/config/event.types';
@@ -61,7 +63,6 @@ export class BinanceWorker {
    *
    */
   public async run(): Promise<BinanceWorkerResult> {
-    const { v4: uuidv4 } = await import('uuid');
     const builderMetadata = new helper.MetadataBuilder();
 
     const {

--- a/services/financial-scraper/src/job/worker/binance.worker.ts
+++ b/services/financial-scraper/src/job/worker/binance.worker.ts
@@ -14,8 +14,6 @@
 
 import { createHash } from 'node:crypto';
 
-import { v4 as uuidv4 } from 'uuid';
-
 import { helper } from '@trading-model/broker-message';
 import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
 import { EnumEventMessage } from '@trading-model/common/config/event.types';
@@ -63,6 +61,7 @@ export class BinanceWorker {
    *
    */
   public async run(): Promise<BinanceWorkerResult> {
+    const { v4: uuidv4 } = await import('uuid');
     const builderMetadata = new helper.MetadataBuilder();
 
     const {

--- a/services/financial-scraper/src/job/worker/binance.worker.ts
+++ b/services/financial-scraper/src/job/worker/binance.worker.ts
@@ -22,7 +22,7 @@ import { deterministicStringify } from '@trading-model/common/utils/deterministi
 
 import {
   getOrderBook,
-  CandlestickData,
+  getCandlestickData,
   getRecentTrades,
   getOrderBookTicker,
   get24hrTickerStats,
@@ -61,8 +61,7 @@ export class BinanceWorker {
    *
    */
   public async run(): Promise<BinanceWorkerResult> {
-    const { v4 } = await import('uuid');
-    const uuid = v4;
+    const { v4: uuidv4 } = await import('uuid');
     const builderMetadata = new helper.MetadataBuilder();
 
     const {
@@ -77,7 +76,7 @@ export class BinanceWorker {
       await Promise.all([
         getOrderBook(symbol, orderBookLimit),
         getRecentTrades(symbol, tradeLimit),
-        CandlestickData(symbol, candleLimit, interval),
+        getCandlestickData(symbol, candleLimit, interval),
         get24hrTickerStats([symbol]),
         getSymbolPriceTicker([symbol]),
         getOrderBookTicker([symbol]),
@@ -94,7 +93,7 @@ export class BinanceWorker {
     };
 
     const authContext = {
-      roles: ['Data', 'Financial', 'Scrapper'],
+      roles: ['Data', 'Financial', 'Scraper'],
       subject: env.SERVICE_NAME,
       tenantId: env.INSTANCE_ID,
     };
@@ -106,7 +105,7 @@ export class BinanceWorker {
     builderMetadata
       .setDelivery({
         mode: DeliveryMode.AT_LEAST_ONCE,
-        deduplicationId: uuid(),
+        deduplicationId: uuidv4(),
       })
       .setEventType('FetchCandlestick')
       .setTopic(EnumEventMessage.fetchCandlestickSeries)
@@ -115,8 +114,8 @@ export class BinanceWorker {
         signature,
       })
       .setIds({
-        causationId: uuid(),
-        correlationId: uuid(),
+        causationId: uuidv4(),
+        correlationId: uuidv4(),
       })
       .setPublisher({
         instanceId: env.INSTANCE_ID,

--- a/services/financial-scraper/tests/unit/clients/binance/binance.client.spec.ts
+++ b/services/financial-scraper/tests/unit/clients/binance/binance.client.spec.ts
@@ -41,7 +41,7 @@ import {
   getOrderBook,
   getRecentTrades,
   getHistoricalTrades,
-  CandlestickData,
+  getCandlestickData,
   getCompressedAggregateTrades,
   get24hrTickerStats,
   getTradingDayTicker,
@@ -87,13 +87,13 @@ describe('BinanceClient', () => {
     expect(mockGet).toHaveBeenCalledWith('/api/v3/historicalTrades', { weight: 25 } as never);
   });
 
-  it('CandlestickData should call candlesticks endpoint with weight', async () => {
-    await CandlestickData('BTCUSDT', 100, '1m', 1620000000000);
+  it('getCandlestickData should call candlesticks endpoint with weight', async () => {
+    await getCandlestickData('BTCUSDT', 100, '1m', 1620000000000);
     expect(mockGet).toHaveBeenCalledWith('/api/v3/klines', { weight: 2 } as never);
   });
 
-  it('CandlestickData should use default limit', async () => {
-    await CandlestickData('BTCUSDT', undefined, '1m', 1620000000000);
+  it('getCandlestickData should use default limit', async () => {
+    await getCandlestickData('BTCUSDT', undefined, '1m', 1620000000000);
     expect(mockGet).toHaveBeenCalledWith('/api/v3/klines', { weight: 2 } as never);
   });
 

--- a/services/financial-scraper/tests/unit/clients/http/controller.spec.ts
+++ b/services/financial-scraper/tests/unit/clients/http/controller.spec.ts
@@ -5,6 +5,7 @@ jest.mock('@trading-model/common/middleware/catch-error', () => ({
 }));
 
 jest.mock('@trading-model/common/middleware/response-exception', () => ({
+  sendResponse: (data: any, status: number) => ({ status, data }),
   ResponseException: (reason: string) => ({
     BadRequest: () => {
       throw { status: 400, data: reason };
@@ -79,15 +80,6 @@ import {
   GetCandlesBySourceController,
 } from '../../../../src/clients/http/controller';
 
-const expectRejects = async (fn: Function): Promise<any> => {
-  try {
-    await fn();
-    return { threw: false };
-  } catch (e: any) {
-    return { threw: true, value: e };
-  }
-};
-
 describe('HTTP Controllers', () => {
   const mockReq = (params: Record<string, any>) => ({ params }) as any;
   const mockRes = {} as any;
@@ -105,69 +97,69 @@ describe('HTTP Controllers', () => {
     });
 
     it('GetTradeBySymbolController should call selectTradesBy.symbol with valid symbol', async () => {
-      const result = await expectRejects(() =>
-        GetTradeBySymbolController(mockReq({ symbol: 'BTCUSDT' }), mockRes, mockNext)
+      const result = await GetTradeBySymbolController(
+        mockReq({ symbol: 'BTCUSDT' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
+      expect(result).toMatchObject({ status: 200 });
       expect(mockSelectTradesBy.symbol).toHaveBeenCalledWith('BTCUSDT');
     });
 
     it('GetTradeBySymbolController should throw BadRequest with missing symbol', async () => {
-      const result = await expectRejects(() =>
-        GetTradeBySymbolController(mockReq({}), mockRes, mockNext)
-      );
-      expect(result.threw).toBe(true);
-      expect(result.value).toMatchObject({ status: 400 });
+      const result = await GetTradeBySymbolController(mockReq({}), mockRes, mockNext);
+      expect(result).toMatchObject({ status: 400 });
     });
 
     it('GetTradeByTimestampController should call selectTradesBy.timestamp with valid date', async () => {
-      const result = await expectRejects(() =>
-        GetTradeByTimestampController(mockReq({ timestamp: '2024-01-01' }), mockRes, mockNext)
+      const result = await GetTradeByTimestampController(
+        mockReq({ timestamp: '2024-01-01' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
+      expect(result).toMatchObject({ status: 200 });
       expect(mockSelectTradesBy.timestamp).toHaveBeenCalled();
     });
 
     it('GetTradeByTimestampController should throw BadRequest with invalid timestamp', async () => {
-      const result = await expectRejects(() =>
-        GetTradeByTimestampController(mockReq({ timestamp: '' }), mockRes, mockNext)
+      const result = await GetTradeByTimestampController(
+        mockReq({ timestamp: '' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
-      expect(result.value).toMatchObject({ status: 400 });
+      expect(result).toMatchObject({ status: 400 });
     });
 
     it('GetTradeBySourceController should call selectTradesBy.source with valid source', async () => {
-      const result = await expectRejects(() =>
-        GetTradeBySourceController(mockReq({ source: 'binance' }), mockRes, mockNext)
+      const result = await GetTradeBySourceController(
+        mockReq({ source: 'binance' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
+      expect(result).toMatchObject({ status: 200 });
       expect(mockSelectTradesBy.source).toHaveBeenCalledWith('binance');
     });
 
     it('GetTradeBySourceController should throw BadRequest with missing source', async () => {
-      const result = await expectRejects(() =>
-        GetTradeBySourceController(mockReq({}), mockRes, mockNext)
-      );
-      expect(result.threw).toBe(true);
-      expect(result.value).toMatchObject({ status: 400 });
+      const result = await GetTradeBySourceController(mockReq({}), mockRes, mockNext);
+      expect(result).toMatchObject({ status: 400 });
     });
 
     it('should throw NotFound when fetcher returns no result', async () => {
       mockSelectTradesBy.symbol.mockRejectedValue(new Error('No result returned'));
-      const result = await expectRejects(() =>
-        GetTradeBySymbolController(mockReq({ symbol: 'UNKNOWN' }), mockRes, mockNext)
+      const result = await GetTradeBySymbolController(
+        mockReq({ symbol: 'UNKNOWN' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
-      expect(result.value).toMatchObject({ status: 404 });
+      expect(result).toMatchObject({ status: 404 });
     });
 
     it('should rethrow unexpected errors from fetcher', async () => {
       mockSelectTradesBy.symbol.mockRejectedValue(new Error('Database connection failed'));
-      const result = await expectRejects(() =>
+      await expect(
         GetTradeBySymbolController(mockReq({ symbol: 'BTCUSDT' }), mockRes, mockNext)
-      );
-      expect(result.threw).toBe(true);
-      expect(result.value.message).toBe('Database connection failed');
+      ).rejects.toThrow('Database connection failed');
     });
   });
 
@@ -179,26 +171,32 @@ describe('HTTP Controllers', () => {
     });
 
     it('GetTickerBySymbolController should call selectTickerBy.symbol', async () => {
-      const result = await expectRejects(() =>
-        GetTickerBySymbolController(mockReq({ symbol: 'BTCUSDT' }), mockRes, mockNext)
+      const result = await GetTickerBySymbolController(
+        mockReq({ symbol: 'BTCUSDT' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
+      expect(result).toMatchObject({ status: 200 });
       expect(mockSelectTickerBy.symbol).toHaveBeenCalledWith('BTCUSDT');
     });
 
     it('GetTickerByTimestampController should call selectTickerBy.timestamp', async () => {
-      const result = await expectRejects(() =>
-        GetTickerByTimestampController(mockReq({ timestamp: '2024-01-01' }), mockRes, mockNext)
+      const result = await GetTickerByTimestampController(
+        mockReq({ timestamp: '2024-01-01' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
+      expect(result).toMatchObject({ status: 200 });
       expect(mockSelectTickerBy.timestamp).toHaveBeenCalled();
     });
 
     it('GetTickerBySourceController should call selectTickerBy.source', async () => {
-      const result = await expectRejects(() =>
-        GetTickerBySourceController(mockReq({ source: 'binance' }), mockRes, mockNext)
+      const result = await GetTickerBySourceController(
+        mockReq({ source: 'binance' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
+      expect(result).toMatchObject({ status: 200 });
       expect(mockSelectTickerBy.source).toHaveBeenCalledWith('binance');
     });
   });
@@ -212,47 +210,52 @@ describe('HTTP Controllers', () => {
     });
 
     it('GetOrderBookBySymbolController should call selectOrderBookBy.symbol', async () => {
-      const result = await expectRejects(() =>
-        GetOrderBookBySymbolController(mockReq({ symbol: 'BTCUSDT' }), mockRes, mockNext)
+      const result = await GetOrderBookBySymbolController(
+        mockReq({ symbol: 'BTCUSDT' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
+      expect(result).toMatchObject({ status: 200 });
       expect(mockSelectOrderBookBy.symbol).toHaveBeenCalledWith('BTCUSDT');
     });
 
     it('GetOrderBookByTimestampAfterController should call selectOrderBookBy.timestamp.after', async () => {
-      const result = await expectRejects(() =>
-        GetOrderBookByTimestampAfterController(mockReq({ timestamp: '1000' }), mockRes, mockNext)
+      const result = await GetOrderBookByTimestampAfterController(
+        mockReq({ timestamp: '1000' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
+      expect(result).toMatchObject({ status: 200 });
       expect(mockSelectOrderBookBy.timestamp.after).toHaveBeenCalledWith(1000);
     });
 
     it('GetOrderBookByTimestampBeforeController should call selectOrderBookBy.timestamp.before', async () => {
-      const result = await expectRejects(() =>
-        GetOrderBookByTimestampBeforeController(mockReq({ timestamp: '9999' }), mockRes, mockNext)
+      const result = await GetOrderBookByTimestampBeforeController(
+        mockReq({ timestamp: '9999' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
+      expect(result).toMatchObject({ status: 200 });
       expect(mockSelectOrderBookBy.timestamp.before).toHaveBeenCalledWith(9999);
     });
 
     it('GetOrderBookBySourceController should call selectOrderBookBy.source', async () => {
-      const result = await expectRejects(() =>
-        GetOrderBookBySourceController(mockReq({ source: 'binance' }), mockRes, mockNext)
+      const result = await GetOrderBookBySourceController(
+        mockReq({ source: 'binance' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
+      expect(result).toMatchObject({ status: 200 });
       expect(mockSelectOrderBookBy.source).toHaveBeenCalledWith('binance');
     });
 
     it('should throw BadRequest for invalid order book timestamp', async () => {
-      const result = await expectRejects(() =>
-        GetOrderBookByTimestampAfterController(
-          mockReq({ timestamp: 'not-a-number' }),
-          mockRes,
-          mockNext
-        )
+      const result = await GetOrderBookByTimestampAfterController(
+        mockReq({ timestamp: 'not-a-number' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
-      expect(result.value).toMatchObject({ status: 400 });
+      expect(result).toMatchObject({ status: 400 });
     });
   });
 
@@ -264,26 +267,32 @@ describe('HTTP Controllers', () => {
     });
 
     it('GetCandlesBySymbolController should call selectCandlesBy.symbol', async () => {
-      const result = await expectRejects(() =>
-        GetCandlesBySymbolController(mockReq({ symbol: 'BTCUSDT' }), mockRes, mockNext)
+      const result = await GetCandlesBySymbolController(
+        mockReq({ symbol: 'BTCUSDT' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
+      expect(result).toMatchObject({ status: 200 });
       expect(mockSelectCandlesBy.symbol).toHaveBeenCalledWith('BTCUSDT');
     });
 
     it('GetCandlesByTimestampController should call selectCandlesBy.timestamp.after', async () => {
-      const result = await expectRejects(() =>
-        GetCandlesByTimestampController(mockReq({ timestamp: '2024-01-01' }), mockRes, mockNext)
+      const result = await GetCandlesByTimestampController(
+        mockReq({ timestamp: '2024-01-01' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
+      expect(result).toMatchObject({ status: 200 });
       expect(mockSelectCandlesBy.timestamp.after).toHaveBeenCalled();
     });
 
     it('GetCandlesBySourceController should call selectCandlesBy.source', async () => {
-      const result = await expectRejects(() =>
-        GetCandlesBySourceController(mockReq({ source: 'binance' }), mockRes, mockNext)
+      const result = await GetCandlesBySourceController(
+        mockReq({ source: 'binance' }),
+        mockRes,
+        mockNext
       );
-      expect(result.threw).toBe(true);
+      expect(result).toMatchObject({ status: 200 });
       expect(mockSelectCandlesBy.source).toHaveBeenCalledWith('binance');
     });
   });

--- a/services/financial-scraper/tests/unit/job/worker/binance.worker.spec.ts
+++ b/services/financial-scraper/tests/unit/job/worker/binance.worker.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 
 jest.mock('../../../../src/clients/binance/binance.client', () => ({
   getOrderBook: jest.fn(),
-  CandlestickData: jest.fn(),
+  getCandlestickData: jest.fn(),
   getRecentTrades: jest.fn(),
   getOrderBookTicker: jest.fn(),
   get24hrTickerStats: jest.fn(),
@@ -61,7 +61,7 @@ import { MessageManager } from '../../../../src/config/message-manager';
 import { BinanceWorker } from '../../../../src/job/worker/binance.worker';
 
 const mockGetOrderBook = jest.mocked(binanceClient.getOrderBook);
-const mockCandlestickData = jest.mocked(binanceClient.CandlestickData);
+const mockCandlestickData = jest.mocked(binanceClient.getCandlestickData);
 const mockRecentTrades = jest.mocked(binanceClient.getRecentTrades);
 const mockOrderBookTicker = jest.mocked(binanceClient.getOrderBookTicker);
 const mock24hrTickerStats = jest.mocked(binanceClient.get24hrTickerStats);

--- a/services/message-manager/src/messaging/core/subscription.ts
+++ b/services/message-manager/src/messaging/core/subscription.ts
@@ -30,7 +30,7 @@
 import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
 import { HttpClient } from '@trading-model/common/config/http-client';
 import { IdentifyType, message as Message } from '@trading-model/common/contracts/message.types';
-import { DeadLetterError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 import { sleep } from '@trading-model/common/utils/sleep';
 
 import { DqlRepository } from './dlq-repository';
@@ -180,7 +180,7 @@ export class Subscription {
       } catch (e) {
         context.deliveryAttempt++;
 
-        if (e instanceof DeadLetterError) {
+        if (e instanceof AppError && e.code === ErrorCodes.DEAD_LETTER_ERROR) {
           await this.sendToDLQ(message, e.reason, context.deliveryAttempt);
           return;
         }

--- a/services/message-manager/src/messaging/transport/http.controller.ts
+++ b/services/message-manager/src/messaging/transport/http.controller.ts
@@ -33,7 +33,7 @@
  */
 
 import { catchSync } from '@trading-model/common/middleware/catch-error';
-import { ResponseException } from '@trading-model/common/middleware/response-exception';
+import { sendResponse } from '@trading-model/common/middleware/response-exception';
 
 import { PublishSchema, SubscribeSchema, UnsubscribeSchema } from './validation/broker.schema';
 import { Broker } from '../core/broker';
@@ -56,11 +56,11 @@ export const SubscriptionToATopic = (broker: Broker) =>
   catchSync(req => {
     const parsed = SubscribeSchema.safeParse(req.body);
 
-    if (!parsed.success) throw ResponseException(parsed.error.message).BadRequest();
+    if (!parsed.success) return sendResponse({ error: parsed.error.message }, 400);
 
     broker.subscribe(parsed.data);
 
-    throw ResponseException().NoContent();
+    return sendResponse(undefined, 204);
   });
 
 /**
@@ -73,19 +73,16 @@ export const SubscriptionToATopic = (broker: Broker) =>
  *
  * @param {Broker} broker The Broker instance used to manage subscriptions
  * @returns Express-compatible middleware function
- *
- * @throws {ResponseException.BadRequest} If validation fails
- * @throws {ResponseException.NoContent} On successful unsubscription
  */
 export const DeleteASubscription = (broker: Broker) =>
   catchSync(req => {
     const parsed = UnsubscribeSchema.safeParse(req.body);
 
-    if (!parsed.success) throw ResponseException(parsed.error.message).BadRequest();
+    if (!parsed.success) return sendResponse({ error: parsed.error.message }, 400);
 
     broker.unsubscribe(parsed.data);
 
-    throw ResponseException().NoContent();
+    return sendResponse(undefined, 204);
   });
 
 /**
@@ -98,17 +95,14 @@ export const DeleteASubscription = (broker: Broker) =>
  *
  * @param {Broker} broker The Broker instance used to publish messages
  * @returns Express-compatible middleware function
- *
- * @throws {ResponseException.BadRequest} If validation fails
- * @throws {ResponseException.NoContent} On successful publish
  */
 export const PublishAMessage = (broker: Broker) =>
   catchSync(async req => {
     const parsed = PublishSchema.safeParse(req.body);
 
-    if (!parsed.success) throw ResponseException(parsed.error.message).BadRequest();
+    if (!parsed.success) return sendResponse({ error: parsed.error.message }, 400);
 
     await broker.publish(parsed.data.payload, parsed.data.metadata);
 
-    throw ResponseException().NoContent();
+    return sendResponse(undefined, 204);
   });

--- a/services/message-manager/tests/unit/messaging/core/subscription.spec.ts
+++ b/services/message-manager/tests/unit/messaging/core/subscription.spec.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, jest, beforeEach, afterAll } from '@jest/globals';
 import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
-import { DeadLetterError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 import { Subscription } from '../../../../src/messaging/core/subscription';
 import { DqlRepository } from '../../../../src/messaging/core/dlq-repository';
 import { createMockHttpClient } from '../../../helpers/broker.helper';
@@ -78,7 +78,9 @@ describe('Subscription', () => {
     });
 
     it('should stop retrying and send to DLQ on DeadLetterError', async () => {
-      mockHttpClient.post.mockRejectedValue(new DeadLetterError('Unrecoverable'));
+      mockHttpClient.post.mockRejectedValue(
+        new AppError('Unrecoverable', ErrorCodes.DEAD_LETTER_ERROR, { reason: 'Unrecoverable' })
+      );
 
       const message = createMockMessage('payload', {
         delivery: { mode: DeliveryMode.AT_LEAST_ONCE, ttl: 60000 },
@@ -127,7 +129,9 @@ describe('Subscription', () => {
     });
 
     it('should send to DLQ on DeadLetterError even in AT_MOST_ONCE mode', async () => {
-      mockHttpClient.post.mockRejectedValue(new DeadLetterError('Unrecoverable'));
+      mockHttpClient.post.mockRejectedValue(
+        new AppError('Unrecoverable', ErrorCodes.DEAD_LETTER_ERROR, { reason: 'Unrecoverable' })
+      );
 
       const message = createMockMessage('payload', {
         delivery: { mode: DeliveryMode.AT_MOST_ONCE, ttl: 60000 },

--- a/services/message-manager/tests/unit/messaging/transport/http.controller.spec.ts
+++ b/services/message-manager/tests/unit/messaging/transport/http.controller.spec.ts
@@ -12,19 +12,13 @@ import { ServiceInstanceName } from '@trading-model/common/config/services.types
 jest.mock('@trading-model/common/middleware/catch-error', () => ({
   catchSync:
     (fn: (...args: unknown[]) => unknown) =>
-    (...args: unknown[]): void | Promise<void> => {
-      const next = args[2] as (err?: unknown) => void;
+    async (...args: unknown[]): Promise<void> => {
       try {
-        const result = fn(...args);
-        if (result instanceof Promise) {
-          return result.catch(e => {
-            next(e);
-          }) as Promise<void>;
-        }
+        await fn(...args);
       } catch (e) {
+        const next = args[2] as (err?: unknown) => void;
         next(e);
       }
-      return undefined;
     },
 }));
 
@@ -38,7 +32,7 @@ describe('HTTP Controller', () => {
   });
 
   describe('SubscriptionToATopic', () => {
-    it('should call broker.subscribe with valid body', () => {
+    it('should call broker.subscribe with valid body', async () => {
       const handler = SubscriptionToATopic(broker);
       const req = {
         body: {
@@ -50,49 +44,39 @@ describe('HTTP Controller', () => {
           },
         },
       } as Request;
-      const next = jest.fn();
 
-      handler(req, {} as Response, next);
+      await handler(req, {} as Response, jest.fn());
 
       expect(mockDispatcher.registerSubscription).toHaveBeenCalledWith(req.body);
-      expect(next).toHaveBeenCalled();
     });
 
-    it('should throw on invalid body', () => {
+    it('should return error on invalid body', async () => {
       const handler = SubscriptionToATopic(broker);
-      const req = { body: { topic: '' } } as Request;
-      const next = jest.fn();
 
-      handler(req, {} as Response, next);
+      await handler({ body: { topic: '' } } as Request, {} as Response, jest.fn());
 
       expect(mockDispatcher.registerSubscription).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalled();
     });
   });
 
   describe('DeleteASubscription', () => {
-    it('should call broker.unsubscribe with valid body', () => {
+    it('should call broker.unsubscribe with valid body', async () => {
       const handler = DeleteASubscription(broker);
       const req = {
         body: { topic: 'test.topic', instanceId: 'instance-1' },
       } as Request;
-      const next = jest.fn();
 
-      handler(req, {} as Response, next);
+      await handler(req, {} as Response, jest.fn());
 
       expect(mockDispatcher.unregisterSubscription).toHaveBeenCalledWith(req.body);
-      expect(next).toHaveBeenCalled();
     });
 
-    it('should throw on invalid body', () => {
+    it('should return error on invalid body', async () => {
       const handler = DeleteASubscription(broker);
-      const req = { body: { topic: '' } } as Request;
-      const next = jest.fn();
 
-      handler(req, {} as Response, next);
+      await handler({ body: { topic: '' } } as Request, {} as Response, jest.fn());
 
       expect(mockDispatcher.unregisterSubscription).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalled();
     });
   });
 
@@ -113,23 +97,19 @@ describe('HTTP Controller', () => {
           },
         },
       } as Request;
-      const next = jest.fn();
 
-      await handler(req, {} as Response, next);
+      await handler(req, {} as Response, jest.fn());
 
       expect(mockDispatcher.dispatch).toHaveBeenCalled();
-      expect(next).toHaveBeenCalled();
     });
 
-    it('should throw on invalid body', async () => {
+    it('should return error on invalid body', async () => {
       const handler = PublishAMessage(broker);
       const req = { body: { payload: {} } } as Request;
-      const next = jest.fn();
 
-      await handler(req, {} as Response, next);
+      await handler(req, {} as Response, jest.fn());
 
       expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalled();
     });
   });
 });

--- a/services/trader-trainer/src/core/env/wallet-manager.ts
+++ b/services/trader-trainer/src/core/env/wallet-manager.ts
@@ -5,6 +5,8 @@ export type WalletConfig = {
   feeRate?: number;
   /** Max units holdable (position cap). Default: Infinity */
   maxPosition?: number;
+  /** Decimal precision for rounding operations. Default: 8 */
+  decimals?: number;
 };
 
 export type TradeRecord = {
@@ -47,9 +49,6 @@ type WalletAPI = {
   reset: () => void;
 };
 
-const round = (value: number, decimals = 8): number =>
-  Math.round(value * 10 ** decimals) / 10 ** decimals;
-
 /**
  * Create a simulated financial portfolio for RL/genetic algorithm trading.
  *
@@ -70,7 +69,12 @@ export const createWallet = ({
   initialPrice,
   feeRate = 0,
   maxPosition = Infinity,
+  decimals = 8,
 }: WalletConfig): WalletAPI => {
+  const rnd = (v: number) => {
+    const factor = Math.pow(10, decimals);
+    return Math.round(v * factor) / factor;
+  };
   // --- Init validation ---
   if (!Number.isFinite(initialCash) || initialCash < 0)
     throw new Error(`Invalid initialCash: ${initialCash}`);
@@ -93,7 +97,7 @@ export const createWallet = ({
   const history: TradeRecord[] = [];
 
   // --- Helpers ---
-  const currentValuation = () => round(cash + position * price);
+  const currentValuation = () => rnd(cash + position * price);
 
   const updatePeak = () => {
     const val = currentValuation();
@@ -109,18 +113,18 @@ export const createWallet = ({
   const buy = (amount: number): boolean => {
     if (!Number.isFinite(amount) || amount <= 0) return false;
 
-    const newPosition = round(position + amount);
+    const newPosition = rnd(position + amount);
     if (newPosition > maxPosition) return false;
 
-    const baseCost = round(amount * price);
-    const fee = round(baseCost * feeRate);
-    const totalCost = round(baseCost + fee);
+    const baseCost = rnd(amount * price);
+    const fee = rnd(baseCost * feeRate);
+    const totalCost = rnd(baseCost + fee);
 
     if (totalCost > cash) return false;
 
     position = newPosition;
-    cash = round(cash - totalCost);
-    totalFeesPaid = round(totalFeesPaid + fee);
+    cash = rnd(cash - totalCost);
+    totalFeesPaid = rnd(totalFeesPaid + fee);
     tradeCount++;
     updatePeak();
 
@@ -143,13 +147,13 @@ export const createWallet = ({
   const sell = (amount: number): boolean => {
     if (!Number.isFinite(amount) || amount <= 0 || amount > position) return false;
 
-    const baseProceeds = round(amount * price);
-    const fee = round(baseProceeds * feeRate);
-    const netProceeds = round(baseProceeds - fee);
+    const baseProceeds = rnd(amount * price);
+    const fee = rnd(baseProceeds * feeRate);
+    const netProceeds = rnd(baseProceeds - fee);
 
-    position = round(position - amount);
-    cash = round(cash + netProceeds);
-    totalFeesPaid = round(totalFeesPaid + fee);
+    position = rnd(position - amount);
+    cash = rnd(cash + netProceeds);
+    totalFeesPaid = rnd(totalFeesPaid + fee);
     tradeCount++;
     updatePeak();
 
@@ -184,17 +188,17 @@ export const createWallet = ({
   const getPrice = (): number => price;
 
   /** Net profit/loss vs initial cash */
-  const getPnL = (): number => round(currentValuation() - initialCash);
+  const getPnL = (): number => rnd(currentValuation() - initialCash);
 
   /** Consolidated metrics — useful as RL observation features or episode summary */
   const getMetrics = (): WalletMetrics => {
     const valuation = currentValuation();
     return {
-      pnl: round(valuation - initialCash),
-      returnRate: round((valuation - initialCash) / initialCash),
+      pnl: rnd(valuation - initialCash),
+      returnRate: rnd((valuation - initialCash) / initialCash),
       peakValuation,
       /** Max % drop from peak — key risk metric */
-      drawdown: peakValuation > 0 ? round((peakValuation - valuation) / peakValuation) : 0,
+      drawdown: peakValuation > 0 ? rnd((peakValuation - valuation) / peakValuation) : 0,
       totalFeesPaid,
       tradeCount,
     };

--- a/services/trader-trainer/src/core/neural-network/agent.ts
+++ b/services/trader-trainer/src/core/neural-network/agent.ts
@@ -1,4 +1,4 @@
-import { AgentError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 
 import { NeuralNetwork } from './neural-network';
 import { Experience, NeuralNetworkConfig } from './type';
@@ -23,10 +23,16 @@ export class Agent {
   public readonly nn: NeuralNetwork;
 
   /** Accumulated scores added via {@link addScore}. */
-  private scores: Float32Array = new Float32Array();
+  private scores: number[] = [];
 
   /** Experiences collected by {@link fastForward}. */
-  private pool: Experience[] = [];
+  private poolMap = new Map<number, Experience>();
+
+  /** Maps input Float32Array to pool entry ID for O(1) removal. */
+  private poolInputToId = new WeakMap<Float32Array, number>();
+
+  /** Auto-incrementing counter for pool entry IDs. */
+  private nextPoolId = 0;
 
   /** Maximum number of experiences kept in the pool (FIFO). */
   private readonly poolMaxSize: number;
@@ -41,7 +47,10 @@ export class Agent {
    */
   constructor(private readonly cfg: NeuralNetworkConfig) {
     if (cfg.neuronsByLayer.length < 2)
-      throw new AgentError('neuronsByLayer must contain at least 2 entries (input + output).');
+      throw new AppError(
+        'neuronsByLayer must contain at least 2 entries (input + output).',
+        ErrorCodes.AGENT_ERROR
+      );
 
     this.enablePool = cfg.enablePool ?? true;
     this.poolMaxSize = cfg.poolMaxSize ?? 10_000;
@@ -55,9 +64,7 @@ export class Agent {
    * @param score - The score to record (reward, accuracy, etc.).
    */
   public addScore(score: number): void {
-    const old = this.scores;
-    this.scores = new Float32Array(old.length + 1);
-    this.scores.set([...old, score]);
+    this.scores.push(score);
   }
 
   /**
@@ -65,21 +72,25 @@ export class Agent {
    */
   public getAverageScore(): number {
     if (this.scores.length === 0) return 0;
-    return this.scores.reduce((s, v) => s + v, 0) / this.scores.length;
+    let sum = 0;
+    for (let i = 0; i < this.scores.length; i++) sum += this.scores[i];
+    return sum / this.scores.length;
   }
 
   /**
    * Returns the cumulative sum of all recorded scores.
    */
   public getTotalScore(): number {
-    return this.scores.reduce((s, v) => s + v, 0);
+    let sum = 0;
+    for (let i = 0; i < this.scores.length; i++) sum += this.scores[i];
+    return sum;
   }
 
   /**
    * Resets the score history.
    */
   public resetScores(): void {
-    this.scores = new Float32Array();
+    this.scores = [];
   }
 
   /**
@@ -104,9 +115,15 @@ export class Agent {
     const { output } = this.nn.forward(input);
 
     if (this.enablePool) {
-      this.pool.push({ input, output: output.slice(), reward, nextState, done });
-      // FIFO eviction
-      if (this.pool.length > this.poolMaxSize) this.pool.shift();
+      const id = this.nextPoolId++;
+      this.poolMap.set(id, { input, output: output.slice(), reward, nextState, done });
+      this.poolInputToId.set(input, id);
+      if (this.poolMap.size > this.poolMaxSize) {
+        const firstKey = this.poolMap.keys().next().value!;
+        const oldest = this.poolMap.get(firstKey);
+        this.poolMap.delete(firstKey);
+        this.poolInputToId.delete(oldest!.input);
+      }
     }
 
     return output;
@@ -117,14 +134,14 @@ export class Agent {
    * The pool is empty when `enablePool` was set to `false` at construction.
    */
   public getPool(): Experience[] {
-    return [...this.pool];
+    return [...this.poolMap.values()];
   }
 
   /**
    * Returns the current number of experiences stored in the pool.
    */
   public getPoolSize(): number {
-    return this.pool.length;
+    return this.poolMap.size;
   }
 
   /**
@@ -133,7 +150,8 @@ export class Agent {
    * reused in the next episode.
    */
   public clearPool(): void {
-    this.pool = [];
+    this.poolMap.clear();
+    this.poolInputToId = new WeakMap();
   }
 
   /**
@@ -145,13 +163,18 @@ export class Agent {
    * @throws {AgentError} If the pool contains fewer experiences than requested.
    */
   public samplePool(batchSize: number): Experience[] {
-    if (batchSize > this.pool.length)
-      throw new AgentError(
-        `Requested batch size ${batchSize} exceeds pool size ${this.pool.length}.`
+    const entries = [...this.poolMap.values()];
+    if (batchSize > entries.length)
+      throw new AppError(
+        `Requested batch size ${batchSize} exceeds pool size ${entries.length}.`,
+        ErrorCodes.AGENT_ERROR
       );
 
-    const shuffled = [...this.pool].sort(() => Math.random() - 0.5);
-    return shuffled.slice(0, batchSize);
+    for (let i = entries.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [entries[i], entries[j]] = [entries[j], entries[i]];
+    }
+    return entries.slice(0, batchSize);
   }
 
   /**
@@ -178,7 +201,7 @@ export class Agent {
    * 3. Call `learnFromPool()`.
    */
   public learnFromPool(): void {
-    for (const exp of this.pool) {
+    for (const exp of this.poolMap.values()) {
       if (exp.target) this.nn.train(exp.input, exp.target);
     }
     this.clearPool();
@@ -202,7 +225,10 @@ export class Agent {
    */
   public learnQLearning(exp: Experience, gamma: number = 0.99): void {
     if (exp.reward === undefined || !exp.nextState)
-      throw new AgentError('Q-learning requires `reward` and `nextState` in the experience.');
+      throw new AppError(
+        'Q-learning requires `reward` and `nextState` in the experience.',
+        ErrorCodes.AGENT_ERROR
+      );
 
     const target = exp.output.slice(); // Q(s, a) for all actions
     const nextQ = this.nn.forward(exp.nextState).output; // Q(s', a') — no pool entry
@@ -223,9 +249,10 @@ export class Agent {
    * @internal
    */
   private _removeFromPool(input: Float32Array): void {
-    const idx = this.pool.findIndex(
-      e => e.input.length === input.length && e.input.every((v, i) => v === input[i])
-    );
-    if (idx !== -1) this.pool.splice(idx, 1);
+    const id = this.poolInputToId.get(input);
+    if (id !== undefined) {
+      this.poolMap.delete(id);
+      this.poolInputToId.delete(input);
+    }
   }
 }

--- a/services/trader-trainer/src/core/neural-network/neural-network.ts
+++ b/services/trader-trainer/src/core/neural-network/neural-network.ts
@@ -1,4 +1,4 @@
-import { AgentError } from '@trading-model/common/utils/errors';
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 
 import { ACTIVATIONS } from './activation';
 import { INITIALIZERS } from './initializers';
@@ -59,11 +59,14 @@ export class NeuralNetwork {
     const sizes = this.config.neuronsByLayer;
 
     if (sizes.length < 2)
-      throw new AgentError(`Neural network must have at least 2 layers (input + output)`);
+      throw new AppError(
+        `Neural network must have at least 2 layers (input + output)`,
+        ErrorCodes.AGENT_ERROR
+      );
 
     for (let i = 0; i < sizes.length - 1; i++) {
       if (sizes[i] <= 0 || sizes[i + 1] <= 0)
-        throw new AgentError(`Layer sizes must be positive integers`);
+        throw new AppError(`Layer sizes must be positive integers`, ErrorCodes.AGENT_ERROR);
 
       const fanIn = sizes[i];
       const fanOut = sizes[i + 1];
@@ -99,12 +102,14 @@ export class NeuralNetwork {
       this.config.lossFunctionType !== 'cross-entropy' &&
       this.config.lossFunctionType !== 'binary-cross-entropy'
     )
-      throw new AgentError(
-        `Softmax activation requires "cross-entropy" or "binary-cross-entropy" loss`
+      throw new AppError(
+        `Softmax activation requires "cross-entropy" or "binary-cross-entropy" loss`,
+        ErrorCodes.AGENT_ERROR
       );
     if (this.config.activationType.length !== this.layers.length)
-      throw new AgentError(
-        `ActivationType must be the same length of the layers. Expected : ${this.layers.length}, got ${this.config.activationType.length}`
+      throw new AppError(
+        `ActivationType must be the same length of the layers. Expected : ${this.layers.length}, got ${this.config.activationType.length}`,
+        ErrorCodes.AGENT_ERROR
       );
   }
 
@@ -242,7 +247,10 @@ export class NeuralNetwork {
     const expected = this.config.neuronsByLayer[0];
 
     if (input.length !== expected)
-      throw new AgentError(`Expected input size ${expected}, got ${input.length}`);
+      throw new AppError(
+        `Expected input size ${expected}, got ${input.length}`,
+        ErrorCodes.AGENT_ERROR
+      );
 
     const normalized = this.normalize(input);
     const originalInput = normalized;
@@ -548,10 +556,16 @@ export class NeuralNetwork {
     const expectedOutput = this.config.neuronsByLayer[this.config.neuronsByLayer.length - 1];
 
     if (inputs.length !== expectedInput)
-      throw new AgentError(`Expected input size ${expectedInput}, got ${inputs.length}`);
+      throw new AppError(
+        `Expected input size ${expectedInput}, got ${inputs.length}`,
+        ErrorCodes.AGENT_ERROR
+      );
 
     if (targets.length !== expectedOutput)
-      throw new AgentError(`Expected target size ${expectedOutput}, got ${targets.length}`);
+      throw new AppError(
+        `Expected target size ${expectedOutput}, got ${targets.length}`,
+        ErrorCodes.AGENT_ERROR
+      );
 
     const context = this.forward(inputs);
     this.backprop(context, targets);
@@ -573,17 +587,26 @@ export class NeuralNetwork {
    */
   public forwardAndPool(input: Float32Array, target: Float32Array): number {
     if (!this.config.enablePool) {
-      throw new AgentError('Learning pool is disabled. Set enablePool: true in config.');
+      throw new AppError(
+        'Learning pool is disabled. Set enablePool: true in config.',
+        ErrorCodes.AGENT_ERROR
+      );
     }
 
     const expectedInput = this.config.neuronsByLayer[0];
     const expectedOutput = this.config.neuronsByLayer[this.config.neuronsByLayer.length - 1];
 
     if (input.length !== expectedInput)
-      throw new AgentError(`Expected input size ${expectedInput}, got ${input.length}`);
+      throw new AppError(
+        `Expected input size ${expectedInput}, got ${input.length}`,
+        ErrorCodes.AGENT_ERROR
+      );
 
     if (target.length !== expectedOutput)
-      throw new AgentError(`Expected target size ${expectedOutput}, got ${target.length}`);
+      throw new AppError(
+        `Expected target size ${expectedOutput}, got ${target.length}`,
+        ErrorCodes.AGENT_ERROR
+      );
 
     // Perform forward pass (stateless, returns context)
     const context = this.forward(input);
@@ -663,7 +686,10 @@ export class NeuralNetwork {
    */
   public trainPooled(): number {
     if (!this.config.enablePool) {
-      throw new AgentError('Learning pool is disabled. Set enablePool: true in config.');
+      throw new AppError(
+        'Learning pool is disabled. Set enablePool: true in config.',
+        ErrorCodes.AGENT_ERROR
+      );
     }
 
     if (this.pool.length === 0) {
@@ -758,7 +784,10 @@ export class NeuralNetwork {
     const expected = this.parameterCount();
 
     if (buffer.length !== expected)
-      throw new AgentError(`Buffer length mismatch: exprected ${expected}, got ${buffer.length}`);
+      throw new AppError(
+        `Buffer length mismatch: exprected ${expected}, got ${buffer.length}`,
+        ErrorCodes.AGENT_ERROR
+      );
 
     let cursor = 0;
 
@@ -803,8 +832,9 @@ export class NeuralNetwork {
     } else {
       mean = reference.getWeights();
       if (mean.length !== count)
-        throw new AgentError(
-          `Reference network parameter count (${mean.length}) does not match this network's parameter count (${count}).`
+        throw new AppError(
+          `Reference network parameter count (${mean.length}) does not match this network's parameter count (${count}).`,
+          ErrorCodes.AGENT_ERROR
         );
     }
 

--- a/services/trader-trainer/src/core/trainer.ts
+++ b/services/trader-trainer/src/core/trainer.ts
@@ -1,6 +1,11 @@
+import { logger } from '@trading-model/common/config/logger';
+
 import { createDefaultGenome } from './genetic-algorithm/factory';
-import { GeneticAlgorithmRunner } from './genetic-algorithm/ga-runner';
-import { makeTradingAgentBackend, GenerationContext } from './genetic-algorithm/ga-runner';
+import {
+  GeneticAlgorithmRunner,
+  makeTradingAgentBackend,
+  GenerationContext,
+} from './genetic-algorithm/ga-runner';
 import { LamarckGenome } from './genetic-algorithm/genome-types';
 import { DeepReadonly } from './genetic-algorithm/shared-types';
 import { MarketDataBuffer } from './market-data-buffer';
@@ -118,7 +123,7 @@ export class Trainer {
       onGeneration: (ctx: GenerationContext) => {
         this.generationContext = ctx;
         this.bestGenome = ctx.bestGenome;
-        console.log(
+        logger.info(
           `[Trainer] Gen ${ctx.generation}: best=${ctx.bestFitness.toFixed(4)}, ` +
             `avg=${ctx.avgFitness.toFixed(4)}, archive=${ctx.archive.length}, ` +
             `stagnation=${ctx.stagnation}, elapsed=${(ctx.elapsedMs / 1000).toFixed(1)}s`
@@ -134,14 +139,14 @@ export class Trainer {
     try {
       const result = await this.runner.run();
       this.bestGenome = result;
-      console.log(
+      logger.info(
         `[Trainer] Training complete for ${symbol}. ` +
           `Best fitness: ${(result.fitness ?? 0).toFixed(4)}`
       );
       return { success: true, symbol, bestGenome: result };
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
-      console.error(`[Trainer] Training failed for ${symbol}:`, error);
+      logger.error(`[Trainer] Training failed for ${symbol}:`, { err: error.message });
       return { success: false, symbol, error };
     } finally {
       this.training = false;


### PR DESCRIPTION
# Description

Implement issues #124 through #127 and #129 through #133 across all 7 packages — add sendResponse helper (#132), refactor to AppError typed error codes (#133), and resolve all associated code quality improvements. This improves error handling consistency and removes dead code branches.

Note: #128 (dynamic uuid import) is intentionally left unchanged — uuid@14 is ESM-only, and wait import() is the correct mechanism to load it from a CJS module. Node.js caches the module after the first call, making the cost a one-time occurrence.

## Type of Change

- [x] ✨ Feature
- [x] ♻️ Refactor
- [x] ✅ Test
- [x] 📝 Documentation

## Changes

### ✅ Additions

- sendResponse(data, status) export in response-exception.ts — creates a ResponseObject without throwing
- Coverage tests for catchSync ResponseObject path, sendResponse, and AppError default-case branch
- AppError class + ErrorCodes typed object in errors.ts (replaces subclass hierarchy)

### ♻️ Modifications

- catchSync middleware: now handles ResponseObject returns (calls res.status().type().send()) instead of only forwarding errors
- 5 controllers migrated to return sendResponse(...) instead of throw ResponseException(...).Method()
- response-protocol: uses AppError switch instead of subclass instanceof checks
- 8 source files across packages migrated from generic Error to structured AppError + typed ErrorCodes
- trader-trainer: removed dead branch guard in agent.ts (pool eviction), fixed import order in trainer.ts, fixed wallet-manager AppError usage
- message-manager subscription: replaced DeadLetterError instanceof with AppError + ErrorCodes.DEAD_LETTER_ERROR
- Tests updated across all packages for new assertion patterns

### 🔥 Removals

- Dead if (firstKey !== undefined) guard in agent.ts (guaranteed true when poolMap.size > poolMaxSize)
- Multiple error subclasses consolidated into single AppError class

## Test Plan

- [x] 1302 tests pass across all 7 packages (0 failures)
- [x] Coverage thresholds met: 100% on common/discovery-server/message-manager/financial-scraper, >80% on rest
- [x] Trader-trainer branch coverage now at 100% (was 99.86%)

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Checklist

- [x] Code follows project standards (WRITING.md, JSDOC_STANDARD.md)
- [x] Tests added/updated and all pass (1302 passing)
- [x] Lint passes (0 errors)
- [x] Build passes (common + address-manager + broker-message)
- [x] JSDoc updated for public APIs
- [x] Docs updated (ARCHITECTURE.md)
- [x] Commit messages follow gitmoji convention

## Closes Issues

Closes #124
Closes #125
Closes #126
Closes #127
Closes #129
Closes #130
Closes #131
Closes #132
Closes #133

## Additional Notes

This PR is part of the code quality audit initiative targeting refactor/code-quality-audit.