### PR TITLE
:bug: :recycle: :white_check_mark: code quality batch #5 — proxy trust, monitoring, dedup, cleanup

### DIFF
--- a/packages/common/src/server/configure-app.ts
+++ b/packages/common/src/server/configure-app.ts
@@ -22,7 +22,7 @@ export function configureApp(
 
   app.use(helmet());
 
-  if (config.trustProxy ?? true) {
+  if (config.trustProxy ?? false) {
     app.set('trust proxy', 1);
   }
 

--- a/packages/common/tests/unit/configure-app.spec.ts
+++ b/packages/common/tests/unit/configure-app.spec.ts
@@ -39,9 +39,15 @@ describe('configureApp', () => {
     expect(mockApp.get).toHaveBeenCalledWith('/ping', expect.any(Function));
   });
 
-  it('should set trust proxy by default', () => {
+  it('should not set trust proxy by default', () => {
     mockApp.set.mockClear();
     configureApp();
+    expect(mockApp.set).not.toHaveBeenCalled();
+  });
+
+  it('should set trust proxy when explicitly enabled', () => {
+    mockApp.set.mockClear();
+    configureApp({ trustProxy: true });
     expect(mockApp.set).toHaveBeenCalledWith('trust proxy', 1);
   });
 

--- a/services/discovery-server/src/core/lease-manager.ts
+++ b/services/discovery-server/src/core/lease-manager.ts
@@ -132,26 +132,26 @@ export class LeaseManager {
    * over the underlying registry structure.
    */
   private cleanupExpiredInstances(): void {
-    const snapshot = this.registry.dump();
     const now = Date.now();
 
-    for (const [serviceName, instances] of Object.entries(snapshot)) {
-      for (const instance of instances) {
+    for (const serviceName of this.registry.listServiceNames()) {
+      for (const instance of this.registry.getInstances(serviceName)) {
         const expired = now - instance.lastHeartbeat > instance.ttl;
 
         if (expired) {
-          /**
-           * Log eviction for traceability and incident analysis.
-           */
           logger.warn(
             `[LeaseManager] Expired instance removed: ${instance.instanceId} (service=${serviceName})`
           );
 
-          /**
-           * Remove the expired instance from the registry.
-           * Subsequent resolve calls will no longer return it.
-           */
-          this.registry.removeInstance(serviceName, instance.instanceId);
+          try {
+            this.registry.removeInstance(serviceName, instance.instanceId);
+          } catch (err) {
+            logger.error('[LeaseManager] Failed to remove expired instance:', {
+              serviceName,
+              instanceId: instance.instanceId,
+              error: err,
+            });
+          }
         }
       }
     }

--- a/services/discovery-server/src/core/lease-manager.ts
+++ b/services/discovery-server/src/core/lease-manager.ts
@@ -123,13 +123,9 @@ export class LeaseManager {
    * Periodic cleanup job.
    *
    * Strategy:
-   * - Take a snapshot of the registry state
-   * - Iterate over all services and their instances
+   * - Iterate over all services via listServiceNames()
+   * - For each service, iterate over its instances via getInstances()
    * - Remove instances whose lease has expired
-   *
-   * Note:
-   * The snapshot approach avoids mutation issues while iterating
-   * over the underlying registry structure.
    */
   private cleanupExpiredInstances(): void {
     const now = Date.now();

--- a/services/discovery-server/tests/unit/lease-manager.spec.ts
+++ b/services/discovery-server/tests/unit/lease-manager.spec.ts
@@ -20,6 +20,7 @@ describe('LeaseManager', () => {
   });
 
   afterEach(() => {
+    jest.clearAllMocks();
     leaseManager.stop();
   });
 
@@ -114,10 +115,8 @@ describe('LeaseManager', () => {
         instanceId: 'expired-id',
         ip: '1.1.1.1',
         port: 8080,
-        ttl: 30000,
+        ttl: 1,
         protocol: 'mtls',
-        registeredAt: Date.now(),
-        lastHeartbeat: Date.now(),
       });
 
       registry.registerInstance({
@@ -125,38 +124,11 @@ describe('LeaseManager', () => {
         instanceId: 'alive-id',
         ip: '1.1.1.2',
         port: 8081,
-        ttl: 30000,
+        ttl: 60000,
         protocol: 'mtls',
-        registeredAt: Date.now(),
-        lastHeartbeat: Date.now(),
       });
 
       const lm = new LeaseManager(registry);
-      jest.spyOn(registry, 'dump').mockReturnValue({
-        'financial-scrapper-service': [
-          {
-            serviceName: 'financial-scrapper-service',
-            instanceId: 'expired-id',
-            ip: '1.1.1.1',
-            port: 8080,
-            ttl: 30000,
-            protocol: 'mtls',
-            registeredAt: Date.now() - 120_000,
-            lastHeartbeat: Date.now() - 60_000,
-          },
-          {
-            serviceName: 'financial-scrapper-service',
-            instanceId: 'alive-id',
-            ip: '1.1.1.2',
-            port: 8081,
-            ttl: 30000,
-            protocol: 'mtls',
-            registeredAt: Date.now() - 1000,
-            lastHeartbeat: Date.now(),
-          },
-        ],
-      });
-
       lm.start();
       jest.advanceTimersByTime(5000);
 
@@ -165,12 +137,45 @@ describe('LeaseManager', () => {
       expect(remaining[0].instanceId).toBe('alive-id');
     });
 
-    it('should log error when cleanup throws', () => {
+    it('should log error when removeInstance throws', () => {
       const registry = new ServiceRegistry();
       const lm = new LeaseManager(registry);
 
-      jest.spyOn(registry, 'dump').mockImplementation(() => {
-        throw new Error('cleanup failed');
+      registry.registerInstance({
+        serviceName: 'test-service',
+        instanceId: 'test-id',
+        ip: '1.1.1.1',
+        port: 8080,
+        ttl: 1,
+        protocol: 'mtls',
+      });
+
+      jest.spyOn(registry, 'removeInstance').mockImplementation(() => {
+        throw new Error('remove failed');
+      });
+
+      lm.start();
+      jest.advanceTimersByTime(5000);
+
+      const { logger } = jest.requireMock<{ logger: { error: jest.Mock } }>(
+        '@trading-model/common/config/logger'
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        '[LeaseManager] Failed to remove expired instance:',
+        {
+          serviceName: 'test-service',
+          instanceId: 'test-id',
+          error: new Error('remove failed'),
+        }
+      );
+    });
+
+    it('should log error when listServiceNames throws in start catch', () => {
+      const registry = new ServiceRegistry();
+      const lm = new LeaseManager(registry);
+
+      jest.spyOn(registry, 'listServiceNames').mockImplementation(() => {
+        throw new Error('unexpected error');
       });
 
       lm.start();
@@ -180,7 +185,7 @@ describe('LeaseManager', () => {
         '@trading-model/common/config/logger'
       );
       expect(logger.error).toHaveBeenCalledWith('[LeaseManager] Cleanup error:', {
-        error: new Error('cleanup failed'),
+        error: new Error('unexpected error'),
       });
     });
   });

--- a/services/message-manager/src/messaging/core/dispatcher.ts
+++ b/services/message-manager/src/messaging/core/dispatcher.ts
@@ -39,6 +39,7 @@
  */
 
 import { HttpClient } from '@trading-model/common/config/http-client';
+import { logger } from '@trading-model/common/config/logger';
 import { IdentifyType, message } from '@trading-model/common/contracts/message.types';
 
 import { DqlRepository } from './dlq-repository';
@@ -131,17 +132,15 @@ export class Dispatcher {
     const subscriptions = this.subscriptionsByTopic.get(topic);
     if (!subscriptions?.length) return;
 
-    const uniqueSubscriptionsByInstance = new Map<string, Subscription>();
-
-    for (const subscription of subscriptions) {
-      uniqueSubscriptionsByInstance.set(subscription.serviceIdentity.instanceId, subscription);
-    }
-
-    const uniqueSubscriptions = [...uniqueSubscriptionsByInstance.values()];
-
-    await Promise.allSettled(
-      uniqueSubscriptions.map(subscription => subscription.dispatch(this.HTTPCLIENT, message))
+    const results = await Promise.allSettled(
+      subscriptions.map(subscription => subscription.dispatch(this.HTTPCLIENT, message))
     );
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        logger.error('[Dispatcher] Message delivery failed:', { error: result.reason });
+      }
+    }
   }
 
   /**

--- a/services/message-manager/src/messaging/core/dispatcher.ts
+++ b/services/message-manager/src/messaging/core/dispatcher.ts
@@ -115,8 +115,7 @@ export class Dispatcher {
    * Dispatch a message to all subscribers of its topic.
    *
    * @description
-   * Resolves all subscriptions matching the message topic,
-   * deduplicates them by service instance identifier,
+   * Resolves all subscriptions matching the message topic
    * and dispatches the message to each subscription in parallel.
    *
    * Message delivery failures are isolated and do not prevent

--- a/services/message-manager/tests/unit/messaging/core/dispatcher.spec.ts
+++ b/services/message-manager/tests/unit/messaging/core/dispatcher.spec.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, jest, beforeEach, afterAll } from '@jest/globals';
 import { Dispatcher } from '../../../../src/messaging/core/dispatcher';
+import { Subscription } from '../../../../src/messaging/core/subscription';
 import { DqlRepository } from '../../../../src/messaging/core/dlq-repository';
 import { createMockHttpClient } from '../../../helpers/broker.helper';
 import {
@@ -11,6 +12,10 @@ import {
   mockSubscriberIdentity,
   mockSubscribeParams,
 } from '../../../fixtures/broker.fixture';
+
+jest.mock('@trading-model/common/config/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
 
 jest.mock('config/address-manager', () => ({
   findAService: jest
@@ -127,6 +132,26 @@ describe('Dispatcher', () => {
       await dispatcher.dispatch(message);
 
       expect(mockHttpClient.post).toHaveBeenCalledTimes(3);
+    });
+
+    it('should log allSettled rejections when subscription.dispatch rejects', async () => {
+      jest
+        .spyOn(Subscription.prototype, 'dispatch')
+        .mockRejectedValue(new Error('Unhandled error'));
+
+      dispatcher.registerSubscription(mockSubscribeParams);
+
+      const message = createMockMessage('test');
+      await dispatcher.dispatch(message);
+
+      const { logger } = jest.requireMock('@trading-model/common/config/logger') as {
+        logger: { info: jest.Mock; warn: jest.Mock; error: jest.Mock };
+      };
+      expect(logger.error).toHaveBeenCalledWith('[Dispatcher] Message delivery failed:', {
+        error: new Error('Unhandled error'),
+      });
+
+      jest.restoreAllMocks();
     });
 
     it('should deduplicate subscriptions by instanceId', async () => {


### PR DESCRIPTION
﻿# Description

Batch of targeted code quality fixes addressing 5 issues from the code quality audit covering security hardening, monitoring, cleanup optimization, and error resilience.

## Type of Change

- [x] :bug: fix — Bug fix
- [x] :recycle: refactor — Code restructuring
- [x] :white_check_mark: test — Tests

## Changes

### ✅ Additions

- `@trading-model/common/config/logger` integration in `Dispatcher` for monitoring delivery failures
- Test coverage for allSettled rejection logging path
- Test coverage for `removeInstance` error handling in `LeaseManager`
- Test coverage for `listServiceNames` throwing in `LeaseManager` start catch
- Test for explicit `trustProxy: true` behavior in `configureApp`

### :recycle: Modifications

- `configure-app.ts` — trust proxy now defaults to `false` (opt-in only) to prevent blind IP spoofing risk
- `dispatcher.ts` — removed redundant subscription deduplication loop (registerSubscription already prevents duplicates)
- `dispatcher.ts` — iterate over allSettled results and log any rejected deliveries for observability
- `lease-manager.ts` — replaced `registry.dump()` with `listServiceNames() + getInstances()` to avoid full snapshot GC pressure on every cycle

### :fire: Removals

- Redundant `uniqueSubscriptionsByInstance` Map and loop in `dispatcher.dispatch()`
- Reliance on full `registry.dump()` snapshot in `lease-manager.cleanupExpiredInstances()`

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Tests

- [x] Existing tests pass
- [x] New tests added
- [x] `npm run test:coverage` — All 7 workspaces at 100%

## Checklist

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — Success
- [x] `npm test` — All tests pass

## Closes Issues

Closes #140
Closes #141
Closes #142
Closes #143
Closes #144

## Additional Notes

Part of the code quality audit initiative (#80).
