### PR TITLE
:bug: :recycle: :white_check_mark: code quality batch #6 — validation, error logging, config, cleanup

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,7 @@ export default defineConfig([
     },
     plugins: { ix },
     rules: {
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' }],
       'ix/order': [
         'error',
         {

--- a/packages/broker-message/src/shared/helper/messages/message.ts
+++ b/packages/broker-message/src/shared/helper/messages/message.ts
@@ -16,6 +16,7 @@ import {
   EventTypeMetadataPredicate,
   TopicMetadataPredicate,
   IdsMetadataPredicate,
+  MessageMetadataSchema,
 } from './message.schema';
 
 /**
@@ -33,6 +34,8 @@ export class MessageMetadata {
   private schemaVersion = '1.0.0';
 
   public constructor(data: Partial<MetadataType> = {}) {
+    MessageMetadataSchema.partial().parse(data);
+
     const { topic, routing, delivery, security, eventType, publisher, causationId, correlationId } =
       data;
 

--- a/packages/broker-message/tests/unit/message-metadata.spec.ts
+++ b/packages/broker-message/tests/unit/message-metadata.spec.ts
@@ -22,6 +22,12 @@ describe('MessageMetadata', () => {
       expect(m).toBeInstanceOf(MessageMetadata);
     });
 
+    it('should throw on invalid data', () => {
+      expect(
+        () => new MessageMetadata({ topic: '' } as any)
+      ).toThrow();
+    });
+
     it('should accept partial data', () => {
       const withData = new MessageMetadata({
         topic: 'test.event.created',

--- a/packages/common/src/middleware/catch-error.ts
+++ b/packages/common/src/middleware/catch-error.ts
@@ -33,7 +33,7 @@ export const catchSync =
   ) =>
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const result = await Promise.resolve(errorFunction(req, res, next));
+      const result = await errorFunction(req, res, next);
       if (result && typeof result === 'object' && 'status' in result) {
         res
           .status(result.status)

--- a/services/financial-scraper/src/job/cron/binance.cron.ts
+++ b/services/financial-scraper/src/job/cron/binance.cron.ts
@@ -65,7 +65,7 @@ export class BinanceCronOrchestrator {
             err: err.message,
           });
         } else {
-          logger.error('[BinanceCron] Unknown batch execution error');
+          logger.error('[BinanceCron] Unknown batch execution error:', { err: String(err) });
         }
       } finally {
         this.isRunning = false;

--- a/services/financial-scraper/src/job/worker/binance.worker.ts
+++ b/services/financial-scraper/src/job/worker/binance.worker.ts
@@ -15,7 +15,7 @@
 import { createHash } from 'node:crypto';
 
 import { helper } from '@trading-model/broker-message';
-import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
+import { DeliveryMode, DeliveryModeEnum } from '@trading-model/common/config/delivery-mode.types';
 import { EnumEventMessage } from '@trading-model/common/config/event.types';
 import { ServiceInstanceName } from '@trading-model/common/config/services.types';
 import { deterministicStringify } from '@trading-model/common/utils/deterministic-stringify';
@@ -39,6 +39,7 @@ export interface BinanceWorkerOptions {
   candleLimit?: number;
   tradeLimit?: number;
   orderBookLimit?: number;
+  deliveryMode?: DeliveryModeEnum;
 }
 
 /** Normalized market data returned by a BinanceWorker execution, ready for persistence. */
@@ -104,7 +105,7 @@ export class BinanceWorker {
 
     builderMetadata
       .setDelivery({
-        mode: DeliveryMode.AT_LEAST_ONCE,
+        mode: this.options.deliveryMode ?? DeliveryMode.AT_LEAST_ONCE,
         deduplicationId: uuidv4(),
       })
       .setEventType('FetchCandlestick')

--- a/services/financial-scraper/tests/unit/job/cron/binance.cron.spec.ts
+++ b/services/financial-scraper/tests/unit/job/cron/binance.cron.spec.ts
@@ -161,7 +161,7 @@ describe('BinanceCronOrchestrator', () => {
       mockWorkerRun.mockRejectedValue('String error' as never);
 
       await expect(cronHandler()).resolves.toBeUndefined();
-      expect(mockLogger.error).toHaveBeenCalledWith('[BinanceCron] Unknown batch execution error');
+      expect(mockLogger.error).toHaveBeenCalledWith('[BinanceCron] Unknown batch execution error:', { err: 'String error' });
     });
 
     it('should reset isRunning after execution', async () => {

--- a/services/message-manager/src/messaging/core/broker.ts
+++ b/services/message-manager/src/messaging/core/broker.ts
@@ -86,7 +86,7 @@ export class Broker {
       metadata: {
         ...metadata,
         emittedAt: new Date(),
-        messageId: String(randomUUID()),
+        messageId: randomUUID(),
       },
       payload,
     };

--- a/services/trader-trainer/src/core/agent/state-manager.ts
+++ b/services/trader-trainer/src/core/agent/state-manager.ts
@@ -45,7 +45,6 @@ export class StateManager {
       try {
         agent.nn.setWeights(genome);
       } catch (_e) {
-        void _e;
         agent.nn.distributeAroundWeights(0, 0.01);
       }
     }

--- a/services/trader-trainer/src/core/agent/trading-agent.ts
+++ b/services/trader-trainer/src/core/agent/trading-agent.ts
@@ -57,7 +57,6 @@ export class TradingAgent {
     price?: number,
     _done: boolean = false
   ): { action: string; reward: number; metrics: Record<string, unknown> } {
-    void _done;
     if (price !== undefined) this.wallet.setPrice(price);
 
     const currentPnL = this.wallet.getPnL();

--- a/services/trader-trainer/src/core/genetic-algorithm/evolution-engine.ts
+++ b/services/trader-trainer/src/core/genetic-algorithm/evolution-engine.ts
@@ -64,7 +64,6 @@ export function selectParent(
  * Mutates network architecture (layers, neurons, activation functions).
  */
 export function mutateGenome(g: Genome, _rng: () => number): Genome {
-  void _rng;
   // Placeholder: implement structural mutations
   // - add/remove hidden layer
   // - change layer size
@@ -78,8 +77,6 @@ export function mutateGenome(g: Genome, _rng: () => number): Genome {
  * Blends network architectures from two parents.
  */
 export function crossoverGenomes(pA: Genome, _pB: Genome, _rng: () => number): Genome {
-  void _pB;
-  void _rng;
   // Placeholder: implement structural crossover
   // - blend layer counts
   // - blend neuron counts

--- a/services/trader-trainer/src/core/genetic-algorithm/factory.ts
+++ b/services/trader-trainer/src/core/genetic-algorithm/factory.ts
@@ -22,7 +22,6 @@ export function createDefaultGenome(
   generation = 0,
   _rng?: () => number // reserved for future stochastic factories
 ): Genome {
-  void _rng;
   const network: NetworkGenome = {
     inputDim: 32,
     outputDim: 3,

--- a/services/trader-trainer/src/core/genetic-algorithm/ga-runner.ts
+++ b/services/trader-trainer/src/core/genetic-algorithm/ga-runner.ts
@@ -125,8 +125,6 @@ export function makeTradingAgentBackend(g: DeepReadonly<LamarckGenome>): RLBacke
       agent.agent.nn.setWeights(new Float32Array(g.trainedWeights));
     } catch (_) {
       /* architecture mismatch after structural mutation — start fresh */
-      /* istanbul ignore next */
-      void _;
     }
   }
 
@@ -138,8 +136,7 @@ export function makeTradingAgentBackend(g: DeepReadonly<LamarckGenome>): RLBacke
       try {
         agent.agent.learnQLearning(e, γ);
       } catch (_) {
-        /* istanbul ignore next */
-        void _;
+        /* Q-learning error skipped — continue training */
       }
     },
     getWeights: () => agent.agent.nn.getWeights(),

--- a/services/trader-trainer/src/core/genetic-algorithm/validation.ts
+++ b/services/trader-trainer/src/core/genetic-algorithm/validation.ts
@@ -314,7 +314,6 @@ export function repairGenome(g: Genome): Genome {
 }
 
 function repairLayer(l: LayerGenome, _index: number): LayerGenome {
-  void _index;
   return {
     neurons: Math.max(1, Math.round(l.neurons ?? 32)),
     activation: VALID_ACTIVATIONS.has(l.activation) ? l.activation : 'ReLu',

--- a/services/trader-trainer/src/core/neural-network/optimizer.ts
+++ b/services/trader-trainer/src/core/neural-network/optimizer.ts
@@ -63,7 +63,6 @@ export const OPTIMIZERS: Record<OptimizerType, Optimizer> = {
   // Stochastic Gradient Descent
   sgd: {
     initState: (_size: number): OptimizerState => {
-      void _size;
       return { t: 0 };
     },
 


### PR DESCRIPTION
﻿# Description

Batch of targeted code quality fixes addressing 5 issues from the code quality audit covering input validation, error logging, configurability, and code cleanup.

## Type of Change

- [x] :bug: fix — Bug fix
- [x] :recycle: refactor — Code restructuring
- [x] :white_check_mark: test — Tests
- [x] :wrench: chore — Configuration

## Changes

### ✅ Additions

- `MessageMetadataSchema.partial().parse(data)` in `MessageMetadata` constructor for early input validation
- `deliveryMode` option in `BinanceWorkerOptions` for configurable message delivery semantics
- Test for invalid constructor data in `MessageMetadata`
- ESLint `argsIgnorePattern` and `caughtErrorsIgnorePattern` for underscore-prefixed unused params

### :recycle: Modifications

- `binance.cron.ts` — log the original error value in the unknown batch error branch, not just a generic message
- `binance.worker.ts` — use `this.options.deliveryMode` or default to `AT_LEAST_ONCE`
- `broker.ts` — remove redundant `String()` wrapping around `randomUUID()`
- `catch-error.ts` — replace `await Promise.resolve(errorFunction(...))` with `await errorFunction(...)`
- `trading-agent.ts`, `validation.ts`, `factory.ts`, `evolution-engine.ts`, `state-manager.ts`, `optimizer.ts`, `ga-runner.ts` — remove `void` silencing lines from underscore-prefixed parameters
- `eslint.config.mjs` — add `@typescript-eslint/no-unused-vars` rule with underscore ignore patterns

### :fire: Removals

- Redundant `void silence` lines from 7 files across trader-trainer
- Unnecessary `String()` wrapping in broker.ts
- Unnecessary `Promise.resolve()` wrapping in catch-error.ts middleware

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Tests

- [x] Existing tests pass
- [x] New tests added
- [x] `npm run test:coverage` — All 7 workspaces at 100%

## Checklist

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — Success
- [x] `npm test` — All tests pass

## Closes Issues

Closes #145
Closes #146
Closes #147
Closes #148
Closes #149

## Additional Notes

Part of the code quality audit initiative (#80).
