### PR TITLE
:recycle: :white_check_mark: code quality batch #7 — JSDoc cleanup, health checks, SRP refactor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,11 @@ services:
       - ${TLS_CERTS_DIR:-./certs}:/certs:ro
     networks:
       - trading-net
+    healthcheck:
+      test: curl -sk --cert /certs/server.crt --key /certs/server-key.pem https://localhost:3000/ping || exit 1
+      interval: 15s
+      timeout: 5s
+      retries: 3
     depends_on:
       mongo:
         condition: service_healthy
@@ -162,7 +167,7 @@ services:
       discovery-server:
         condition: service_healthy
       message-manager:
-        condition: service_started
+        condition: service_healthy
 
   # ---------------------------------------------------------------------------
   #  Trader Trainer — GA + DQN agent evolution
@@ -206,11 +211,16 @@ services:
       - ${TLS_CERTS_DIR:-./certs}:/certs:ro
     networks:
       - trading-net
+    healthcheck:
+      test: curl -sk --cert /certs/server.crt --key /certs/server-key.pem https://localhost:3000/ping || exit 1
+      interval: 15s
+      timeout: 5s
+      retries: 3
     depends_on:
       discovery-server:
         condition: service_healthy
       message-manager:
-        condition: service_started
+        condition: service_healthy
 
 networks:
   trading-net:

--- a/packages/common/src/middleware/response-protocol.ts
+++ b/packages/common/src/middleware/response-protocol.ts
@@ -9,7 +9,7 @@ type ErrorInput = Error | ResponseObject;
 /**
  * Maps domain / technical errors to standardized HTTP responses.
  *
- * This function acts as the single translation layer between
+ * Acts as the single translation layer between
  * internal error types and external HTTP representations.
  */
 function mapErrorToResponse(err: Error): ResponseObject {
@@ -38,24 +38,35 @@ function mapErrorToResponse(err: Error): ResponseObject {
 }
 
 /**
+ * Log server-side errors (HTTP 5xx) with request context.
+ *
+ * Separated from the response middleware to isolate the logging concern.
+ */
+function logServerError(err: ErrorInput, req: Request, response: ResponseObject): void {
+  if (response.status >= 500) {
+    const originalError = err instanceof Error ? err : undefined;
+    logger.error('Server error', {
+      message: originalError?.message,
+      stack: originalError?.stack,
+      url: req.originalUrl,
+      method: req.method,
+      ip: req.ip,
+    });
+  }
+}
+
+/**
  * Global Express error-handling middleware.
  *
- * This middleware standardizes all outgoing JSON error responses and logs
- * critical server-side errors (HTTP 5xx) for monitoring and debugging purposes.
+ * Composes three concerns:
+ *  1. Error mapping (`mapErrorToResponse`) — domain → HTTP response
+ *  2. Server error logging (`logServerError`) — 5xx monitoring
+ *  3. Response sending — standardized JSON output
  *
- * Features:
- *  - Converts unstructured errors into a consistent JSON format using
- *    `ClassResponseExceptions`.
- *  - Logs server errors (status >= 500) with full stack trace and request context.
- *  - Sends the standardized response to the client with the correct HTTP status.
- *
- * @param err - The error caught in the request pipeline, either an instance
- *              of `Error` or a pre-formatted response object.
- * @param req - Express request object, used for logging request details.
- * @param res - Express response object, used to send the final standardized response.
- * @param next - Express next function; included for middleware compliance.
- *
- * @returns The standardized JSON error response sent to the client.
+ * @param err - The error caught in the request pipeline.
+ * @param req - Express request object.
+ * @param res - Express response object.
+ * @param next - Express next function.
  *
  * @example
  * app.use(ResponseProtocole);
@@ -66,36 +77,9 @@ export const ResponseProtocole = (
   res: Response,
   next: NextFunction
 ) => {
-  let response: ResponseObject;
-  let originalError: Error | undefined;
+  const response = err instanceof Error ? mapErrorToResponse(err) : err;
 
-  /**
-   * Case 1:
-   * Error already formatted as a response object
-   */
-  if (!(err instanceof Error)) {
-    response = err;
-  } else {
-    /**
-     * Case 2:
-     * Standard Error → mapped via domain translation
-     */
-    originalError = err;
-    response = mapErrorToResponse(err);
-  }
-
-  /**
-   * Log only server-side errors (5xx)
-   */
-  if (response.status >= 500) {
-    logger.error('Server error', {
-      message: originalError?.message,
-      stack: originalError?.stack,
-      url: req.originalUrl,
-      method: req.method,
-      ip: req.ip,
-    });
-  }
+  logServerError(err, req, response);
 
   res.status(response.status).type('json').send(response.data);
   next();

--- a/packages/common/tests/unit/response-protocol.spec.ts
+++ b/packages/common/tests/unit/response-protocol.spec.ts
@@ -63,6 +63,12 @@ describe('ResponseProtocole', () => {
     expect(res.send).toHaveBeenCalledWith('teapot');
   });
 
+  it('should log server error for pre-formatted 500 response', () => {
+    const err = { status: 500, data: 'Internal error' };
+    ResponseProtocole(err as any, req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
   it('should call next() after sending response', () => {
     const err = new Error('test');
     ResponseProtocole(err, req, res, next);

--- a/services/message-manager/src/config/message-manager.ts
+++ b/services/message-manager/src/config/message-manager.ts
@@ -24,12 +24,6 @@
  * @architecture
  * Infrastructure / integration layer.
  * This module wires the messaging broker into the HTTP server.
- *
- * @author docteur-turboss
- *
- * @version 1.0.0
- *
- * @since 2026.01.28
  */
 
 import { env } from './env';

--- a/services/message-manager/src/messaging/core/broker.ts
+++ b/services/message-manager/src/messaging/core/broker.ts
@@ -22,12 +22,6 @@
  * Application / messaging layer.
  * This class exposes the public API of the messaging system and delegates
  * all delivery responsibilities to the dispatcher.
- *
- * @author docteur-turboss
- *
- * @version 1.0.0
- *
- * @since 2026.01.28
  */
 
 import { randomUUID } from 'node:crypto';

--- a/services/message-manager/src/messaging/core/dispatcher.ts
+++ b/services/message-manager/src/messaging/core/dispatcher.ts
@@ -28,14 +28,6 @@
  * Messaging / application layer component.
  * This class acts as an in-memory dispatcher and delegates
  * actual delivery to `Subscription` instances.
- *
- * @author docteur-turboss
- *
- * @version
- * 1.0.0
- *
- * @since
- * 2026.01.28
  */
 
 import { HttpClient } from '@trading-model/common/config/http-client';

--- a/services/message-manager/src/messaging/core/subscription.ts
+++ b/services/message-manager/src/messaging/core/subscription.ts
@@ -20,12 +20,6 @@
  * @architecture
  * Infrastructure / messaging layer component.
  * Acts as a delivery orchestrator for the Broker service.
- *
- * @author docteur-turboss
- *
- * @version 1.0.0
- *
- * @since 2026.01.28
  */
 import { DeliveryMode } from '@trading-model/common/config/delivery-mode.types';
 import { HttpClient } from '@trading-model/common/config/http-client';

--- a/services/message-manager/src/messaging/index.ts
+++ b/services/message-manager/src/messaging/index.ts
@@ -22,12 +22,6 @@
  * - `Dispatcher` → manages subscriptions and message delivery
  * - `Broker` → exposes publish/subscribe API
  * - `BrokerRoutes` → maps HTTP endpoints to broker actions
- *
- * @author docteur-turboss
- *
- * @version 1.0.0
- *
- * @since 2026.01.28
  */
 import { Application } from 'express';
 

--- a/services/message-manager/src/messaging/transport/http.controller.ts
+++ b/services/message-manager/src/messaging/transport/http.controller.ts
@@ -24,12 +24,6 @@
  * @architecture
  * Layer connecting the **core Broker** to HTTP endpoints.
  * No business logic is performed here; purely request/response orchestration.
- *
- * @author docteur-turboss
- *
- * @version 1.0.0
- *
- * @since 2026.01.28
  */
 
 import { catchSync } from '@trading-model/common/middleware/catch-error';

--- a/services/message-manager/src/messaging/transport/http.routes.ts
+++ b/services/message-manager/src/messaging/transport/http.routes.ts
@@ -19,12 +19,6 @@
  * @architecture
  * Part of the **API layer** in the broker system.
  * Delegates all logic to controllers and Broker core services.
- *
- * @author docteur-turboss
- *
- * @version 1.0.0
- *
- * @since 2026.01.28
  */
 
 import { Router } from 'express';

--- a/services/message-manager/src/messaging/transport/validation/broker.schema.ts
+++ b/services/message-manager/src/messaging/transport/validation/broker.schema.ts
@@ -18,12 +18,6 @@
  * @architecture
  * Utility module used by the broker layer.
  * Acts as a **data contract enforcement** component.
- *
- * @author docteur-turboss
- *
- * @version 1.0.0
- *
- * @since 2026.01.28
  */
 
 import { z } from 'zod';


### PR DESCRIPTION
﻿# Description

Batch of targeted code quality fixes addressing 3 issues from the code quality audit covering JSDoc cleanup, Docker health checks, and SRP refactoring.

## Type of Change

- [x] :recycle: refactor — Code restructuring
- [x] :white_check_mark: test — Tests

## Changes

### ✅ Additions

- `logServerError()` function in response-protocol.ts — isolated logging concern
- Healthcheck definitions for `message-manager` and `trader-trainer` services in docker-compose.yml
- Test for pre-formatted 500 ResponseObject in response-protocol.spec.ts

### :recycle: Modifications

- **8 files** in message-manager — removed stale @author, @version, @since JSDoc boilerplate tags
- **docker-compose.yml** — changed `condition: service_started` to `condition: service_healthy` for message-manager and trader-trainer dependencies
- **response-protocol.ts** — extracted logging into `logServerError()` function, simplified middleware to compose three clear concerns (mapping, logging, response)

### :fire: Removals

- Stale JSDoc boilerplate tags (@author, @version, @since) from 8 message-manager files
- Redundant `originalError` variable and inline logging block in response-protocol middleware

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Tests

- [x] Existing tests pass
- [x] New tests added
- [x] `npm run test:coverage` — All 7 workspaces at 100%

## Checklist

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — Success
- [x] `npm test` — All tests pass

## Closes Issues

Closes #150
Closes #152
Closes #153

## Additional Notes

Part of the code quality audit initiative (#80).
