### PR TITLE
:bug:(middleware): fix LSP violation AddressManagerBaseError + :recycle:(trainer,common): ISP NeuralNetworkConfig and SRP bootstrap

### DIFF
--- a/docs/architecture/api/common.md
+++ b/docs/architecture/api/common.md
@@ -39,7 +39,7 @@ Features:
 
 ## Bootstrap
 
-Lifecycle manager for services.
+Lifecycle manager for services. Signal handling is delegated to a separate module (`signal-handler.ts`) to respect SRP.
 
 - **Import**: `@trading-model/common/server/bootstrap`
 - **Function**: `createBootstrap(options)`
@@ -57,10 +57,24 @@ import { createBootstrap } from '@trading-model/common/server/bootstrap';
 
 Features:
 
-- Attaches `SIGTERM`, `SIGINT` handlers
-- Captures `uncaughtException` and `unhandledRejection`
+- Delegates `SIGTERM`, `SIGINT`, `uncaughtException`, and `unhandledRejection` handling to `setupProcessHandlers()`
 - `onStart` and `onStop` callbacks wrapped in try/catch — failures are logged and do not crash the process
 - Graceful shutdown on fatal error: closes HTTP server and calls `onStop` before exit
+
+## SignalHandler
+
+Process signal and error handler registration, extracted from bootstrap for SRP.
+
+- **Import**: `@trading-model/common/server/signal-handler`
+
+```ts
+import { setupProcessHandlers, removeProcessHandlers } from '@trading-model/common/server/signal-handler';
+```
+
+| Function                  | Description                                      |
+| ------------------------- | ------------------------------------------------ |
+| `setupProcessHandlers`    | Registers SIGTERM, SIGINT, uncaughtException, unhandledRejection handlers |
+| `removeProcessHandlers`   | Removes all registered handlers (test cleanup)    |
 
 ## SecureServer
 

--- a/docs/architecture/api/trader-trainer.md
+++ b/docs/architecture/api/trader-trainer.md
@@ -84,10 +84,20 @@ Data is stored in a `MarketDataBuffer` (configurable window via `TRAINER_DATA_WI
 
 ## Neural Network
 
-- Configurable architecture (layers, neurons per layer)
+Configurable via `NeuralNetworkConfig` (a composition of focused interfaces per ISP):
+
+| Interface               | Properties                                      |
+| ----------------------- | ----------------------------------------------- |
+| `NetworkArchitecture`   | neuronsByLayer, activationType, connectionType, normalisationType, normalizedInputRange, enablePool, poolMaxSize |
+| `LossConfig`            | lossFunctionType, deltaHuber |
+| `OptimizerConfig`       | optimizerType, optimizerHyperparams, learningRate, gradientClipNorm |
+| `InitializationConfig`  | initialisationType, useBias, biasInitialisationType |
+| `MutationConfig`        | biasMutationScale, weightMutationScale |
+
 - Activation functions: ReLU, sigmoid, tanh, etc.
 - Optimisers: Adam, SGD, etc.
 - Weights encoded in the genetic algorithm genome
+- `Agent` accepts `NetworkArchitecture` only (ISP) and passes through to `NeuralNetwork`
 
 ## Environment Variables (TRAINER\_\*)
 

--- a/packages/common/src/middleware/response-protocol.ts
+++ b/packages/common/src/middleware/response-protocol.ts
@@ -28,7 +28,7 @@ function mapErrorToResponse(err: Error): ResponseObject {
           err.code === ErrorCodes.ADDRESS_MANAGER_ERROR ||
           err.code.startsWith('ADDRESS_MANAGER_')
         ) {
-          return response.UnknownError();
+          return response.ServiceUnavailable();
         }
         break;
     }

--- a/packages/common/src/server/bootstrap.ts
+++ b/packages/common/src/server/bootstrap.ts
@@ -1,4 +1,5 @@
 import { HttpServer } from './create-secure-server';
+import { setupProcessHandlers } from './signal-handler';
 import { logger } from '../config/logger';
 
 /** Options for configuring a service bootstrap lifecycle. */
@@ -10,7 +11,8 @@ export interface BootstrapOptions {
 }
 
 /**
- * Initializes and starts a service, binding process-level shutdown handlers.
+ * Initializes and starts a service, delegating process signal management to
+ * {@link setupProcessHandlers} (SRP).
  * Returns handles to the running server and a shutdown trigger.
  */
 export function createBootstrap(options: BootstrapOptions): {
@@ -88,18 +90,7 @@ export function createBootstrap(options: BootstrapOptions): {
     }
   }
 
-  process.on('SIGTERM', shutdown);
-  process.on('SIGINT', shutdown);
-
-  process.on('uncaughtException', error => {
-    logger.error('Uncaught exception - exiting', { err: error });
-    hardShutdown(1);
-  });
-
-  process.on('unhandledRejection', reason => {
-    logger.error('Unhandled promise rejection - exiting', { reason });
-    hardShutdown(1);
-  });
+  setupProcessHandlers(shutdown, hardShutdown);
 
   bootstrap();
 

--- a/packages/common/src/server/signal-handler.ts
+++ b/packages/common/src/server/signal-handler.ts
@@ -1,0 +1,66 @@
+import { logger } from '../config/logger';
+
+/** Callback signature for graceful shutdown. */
+export type ShutdownHandler = (signal: string) => Promise<void>;
+
+/** Callback signature for forced shutdown. */
+export type HardShutdownHandler = (code: number) => void;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SignalListener = (...args: any[]) => void;
+
+/** Tracks registered signal listeners for cleanup. */
+const registeredSignals = new Map<string, SignalListener>();
+
+/**
+ * Registers process-level signal and error handlers.
+ * Separated from the bootstrap lifecycle to respect SRP.
+ *
+ * @param shutdown  - Graceful shutdown handler (SIGTERM, SIGINT).
+ * @param hardShutdown - Forced shutdown handler (uncaughtException, unhandledRejection).
+ */
+export function setupProcessHandlers(
+  shutdown: ShutdownHandler,
+  hardShutdown: HardShutdownHandler
+): void {
+  const onSigTerm = async () => {
+    logger.warn('SIGTERM received');
+    await shutdown('SIGTERM');
+  };
+
+  const onSigInt = async () => {
+    logger.warn('SIGINT received');
+    await shutdown('SIGINT');
+  };
+
+  const onUncaughtException = (error: Error) => {
+    logger.error('Uncaught exception - exiting', { err: error });
+    hardShutdown(1);
+  };
+
+  const onUnhandledRejection = (reason: unknown) => {
+    logger.error('Unhandled promise rejection - exiting', { reason });
+    hardShutdown(1);
+  };
+
+  process.on('SIGTERM', onSigTerm);
+  process.on('SIGINT', onSigInt);
+  process.on('uncaughtException', onUncaughtException);
+  process.on('unhandledRejection', onUnhandledRejection);
+
+  registeredSignals.set('SIGTERM', onSigTerm);
+  registeredSignals.set('SIGINT', onSigInt);
+  registeredSignals.set('uncaughtException', onUncaughtException);
+  registeredSignals.set('unhandledRejection', onUnhandledRejection);
+}
+
+/**
+ * Removes all registered process handlers.
+ * Useful for test cleanup to avoid side effects between tests.
+ */
+export function removeProcessHandlers(): void {
+  for (const [signal, handler] of registeredSignals) {
+    process.removeListener(signal, handler);
+  }
+  registeredSignals.clear();
+}

--- a/packages/common/tests/unit/bootstrap.spec.ts
+++ b/packages/common/tests/unit/bootstrap.spec.ts
@@ -11,6 +11,7 @@ jest.mock('../../src/config/logger', () => ({
 }));
 
 import { createBootstrap } from '../../src/server/bootstrap';
+import { removeProcessHandlers } from '../../src/server/signal-handler';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -24,6 +25,7 @@ describe('createBootstrap', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    removeProcessHandlers();
   });
 
   it('should create server and call onStart', () => {

--- a/packages/common/tests/unit/response-protocol.spec.ts
+++ b/packages/common/tests/unit/response-protocol.spec.ts
@@ -38,10 +38,10 @@ describe('ResponseProtocole', () => {
     expect(res.status).toHaveBeenCalledWith(498);
   });
 
-  it('should map ADDRESS_MANAGER_ERROR to 500', () => {
+  it('should map ADDRESS_MANAGER_ERROR to 503', () => {
     const err = new AppError('Generic error', ErrorCodes.ADDRESS_MANAGER_ERROR);
     ResponseProtocole(err, req, res, next);
-    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.status).toHaveBeenCalledWith(503);
   });
 
   it('should map unknown errors to 500', () => {

--- a/packages/common/tests/unit/signal-handler.spec.ts
+++ b/packages/common/tests/unit/signal-handler.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+jest.mock('../../src/config/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+  _private: class {},
+}));
+
+import { setupProcessHandlers, removeProcessHandlers } from '../../src/server/signal-handler';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('signal-handler', () => {
+  let processOnSpy: any;
+  let removeListenerSpy: any;
+
+  beforeEach(() => {
+    jest.spyOn(process, 'exit').mockImplementation((() => undefined) as any);
+    processOnSpy = jest.spyOn(process, 'on').mockImplementation(() => process as any);
+    removeListenerSpy = jest
+      .spyOn(process, 'removeListener')
+      .mockImplementation(() => process as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    removeProcessHandlers();
+  });
+
+  it('should register SIGTERM handler', () => {
+    setupProcessHandlers(jest.fn() as any, jest.fn() as any);
+    expect(processOnSpy).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+  });
+
+  it('should register SIGINT handler', () => {
+    setupProcessHandlers(jest.fn() as any, jest.fn() as any);
+    expect(processOnSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+  });
+
+  it('should register uncaughtException handler', () => {
+    setupProcessHandlers(jest.fn() as any, jest.fn() as any);
+    expect(processOnSpy).toHaveBeenCalledWith('uncaughtException', expect.any(Function));
+  });
+
+  it('should register unhandledRejection handler', () => {
+    setupProcessHandlers(jest.fn() as any, jest.fn() as any);
+    expect(processOnSpy).toHaveBeenCalledWith('unhandledRejection', expect.any(Function));
+  });
+
+  it('should remove all handlers on cleanup', () => {
+    setupProcessHandlers(jest.fn() as any, jest.fn() as any);
+    removeProcessHandlers();
+    expect(removeListenerSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('should call shutdown on SIGTERM via captured handler', async () => {
+    const shutdown: any = jest.fn();
+    setupProcessHandlers(shutdown, jest.fn() as any);
+
+    const sigtermCall = processOnSpy.mock.calls.find(
+      (c: unknown[]) => (c as unknown[])[0] === 'SIGTERM'
+    );
+    const handler: () => Promise<void> = (
+      sigtermCall ? (sigtermCall as unknown[])[1] : undefined
+    ) as any;
+
+    expect(handler).toBeDefined();
+    await handler();
+    expect(shutdown).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('should call shutdown on SIGINT via captured handler', async () => {
+    const shutdown: any = jest.fn();
+    setupProcessHandlers(shutdown, jest.fn() as any);
+
+    const sigintCall = processOnSpy.mock.calls.find(
+      (c: unknown[]) => (c as unknown[])[0] === 'SIGINT'
+    );
+    const handler: () => Promise<void> = (
+      sigintCall ? (sigintCall as unknown[])[1] : undefined
+    ) as any;
+
+    expect(handler).toBeDefined();
+    await handler();
+    expect(shutdown).toHaveBeenCalledWith('SIGINT');
+  });
+
+  it('should call hardShutdown on uncaughtException via captured handler', () => {
+    const hardShutdown = jest.fn();
+    setupProcessHandlers(jest.fn() as any, hardShutdown as any);
+
+    const uncaughtCall = processOnSpy.mock.calls.find(
+      (c: unknown[]) => (c as unknown[])[0] === 'uncaughtException'
+    );
+    const handler: (err: Error) => void = (
+      uncaughtCall ? (uncaughtCall as unknown[])[1] : undefined
+    ) as any;
+
+    expect(handler).toBeDefined();
+    handler(new Error('crash'));
+    expect(hardShutdown).toHaveBeenCalledWith(1);
+  });
+
+  it('should call hardShutdown on unhandledRejection via captured handler', () => {
+    const hardShutdown = jest.fn();
+    setupProcessHandlers(jest.fn() as any, hardShutdown as any);
+
+    const rejectionCall = processOnSpy.mock.calls.find(
+      (c: unknown[]) => (c as unknown[])[0] === 'unhandledRejection'
+    );
+    const handler: (reason: unknown) => void = (
+      rejectionCall ? (rejectionCall as unknown[])[1] : undefined
+    ) as any;
+
+    expect(handler).toBeDefined();
+    handler(new Error('rejected'));
+    expect(hardShutdown).toHaveBeenCalledWith(1);
+  });
+});

--- a/services/trader-trainer/src/core/neural-network/agent.ts
+++ b/services/trader-trainer/src/core/neural-network/agent.ts
@@ -1,7 +1,7 @@
 import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
 
 import { NeuralNetwork } from './neural-network';
-import { Experience, NeuralNetworkConfig } from './type';
+import { Experience, NetworkArchitecture, NeuralNetworkConfig } from './type';
 
 /**
  * High-level agent that wraps a {@link NeuralNetwork} and adds:
@@ -41,11 +41,10 @@ export class Agent {
   private readonly enablePool: boolean;
 
   /**
-   * @param cfg - Full network configuration forwarded to {@link NeuralNetwork}.
-   *   `enablePool` and `poolMaxSize` are consumed by the agent layer;
-   *   everything else is forwarded verbatim.
+   * @param cfg - Architecture settings consumed by the agent layer;
+   *   forwarded to {@link NeuralNetwork} with defaults for the rest.
    */
-  constructor(private readonly cfg: NeuralNetworkConfig) {
+  constructor(private readonly cfg: NetworkArchitecture) {
     if (cfg.neuronsByLayer.length < 2)
       throw new AppError(
         'neuronsByLayer must contain at least 2 entries (input + output).',
@@ -54,7 +53,7 @@ export class Agent {
 
     this.enablePool = cfg.enablePool ?? true;
     this.poolMaxSize = cfg.poolMaxSize ?? 10_000;
-    this.nn = new NeuralNetwork(cfg);
+    this.nn = new NeuralNetwork(cfg as NeuralNetworkConfig);
   }
 
   /**

--- a/services/trader-trainer/src/core/neural-network/losses.ts
+++ b/services/trader-trainer/src/core/neural-network/losses.ts
@@ -1,4 +1,4 @@
-import { LossFunctionType, NeuralNetworkConfig } from './type';
+import { LossConfig, LossFunctionType } from './type';
 
 const EPSILON = 1e-10;
 
@@ -18,10 +18,10 @@ export interface LossDefinition {
    *
    * @param output - Network output activations.
    * @param target - Expected target values.
-   * @param config - Network configuration.
+   * @param config - Loss configuration.
    * @returns The scalar loss value.
    */
-  loss(output: Float32Array, target: Float32Array, config: Required<NeuralNetworkConfig>): number;
+  loss(output: Float32Array, target: Float32Array, config: Required<LossConfig>): number;
 
   /**
    * Compute the gradient of the loss with respect to the network output.
@@ -29,14 +29,10 @@ export interface LossDefinition {
    *
    * @param output - Network output activations.
    * @param target - Expected target values.
-   * @param config - Network configuration.
+   * @param config - Loss configuration.
    * @returns Gradient array of the same length as output.
    */
-  gradient(
-    output: Float32Array,
-    target: Float32Array,
-    config: Required<NeuralNetworkConfig>
-  ): Float32Array;
+  gradient(output: Float32Array, target: Float32Array, config: Required<LossConfig>): Float32Array;
 }
 
 export const LOSSES: Record<LossFunctionType, LossDefinition> = {

--- a/services/trader-trainer/src/core/neural-network/type.ts
+++ b/services/trader-trainer/src/core/neural-network/type.ts
@@ -35,11 +35,8 @@ export type ConnectionType = 'fully-connected' | 'dense-skip' | 'residual-connec
 export type InitialisationType = 'zeros' | 'leCun' | 'he' | 'xavier' | 'random';
 export type OptimizerType = 'sgd' | 'adam' | 'rmsprop';
 
-/**
- * Full set of hyperparameters required to build an NeuralNetwork.
- */
-
-export interface NeuralNetworkConfig {
+/** Network topology and layer configuration. */
+export interface NetworkArchitecture {
   /** Number of neurons per layer, from input to output. */
   neuronsByLayer: number[];
 
@@ -48,12 +45,6 @@ export interface NeuralNetworkConfig {
 
   /** How to connect layers. */
   connectionType?: ConnectionType;
-
-  /** Strategy used to initialise weight matrices. */
-  initialisationType?: InitialisationType;
-
-  /** Loss function used during backpropagation. */
-  lossFunctionType?: LossFunctionType;
 
   /** Normalisation applied to the input vector before the forward pass. */
   normalisationType?: NormalisationType;
@@ -65,11 +56,51 @@ export interface NeuralNetworkConfig {
    */
   normalizedInputRange?: [number, number];
 
-  /** Step size used during gradient descent. @default 0.1 */
-  learningRate?: number;
+  /**
+   * Enable the experience replay pool.
+   * When `false` the pool is never populated and no memory is allocated for it.
+   * @default true
+   */
+  enablePool?: boolean;
+
+  /** Maximum number of experiences kept in the pool (FIFO). @default 10_000 */
+  poolMaxSize?: number;
+}
+
+/** Hyperparameters controlling the loss computation. */
+export interface LossConfig {
+  /** Loss function used during backpropagation. */
+  lossFunctionType?: LossFunctionType;
 
   /** Delta threshold for Huber loss. @default 1 */
   deltaHuber?: number;
+}
+
+/** Hyperparameters controlling the optimisation loop. */
+export interface OptimizerConfig {
+  /**
+   * Which optimizer to use for weight updates.
+   * @default "sgd"
+   */
+  optimizerType?: OptimizerType;
+
+  /**
+   * Overrides for optimizer hyperparameters (beta1, beta2, epsilon).
+   * Unset fields fall back to DEFAULT_HYPERPARAMS.
+   */
+  optimizerHyperparams?: Partial<OptimizerHyperparams>;
+
+  /** Step size used during gradient descent. @default 0.1 */
+  learningRate?: number;
+
+  /** Norm used to clip gradients during backpropagation. @default 5.0 */
+  gradientClipNorm?: number;
+}
+
+/** Weight and bias initialisation settings. */
+export interface InitializationConfig {
+  /** Strategy used to initialise weight matrices. */
+  initialisationType?: InitialisationType;
 
   /**
    * When `false` bias vectors are zeroed and never updated.
@@ -82,7 +113,10 @@ export interface NeuralNetworkConfig {
    * weights.  Falls back to `initialisationType` when omitted.
    */
   biasInitialisationType?: InitialisationType;
+}
 
+/** Mutation scale factors for genetic algorithm operators. */
+export interface MutationConfig {
   /**
    * Scale factor applied to bias mutations when calling Agent.mutate.
    * Weights use their own scale; biases can be mutated at a different rate.
@@ -95,32 +129,14 @@ export interface NeuralNetworkConfig {
    * @default 0.1
    */
   weightMutationScale?: number;
-
-  /**
-   * Enable the experience replay pool.
-   * When `false` the pool is never populated and no memory is allocated for it.
-   * @default true
-   */
-  enablePool?: boolean;
-
-  /** Maximum number of experiences kept in the pool (FIFO). @default 10_000 */
-  poolMaxSize?: number;
-
-  /** Norm used to clip gradients during backpropagation. @default 5.0 */
-  gradientClipNorm?: number;
-
-  /**
-   * Which optimizer to use for weight updates.
-   * @default "sgd"
-   */
-  optimizerType?: OptimizerType;
-
-  /**
-   * Overrides for optimizer hyperparameters (beta1, beta2, epsilon).
-   * Unset fields fall back to DEFAULT_HYPERPARAMS.
-   */
-  optimizerHyperparams?: Partial<OptimizerHyperparams>;
 }
+
+/**
+ * Full set of hyperparameters required to build an NeuralNetwork.
+ * Composes smaller focused interfaces (ISP).
+ */
+export interface NeuralNetworkConfig
+  extends NetworkArchitecture, LossConfig, OptimizerConfig, InitializationConfig, MutationConfig {}
 
 /**
  * A single experience tuple stored in the replay pool.

--- a/services/trader-trainer/tests/unit/agent/state-manager.spec.ts
+++ b/services/trader-trainer/tests/unit/agent/state-manager.spec.ts
@@ -6,11 +6,8 @@ function makeAgent(): Agent {
   return new Agent({
     neuronsByLayer: [4, 6, 3],
     activationType: ['ReLu', 'sigmoid'],
-    initialisationType: 'zeros',
-    lossFunctionType: 'mean-squared-error',
     normalisationType: 'none',
     connectionType: 'fully-connected',
-    learningRate: 0.01,
     enablePool: false,
   });
 }

--- a/services/trader-trainer/tests/unit/neural-network/agent.spec.ts
+++ b/services/trader-trainer/tests/unit/neural-network/agent.spec.ts
@@ -1,16 +1,13 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import { Agent } from '../../../src/core/neural-network/agent';
-import type { NeuralNetworkConfig } from '../../../src/core/neural-network/type';
+import type { NetworkArchitecture } from '../../../src/core/neural-network/type';
 
-function makeConfig(overrides?: Partial<NeuralNetworkConfig>): NeuralNetworkConfig {
+function makeConfig(overrides?: Partial<NetworkArchitecture>): NetworkArchitecture {
   return {
     neuronsByLayer: [4, 6, 3],
     activationType: ['ReLu', 'sigmoid'],
-    initialisationType: 'zeros',
-    lossFunctionType: 'mean-squared-error',
     normalisationType: 'none',
     connectionType: 'fully-connected',
-    learningRate: 0.01,
     enablePool: true,
     poolMaxSize: 100,
     ...overrides,
@@ -178,7 +175,7 @@ describe('Agent', () => {
 
   describe('learnSupervised', () => {
     it('should train on a single sample and remove it from pool', () => {
-      const agent = new Agent(makeConfig({ learningRate: 0.01 }));
+      const agent = new Agent(makeConfig());
       const input = new Float32Array([0.5, -0.3, 0.1, 0.8]);
       const target = new Float32Array([1, 0, 0]);
 
@@ -189,7 +186,7 @@ describe('Agent', () => {
     });
 
     it('should handle input not in pool without error', () => {
-      const agent = new Agent(makeConfig({ learningRate: 0.01 }));
+      const agent = new Agent(makeConfig());
       const input = new Float32Array([0.5, -0.3, 0.1, 0.8]);
       const target = new Float32Array([1, 0, 0]);
 
@@ -199,7 +196,7 @@ describe('Agent', () => {
 
   describe('learnFromPool', () => {
     it('should train on all pooled experiences with targets', () => {
-      const agent = new Agent(makeConfig({ learningRate: 0.01 }));
+      const agent = new Agent(makeConfig());
       const input = new Float32Array([0.5, -0.3, 0.1, 0.8]);
 
       agent.fastForward(input);
@@ -214,7 +211,7 @@ describe('Agent', () => {
     });
 
     it('should skip experiences without targets and clear pool', () => {
-      const agent = new Agent(makeConfig({ learningRate: 0.01 }));
+      const agent = new Agent(makeConfig());
       const input = new Float32Array([0.5, -0.3, 0.1, 0.8]);
 
       agent.fastForward(input);
@@ -230,7 +227,7 @@ describe('Agent', () => {
     let agent: Agent;
 
     beforeEach(() => {
-      agent = new Agent(makeConfig({ learningRate: 0.01 }));
+      agent = new Agent(makeConfig());
     });
 
     it('should throw when reward is missing', () => {


### PR DESCRIPTION
﻿# Description

Address three SOLID violations: LSP in error mapping (ADDRESS_MANAGER_ERROR → 503), ISP in NeuralNetworkConfig (split into 5 focused interfaces), SRP in bootstrap (extract signal handling).

## Type of Change

- [x] :bug: fix — Bug fix
- [x] :recycle: refactor — Code restructuring
- [x] :memo: docs — Documentation
- [x] :white_check_mark: test — Tests

## Changes

### ✅ Additions

- `packages/common/src/server/signal-handler.ts` — extracted process signal management (SRP)
- `packages/common/tests/unit/signal-handler.spec.ts` — 100% coverage for signal handlers

### :recycle: Modifications

- **#157**: `mapErrorToResponse` now maps `ADDRESS_MANAGER_ERROR` to **503 ServiceUnavailable** instead of 500 UnknownError, preserving the subtype semantics (LSP)
- **#156**: `NeuralNetworkConfig` split into `NetworkArchitecture`, `LossConfig`, `OptimizerConfig`, `InitializationConfig`, `MutationConfig` — consumers (`Agent`, `LossDefinition`) now only declare the interface they actually use (ISP)
- **#159**: `createBootstrap` delegates `SIGTERM`, `SIGINT`, `uncaughtException`, `unhandledRejection` handling to `setupProcessHandlers()` — bootstrap is now focused on server lifecycle (SRP)
- Updated `docs/architecture/api/common.md` and `docs/architecture/api/trader-trainer.md`

### :fire: Removals

- Inline `process.on(...)` calls removed from `bootstrap.ts` — replaced by delegation to `signal-handler.ts`

## Breaking Changes

- [ ] Yes
- [x] No

## Tests

- [x] Existing tests pass
- [x] New tests added for `signal-handler.ts`
- [x] 100% coverage across all workspaces

## Checklist

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — Success
- [x] `npm test` — All 556 tests pass

## Closes Issues

Closes #156
Closes #157
Closes #159
