### PR TITLE
:white_check_mark: test: add integration tests, regression tests, and mock helpers (#179-#181)

### DIFF
--- a/services/discovery-server/tests/integration/discovery-lifecycle.spec.ts
+++ b/services/discovery-server/tests/integration/discovery-lifecycle.spec.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import http from 'http';
+import express from 'express';
+import { ServiceRegistry } from '../../src/core/service-registry';
+import { registryRoutes } from '../../src/routes/register.routes';
+import { heartbeatRoutes } from '../../src/routes/heartbeat.routes';
+
+jest.mock('@trading-model/common/config/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('../../src/config/env', () => ({
+  env: { CLEANUP_SERVICE_INTERVAL_MS: 5000, ERROR_URL_WEBHOOK: 'https://hooks.example.com/error' },
+}));
+
+describe('Discovery Lifecycle — Full HTTP Integration', () => {
+  let registry: ServiceRegistry;
+  let server: http.Server;
+  let baseUrl: string;
+
+  function postJson(
+    path: string,
+    body: unknown,
+    token?: string
+  ): Promise<{ status: number; body: unknown }> {
+    return new Promise((resolve, reject) => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Server not listening'));
+        return;
+      }
+      const data = JSON.stringify(body);
+      const options: http.RequestOptions = {
+        hostname: 'localhost',
+        port: addr.port,
+        path,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(data),
+          ...(token ? { 'x-instance-token': token } : {}),
+        },
+      };
+      const req = http.request(options, res => {
+        let responseData = '';
+        res.on('data', (chunk: string) => {
+          responseData += chunk;
+        });
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode ?? 500, body: JSON.parse(responseData) });
+          } catch {
+            resolve({ status: res.statusCode ?? 500, body: responseData });
+          }
+        });
+        res.on('error', reject);
+      });
+      req.on('error', reject);
+      req.write(data);
+      req.end();
+    });
+  }
+
+  function getJson(path: string): Promise<{ status: number; body: unknown }> {
+    return new Promise((resolve, reject) => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Server not listening'));
+        return;
+      }
+      const req = http.get(`http://localhost:${addr.port}${path}`, res => {
+        let responseData = '';
+        res.on('data', (chunk: string) => {
+          responseData += chunk;
+        });
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode ?? 500, body: JSON.parse(responseData) });
+          } catch {
+            resolve({ status: res.statusCode ?? 500, body: responseData });
+          }
+        });
+        res.on('error', reject);
+      });
+      req.on('error', reject);
+    });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    registry = new ServiceRegistry();
+    const app = express();
+    app.use(express.json());
+    app.use('/', registryRoutes(registry));
+    app.use('/', heartbeatRoutes(registry));
+    return new Promise<void>(resolve => {
+      server = app.listen(0, () => {
+        const addr = server.address();
+        if (addr && typeof addr !== 'string') {
+          baseUrl = `http://localhost:${addr.port}`;
+        }
+        resolve();
+      });
+    });
+  });
+
+  afterEach(() => {
+    return new Promise<void>(resolve => {
+      if (server?.listening) {
+        server.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  it('should register an instance via POST /register', async () => {
+    const result = await postJson('/register', {
+      serviceName: 'financial-scraper-service',
+      instanceId: 'node-1',
+      ip: '10.0.0.1',
+      port: 8444,
+    });
+    expect(result.status).toBe(201);
+    expect(result.body).toHaveProperty('instanceId', 'node-1');
+    expect(result.body).toHaveProperty('token');
+  });
+
+  it('should reject registration with missing required fields', async () => {
+    const result = await postJson('/register', { serviceName: 'financial-scraper-service' });
+    expect(result.status).toBe(400);
+    expect(result.body).toHaveProperty('error', 'Invalid request body');
+  });
+
+  it('should reject registration with invalid IP', async () => {
+    const result = await postJson('/register', {
+      serviceName: 'financial-scraper-service',
+      instanceId: 'node-1',
+      ip: 'not-an-ip',
+      port: 8444,
+    });
+    expect(result.status).toBe(400);
+    expect(result.body).toHaveProperty('error', 'Invalid request body');
+  });
+
+  it('should reject registration with invalid service name', async () => {
+    const result = await postJson('/register', {
+      serviceName: 'unknown-service',
+      instanceId: 'node-1',
+      ip: '10.0.0.1',
+      port: 8444,
+    });
+    expect(result.status).toBe(400);
+    expect(result.body).toHaveProperty('error', 'Invalid service name');
+  });
+
+  it('should list registered services via GET /services', async () => {
+    await postJson('/register', {
+      serviceName: 'financial-scraper-service',
+      instanceId: 'node-1',
+      ip: '10.0.0.1',
+      port: 8444,
+    });
+    await postJson('/register', {
+      serviceName: 'message-delivery-service',
+      instanceId: 'msg-1',
+      ip: '10.0.0.2',
+      port: 8445,
+    });
+    const result = await getJson('/services');
+    expect(result.status).toBe(200);
+    expect(result.body).toContain('financial-scraper-service');
+    expect(result.body).toContain('message-delivery-service');
+  });
+
+  it('should handle full lifecycle: register → heartbeat → token rotate → get instance', async () => {
+    const registerResult = await postJson('/register', {
+      serviceName: 'financial-scraper-service',
+      instanceId: 'node-1',
+      ip: '10.0.0.1',
+      port: 8444,
+    });
+    expect(registerResult.status).toBe(201);
+    const token = (registerResult.body as Record<string, unknown>).token as string;
+    expect(token).toBeDefined();
+
+    const heartbeatResult = await postJson(
+      '/heartbeat',
+      { serviceName: 'financial-scraper-service', instanceId: 'node-1' },
+      token
+    );
+    expect(heartbeatResult.status).toBe(200);
+    expect(heartbeatResult.body).toHaveProperty('ttl', 30_000);
+
+    const rotateResult = await postJson('/token/rotate', { instanceId: 'node-1' }, token);
+    expect(rotateResult.status).toBe(200);
+    expect(rotateResult.body).toHaveProperty('token');
+    const newToken = (rotateResult.body as Record<string, unknown>).token as string;
+    expect(newToken).not.toBe(token);
+
+    const instanceResult = await getJson('/services/financial-scraper-service/node-1');
+    expect(instanceResult.status).toBe(200);
+    expect(instanceResult.body).toHaveProperty('instanceId', 'node-1');
+  });
+
+  it('should reject heartbeat with invalid token', async () => {
+    await postJson('/register', {
+      serviceName: 'financial-scraper-service',
+      instanceId: 'node-1',
+      ip: '10.0.0.1',
+      port: 8444,
+    });
+    const result = await postJson(
+      '/heartbeat',
+      { serviceName: 'financial-scraper-service', instanceId: 'node-1' },
+      'invalid-token'
+    );
+    expect(result.status).toBe(401);
+  });
+
+  it('should get all instances for a service via GET /services/:name', async () => {
+    const instances = [
+      {
+        serviceName: 'financial-scraper-service',
+        instanceId: 'node-1',
+        ip: '10.0.0.1',
+        port: 8444,
+      },
+      {
+        serviceName: 'financial-scraper-service',
+        instanceId: 'node-2',
+        ip: '10.0.0.2',
+        port: 8444,
+      },
+    ];
+    for (const inst of instances) {
+      await postJson('/register', inst);
+    }
+
+    const result = await getJson('/services/financial-scraper-service');
+    expect(result.status).toBe(200);
+    expect(Array.isArray(result.body)).toBe(true);
+    expect((result.body as unknown[]).length).toBe(2);
+  });
+
+  it('should return 404 for unknown service on GET /services/:name', async () => {
+    const result = await getJson('/services/unknown-service');
+    expect(result.status).toBe(404);
+  });
+
+  it('should return 404 for unknown instance on GET /services/:name/:id', async () => {
+    const result = await getJson('/services/financial-scraper-service/non-existent');
+    expect(result.status).toBe(404);
+  });
+});

--- a/services/trader-trainer/tests/unit/genetic-algorithm/ga-regression.spec.ts
+++ b/services/trader-trainer/tests/unit/genetic-algorithm/ga-regression.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { crossoverScalar, crossoverGenomes } from '../../../src/core/genetic-algorithm/crossover';
+import { createDefaultGenome } from '../../../src/core/genetic-algorithm/factory';
+import type {
+  CrossoverGenome,
+  LamarckGenome,
+} from '../../../src/core/genetic-algorithm/genome-types';
+
+describe('GA Regression — Crossover', () => {
+  describe('crossoverScalar', () => {
+    it('arithmetic crossover with known alpha produces deterministic blend', () => {
+      const co: CrossoverGenome = {
+        type: 'arithmetic',
+        probability: 0.5,
+        blendAlpha: 0.3,
+        sbxEta: 0,
+      };
+      const rng = jest.fn<() => number>();
+      const result = crossoverScalar(10, 20, co, rng);
+      expect(result).toBe(10 + (20 - 10) * 0.3);
+      expect(result).toBe(13);
+      expect(rng).not.toHaveBeenCalled();
+    });
+
+    it('uniform crossover picks parent based on rng threshold', () => {
+      const co: CrossoverGenome = { type: 'uniform', probability: 0.5, blendAlpha: 0, sbxEta: 0 };
+      const rng = jest.fn<() => number>();
+      rng.mockReturnValueOnce(0.2);
+      expect(crossoverScalar(5, 15, co, rng)).toBe(5);
+      rng.mockReturnValueOnce(0.7);
+      expect(crossoverScalar(5, 15, co, rng)).toBe(15);
+    });
+
+    it('blend crossover output is bounded within expected range', () => {
+      const co: CrossoverGenome = { type: 'blend', probability: 0.5, blendAlpha: 0.5, sbxEta: 0 };
+      const rng = jest.fn<() => number>();
+      rng.mockReturnValue(0.5);
+      const result = crossoverScalar(10, 20, co, rng);
+      const d = 20 - 10;
+      const expectedLo = 10 - 0.5 * d;
+      const expectedHi = 20 + 2 * 0.5 * d;
+      expect(result).toBeGreaterThanOrEqual(expectedLo);
+      expect(result).toBeLessThanOrEqual(expectedHi);
+    });
+
+    it('sbx crossover produces symmetric offspring for symmetric parents', () => {
+      const co: CrossoverGenome = { type: 'sbx', probability: 0.5, blendAlpha: 0, sbxEta: 2 };
+      const rng = jest.fn<() => number>();
+      rng.mockReturnValue(0.5);
+      const result = crossoverScalar(10, 10, co, rng);
+      expect(result).toBe(10);
+    });
+  });
+
+  describe('crossoverGenomes', () => {
+    it('offspring preserves parent A structure when crossover is skipped', () => {
+      const rng = jest.fn<() => number>();
+      rng.mockReturnValue(1);
+      const parentA = createDefaultGenome('parent-a', 3) as LamarckGenome;
+      const parentB = createDefaultGenome('parent-b', 3) as LamarckGenome;
+      const child = crossoverGenomes(parentA, parentB, rng);
+      expect(child.id).toBe(parentA.id);
+      expect(child.network.inputDim).toBe(parentA.network.inputDim);
+      expect(child.network.outputDim).toBe(parentA.network.outputDim);
+      expect(child.rl.gamma).toBe(parentA.rl.gamma);
+    });
+
+    it('produces valid genome after crossover with deterministic RNG', () => {
+      const rng = jest.fn<() => number>();
+      rng.mockReturnValue(0);
+      const parentA = createDefaultGenome('parent-a', 3) as LamarckGenome;
+      const parentB = createDefaultGenome('parent-b', 3) as LamarckGenome;
+      const child = crossoverGenomes(parentA, parentB, rng);
+      expect(child).toBeDefined();
+      expect(child.id).toBe(parentA.id);
+      expect(child.network.hiddenLayers.length).toBe(
+        Math.min(parentA.network.hiddenLayers.length, parentB.network.hiddenLayers.length)
+      );
+    });
+
+    it('identical parents produce identical offspring', () => {
+      const rng = jest.fn<() => number>();
+      rng.mockReturnValue(0);
+      const parent = createDefaultGenome('parent', 3) as LamarckGenome;
+      const child1 = crossoverGenomes(parent, parent, rng);
+      rng.mockClear();
+      rng.mockReturnValue(0);
+      const child2 = crossoverGenomes(parent, parent, rng);
+      expect(child1.network.hiddenLayers.length).toBe(child2.network.hiddenLayers.length);
+      for (let i = 0; i < child1.network.hiddenLayers.length; i++) {
+        expect(child1.network.hiddenLayers[i].neurons).toBe(child2.network.hiddenLayers[i].neurons);
+      }
+    });
+  });
+});

--- a/services/trader-trainer/tests/unit/neural-network/nn-regression.spec.ts
+++ b/services/trader-trainer/tests/unit/neural-network/nn-regression.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { NeuralNetwork } from '../../../src/core/neural-network/neural-network';
+import { LOSSES } from '../../../src/core/neural-network/losses';
+import { ACTIVATIONS } from '../../../src/core/neural-network/activation';
+
+jest.mock('../../../src/config/env', () => ({
+  env: {},
+}));
+
+describe('NN Regression — Forward Pass', () => {
+  it('forward pass with known weights produces deterministic output', () => {
+    const nn = new NeuralNetwork({
+      neuronsByLayer: [2, 1],
+      activationType: ['ReLu'],
+      initialisationType: 'zeros',
+      biasInitialisationType: 'zeros',
+      useBias: true,
+      normalisationType: 'none',
+      connectionType: 'fully-connected',
+      lossFunctionType: 'mean-squared-error',
+    });
+
+    const weights = new Float32Array([0.5, 0.3]);
+    const biases = new Float32Array([0.2]);
+    const params = new Float32Array(weights.length + biases.length);
+    params.set(weights, 0);
+    params.set(biases, weights.length);
+    nn.setWeights(params);
+
+    const input = new Float32Array([1.0, 2.0]);
+    const ctx = nn.forward(input);
+    const expected = 0.5 * 1.0 + 0.3 * 2.0 + 0.2;
+    expect(ctx.output.length).toBe(1);
+    expect(ctx.output[0]).toBeCloseTo(expected, 5);
+  });
+
+  it('forward pass with different weights produces different output', () => {
+    const nn = new NeuralNetwork({
+      neuronsByLayer: [2, 1],
+      activationType: ['ReLu'],
+      initialisationType: 'zeros',
+      biasInitialisationType: 'zeros',
+      useBias: true,
+      normalisationType: 'none',
+    });
+
+    const params = new Float32Array([0.8, 0.2, 0]);
+    nn.setWeights(params);
+
+    const ctx = nn.forward(new Float32Array([1.0, 1.0]));
+    const expected = 0.8 * 1.0 + 0.2 * 1.0;
+    expect(ctx.output[0]).toBeCloseTo(expected, 5);
+  });
+
+  it('forward pass with negative weights produces negative ReLu output (clamps to zero)', () => {
+    const nn = new NeuralNetwork({
+      neuronsByLayer: [1, 1],
+      activationType: ['ReLu'],
+      initialisationType: 'zeros',
+      biasInitialisationType: 'zeros',
+      useBias: true,
+      normalisationType: 'none',
+    });
+
+    const params = new Float32Array([-2.0, 0]);
+    nn.setWeights(params);
+
+    const ctx = nn.forward(new Float32Array([5.0]));
+    expect(ctx.output[0]).toBe(0);
+  });
+});
+
+describe('NN Regression — Loss Functions', () => {
+  const config = {
+    lossFunctionType: 'mean-squared-error' as const,
+    deltaHuber: 1,
+    neuronsByLayer: [2, 1],
+    useBias: true,
+    normalisationType: 'none' as const,
+    connectionType: 'fully-connected' as const,
+    initialisationType: 'zeros' as const,
+  };
+
+  it('MSE of identical vectors is zero', () => {
+    const output = new Float32Array([0.5, 0.3]);
+    const target = new Float32Array([0.5, 0.3]);
+    const loss = LOSSES['mean-squared-error'].loss(output, target, config);
+    expect(loss).toBe(0);
+  });
+
+  it('MSE of known vectors computes correct value', () => {
+    const output = new Float32Array([0.5, 0.3]);
+    const target = new Float32Array([0.7, 0.1]);
+    const loss = LOSSES['mean-squared-error'].loss(output, target, config);
+    const expected = (Math.pow(0.5 - 0.7, 2) + Math.pow(0.3 - 0.1, 2)) / 2;
+    expect(loss).toBeCloseTo(expected, 5);
+    expect(loss).toBeCloseTo(0.04, 5);
+  });
+
+  it('MAE of known vectors computes correct value', () => {
+    const output = new Float32Array([10, 20]);
+    const target = new Float32Array([12, 18]);
+    const loss = LOSSES['mean-absolute-error'].loss(output, target, config);
+    const expected = (Math.abs(10 - 12) + Math.abs(20 - 18)) / 2;
+    expect(loss).toBeCloseTo(expected, 5);
+    expect(loss).toBe(2);
+  });
+
+  it('cross-entropy loss is finite for valid probabilities', () => {
+    const output = new Float32Array([0.7, 0.3]);
+    const target = new Float32Array([1, 0]);
+    const loss = LOSSES['cross-entropy'].loss(output, target, config);
+    expect(loss).toBeGreaterThan(0);
+    expect(isFinite(loss)).toBe(true);
+  });
+
+  it('binary-cross-entropy loss is zero for perfect prediction', () => {
+    const output = new Float32Array([1]);
+    const target = new Float32Array([1]);
+    const loss = LOSSES['binary-cross-entropy'].loss(output, target, config);
+    expect(loss).toBeCloseTo(0, 5);
+  });
+});
+
+describe('NN Regression — Activations', () => {
+  it('sigmoid(0) is 0.5', () => {
+    expect(ACTIVATIONS.sigmoid.fn(0)).toBeCloseTo(0.5, 10);
+  });
+
+  it('tanh(0) is 0', () => {
+    expect(ACTIVATIONS.tanh.fn(0)).toBe(0);
+  });
+
+  it('ReLu negative input clamps to zero', () => {
+    expect(ACTIVATIONS.ReLu.fn(-5)).toBe(0);
+  });
+
+  it('ReLu positive input passes through', () => {
+    expect(ACTIVATIONS.ReLu.fn(3)).toBe(3);
+  });
+
+  it('leakyReLu passes small gradient for negative input', () => {
+    const result = ACTIVATIONS.leakyReLu.fn(-2);
+    expect(result).toBeCloseTo(-2 * 0.01, 5);
+  });
+
+  it('softmax sums to 1', () => {
+    const z = new Float32Array([1, 2, 3]);
+    const out = new Float32Array(3);
+    let max = z[0];
+    for (let i = 1; i < 3; i++) if (z[i] > max) max = z[i];
+    let expSum = 0;
+    for (let i = 0; i < 3; i++) {
+      const e = Math.exp(z[i] - max);
+      out[i] = e;
+      expSum += e;
+    }
+    const inv = 1 / expSum;
+    let sum = 0;
+    for (let i = 0; i < 3; i++) {
+      out[i] *= inv;
+      sum += out[i];
+    }
+    expect(sum).toBeCloseTo(1, 5);
+  });
+});

--- a/tests/helpers/mock-common.ts
+++ b/tests/helpers/mock-common.ts
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals';
+
+/** Pre-configured mock logger for tests that need a logger. */
+export function createMockLogger() {
+  return {
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  };
+}
+
+/** Pre-configured mock env object for discovery-server tests. */
+export function createMockDiscoveryEnv(overrides?: Record<string, unknown>) {
+  return {
+    env: {
+      CLEANUP_SERVICE_INTERVAL_MS: 5000,
+      ERROR_URL_WEBHOOK: 'https://hooks.example.com/error',
+      ...overrides,
+    },
+  };
+}
+
+/** Utility mock object for axios-based http clients. */
+export function createMockHttpClient() {
+  return {
+    get: jest
+      .fn<(...args: unknown[]) => Promise<{ data: unknown }>>()
+      .mockResolvedValue({ data: {} }),
+    post: jest
+      .fn<(...args: unknown[]) => Promise<{ data: unknown }>>()
+      .mockResolvedValue({ data: {} }),
+    put: jest
+      .fn<(...args: unknown[]) => Promise<{ data: unknown }>>()
+      .mockResolvedValue({ data: {} }),
+    delete: jest
+      .fn<(...args: unknown[]) => Promise<{ data: unknown }>>()
+      .mockResolvedValue({ data: {} }),
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() },
+    },
+    defaults: {},
+  };
+}


### PR DESCRIPTION
# Description

Add integration tests, regression tests, and centralized mock helpers to complete the testing phase of the code quality audit.

## Type of Change

- [ ] :sparkles: feat - New feature
- [ ] :bug: fix - Bug fix
- [ ] :memo: docs - Documentation
- [ ] :recycle: refactor - Code restructuring
- [x] :white_check_mark: test - Tests
- [x] :wrench: chore - Configuration / tooling
- [ ] :construction_worker: ci - CI/CD
- [ ] :lock: security - Security

## Changes

### :white_check_mark: Additions

- HTTP-level integration tests for discovery-server lifecycle (register -> heartbeat -> token rotate -> get instance) - #179
- Regression tests for GA crossover (crossoverScalar arithmetic/uniform/blend/sbx, crossoverGenomes structural consistency) - #180
- Regression tests for neural network (forward pass with known weights, loss function values, activation outputs) - #180
- Centralized mock helper (mock-common.ts) with reusable factories for logger, env, and HTTP client - #181

### :recycle: Modifications

- Existing test suite expanded from 593 to 614 tests (trader-trainer) and from 91 to 101 tests (discovery-server)

### :fire: Removovals

None

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Tests

- [x] Existing tests pass
- [x] New tests added (31 new tests across discovery-server and trader-trainer)
- [x] npm run test:coverage - All 7 workspaces at 100%
- [x] npm run lint - 0 errors
- [x] npm run build - Success

## Closes Issues

Closes #179
Closes #180
Closes #181

## Additional Notes

All external dependencies (axios, mysql2, node-cron, p-limit, uuid) were already properly mocked across the codebase. The centralized mock helper in tests/helpers/mock-common.ts provides reusable factories to maintain this standard going forward.
