### PR TITLE
:sparkles:(job-scheduler): add job scheduler service with queue, ACK, recovery, worker protocol and 100% test coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trading-model",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trading-model",
-      "version": "2.0.0",
+      "version": "2.0.3",
       "workspaces": [
         "packages/*",
         "services/*"
@@ -3257,6 +3257,10 @@
       "resolved": "packages/common",
       "link": true
     },
+    "node_modules/@trading-model/job-scheduler": {
+      "resolved": "services/job-scheduler",
+      "link": true
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -3535,6 +3539,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
@@ -3548,6 +3559,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -11794,6 +11815,27 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -11988,7 +12030,7 @@
     },
     "packages/common": {
       "name": "@trading-model/common",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "chained-error": "^1.0.0",
@@ -12077,7 +12119,7 @@
       }
     },
     "services/financial-scraper": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "@trading-model/address-manager": "*",
@@ -12135,6 +12177,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "services/job-scheduler": {
+      "name": "@trading-model/job-scheduler",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@trading-model/address-manager": "*",
+        "@trading-model/broker-message": "*",
+        "@trading-model/common": "*",
+        "express": "^5.2.1",
+        "mongodb": "^7.2.0",
+        "uuid": "^14.0.0",
+        "ws": "^8.16.0",
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "@jest/globals": "^30.4.1",
+        "@types/express": "^5.0.6",
+        "@types/jest": "^30.0.0",
+        "@types/node": "^25.9.2",
+        "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.16.0",
+        "eslint": "^10.4.1",
+        "globals": "^17.6.0",
+        "jest": "^30.4.2",
+        "standard-version": "^9.5.0",
+        "ts-jest": "^29.4.11",
+        "ts-node": "^10.9.2",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.59.2"
       }
     },
     "services/message-manager": {

--- a/packages/common/src/config/services.types.ts
+++ b/packages/common/src/config/services.types.ts
@@ -9,6 +9,7 @@ export const ServiceInstanceName = {
   PredictPriceService: 'predict-price-service',
   RiskAnalysisService: 'risk-analysis-service',
   TraderTrainingService: 'trader-training-service',
+  JobSchedulerService: 'job-scheduler-service',
 } as const;
 
 export type ServiceInstanceName = (typeof ServiceInstanceName)[keyof typeof ServiceInstanceName];

--- a/packages/common/src/server/server-factory.ts
+++ b/packages/common/src/server/server-factory.ts
@@ -16,6 +16,8 @@ export interface HttpsServerOptions {
 /** Minimal abstraction over a running HTTP server. */
 export interface HttpServer {
   close: () => Promise<void>;
+  /** The underlying Node.js HTTPS server instance, useful for WebSocket upgrades. */
+  raw: https.Server;
 }
 
 /**
@@ -56,6 +58,7 @@ export async function createAndStartHttpsServer(
   });
 
   return {
+    raw: httpsServer,
     close: () =>
       new Promise<void>((resolve, reject) => {
         httpsServer.close(err => {

--- a/services/job-scheduler/Dockerfile
+++ b/services/job-scheduler/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./
+EXPOSE 3000
+CMD ["node", "dist/app/index.js"]

--- a/services/job-scheduler/jest.config.js
+++ b/services/job-scheduler/jest.config.js
@@ -1,0 +1,22 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  rootDir: '.',
+  testMatch: ['**/?(*.)+(spec).ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  moduleNameMapper: {
+    '^@trading-model/common/(.*)$': '<rootDir>/../../packages/common/src/$1',
+    '^@trading-model/address-manager/(.*)$': '<rootDir>/../../packages/address-manager/src/$1',
+    '^@trading-model/broker-message/(.*)$': '<rootDir>/../../packages/broker-message/src/$1',
+  },
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+};

--- a/services/job-scheduler/package.json
+++ b/services/job-scheduler/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@trading-model/job-scheduler",
+  "version": "1.0.0",
+  "description": "Orchestrateur central de job distribué avec files d'attente, ACK et reprise sur panne",
+  "homepage": "https://github.com/docteur-turboss/trading-model#readme",
+  "bugs": {
+    "url": "https://github.com/docteur-turboss/trading-model/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/docteur-turboss/trading-model.git"
+  },
+  "keywords": [
+    "scheduler",
+    "job",
+    "orchestrator"
+  ],
+  "license": "ISC",
+  "author": "Docteur Turboss <@docteur-turboss>",
+  "type": "commonjs",
+  "main": "./dist/app/index.js",
+  "scripts": {
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "build": "tsc",
+    "dev": "ts-node src/app/index.ts"
+  },
+  "dependencies": {
+    "@trading-model/address-manager": "*",
+    "@trading-model/broker-message": "*",
+    "@trading-model/common": "*",
+    "express": "^5.2.1",
+    "mongodb": "^7.2.0",
+    "uuid": "^14.0.0",
+    "ws": "^8.16.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "@jest/globals": "^30.4.1",
+    "@types/express": "^5.0.6",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^25.9.2",
+    "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.16.0",
+    "eslint": "^10.4.1",
+    "globals": "^17.6.0",
+    "jest": "^30.4.2",
+    "standard-version": "^9.5.0",
+    "ts-jest": "^29.4.11",
+    "ts-node": "^10.9.2",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.59.2"
+  }
+}

--- a/services/job-scheduler/src/app/index.ts
+++ b/services/job-scheduler/src/app/index.ts
@@ -1,0 +1,57 @@
+import { MongoClient } from 'mongodb';
+
+import { createBootstrap } from '@trading-model/common/server/bootstrap';
+import { logger } from '@trading-model/common/config/logger';
+
+import { bootstrapAddressManager } from '../config/address-manager';
+import { env } from '../config/env';
+import { JobRepository } from '../persistence/job-repository';
+import { createServer } from './server';
+import { JobScheduler } from '../scheduler/job-scheduler';
+import { WorkerProtocol } from '../worker/worker-protocol';
+
+let addressManager: ReturnType<typeof bootstrapAddressManager> | null = null;
+let mongoClient: MongoClient | null = null;
+let scheduler: JobScheduler | null = null;
+let workerProtocol: WorkerProtocol | null = null;
+
+createBootstrap({
+  name: 'Job Scheduler',
+  createServer: async () => {
+    mongoClient = new MongoClient(env.MONGODB_URI);
+    await mongoClient.connect();
+    const db = mongoClient.db();
+    const repository = new JobRepository(db);
+    await repository.ensureIndexes();
+
+    scheduler = new JobScheduler(repository);
+
+    const server = createServer(scheduler);
+    const serverInstance = server as unknown as import('net').Server;
+
+    workerProtocol = new WorkerProtocol(
+      serverInstance as unknown as import('stream').Duplex,
+      scheduler.workers,
+      (workerId: string) => scheduler!.onWorkerDisconnect(workerId),
+    );
+    scheduler.setWorkerProtocol(workerProtocol);
+
+    await scheduler.start();
+
+    return server;
+  },
+  onStart: () => {
+    addressManager = bootstrapAddressManager();
+    logger.info('Job Scheduler fully operational', {
+      port: env.PORT,
+      maxQueueDepth: env.MAX_QUEUE_DEPTH,
+      ackTimeoutMs: env.ACK_TIMEOUT_MS,
+    });
+  },
+  onStop: async () => {
+    if (scheduler) await scheduler.stop();
+    if (workerProtocol) workerProtocol.close();
+    if (addressManager) addressManager.stop();
+    if (mongoClient) await mongoClient.close();
+  },
+});

--- a/services/job-scheduler/src/app/index.ts
+++ b/services/job-scheduler/src/app/index.ts
@@ -1,12 +1,12 @@
 import { MongoClient } from 'mongodb';
 
-import { createBootstrap } from '@trading-model/common/server/bootstrap';
 import { logger } from '@trading-model/common/config/logger';
+import { createBootstrap } from '@trading-model/common/server/bootstrap';
 
+import { createServer } from './server';
 import { bootstrapAddressManager } from '../config/address-manager';
 import { env } from '../config/env';
 import { JobRepository } from '../persistence/job-repository';
-import { createServer } from './server';
 import { JobScheduler } from '../scheduler/job-scheduler';
 import { WorkerProtocol } from '../worker/worker-protocol';
 
@@ -26,11 +26,10 @@ createBootstrap({
 
     scheduler = new JobScheduler(repository);
 
-    const server = createServer(scheduler);
-    const serverInstance = server as unknown as import('net').Server;
+    const server = await createServer(scheduler);
 
     workerProtocol = new WorkerProtocol(
-      serverInstance as unknown as import('stream').Duplex,
+      server.raw,
       scheduler.workers,
       (workerId: string) => scheduler!.onWorkerDisconnect(workerId),
     );

--- a/services/job-scheduler/src/app/server.ts
+++ b/services/job-scheduler/src/app/server.ts
@@ -1,0 +1,25 @@
+import { createSecureServer } from '@trading-model/common/server/create-secure-server';
+import { loadTlsConfig } from '@trading-model/common/server/load-tls-config';
+
+import { AddressManagerRoutes } from '../config/address-manager';
+import { env } from '../config/env';
+import { ackRoutes } from '../routes/ack.routes';
+import { healthRoutes } from '../routes/health.routes';
+import { jobRoutes } from '../routes/job.routes';
+import { workerRoutes } from '../routes/worker.routes';
+import { JobScheduler } from '../scheduler/job-scheduler';
+
+export function createServer(scheduler: JobScheduler) {
+  return createSecureServer({
+    port: env.PORT,
+    tls: loadTlsConfig(env),
+    trustProxy: true,
+    routes: app => {
+      app.use('/', jobRoutes(scheduler));
+      app.use('/', ackRoutes(scheduler));
+      app.use('/', workerRoutes(scheduler.workers));
+      app.use('/', healthRoutes(scheduler.queue, scheduler.backPressure, scheduler.workers));
+      AddressManagerRoutes(app);
+    },
+  });
+}

--- a/services/job-scheduler/src/config/address-manager.ts
+++ b/services/job-scheduler/src/config/address-manager.ts
@@ -1,0 +1,10 @@
+import { createAddressManager } from '@trading-model/address-manager/create-address-manager';
+
+import { env } from './env';
+
+const addressManager = createAddressManager(env);
+
+const bootstrapAddressManager = addressManager.start;
+const AddressManagerRoutes = addressManager.listenExpress;
+
+export { AddressManagerRoutes, bootstrapAddressManager, addressManager as AddressManager };

--- a/services/job-scheduler/src/config/env.ts
+++ b/services/job-scheduler/src/config/env.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+import {
+  BaseEnvSchema,
+  AddressManagerEnvSchema,
+  validateEnv,
+} from '@trading-model/common/validation/env';
+
+const JobSchedulerEnvSchema = BaseEnvSchema.extend({
+  ...AddressManagerEnvSchema.shape,
+  MONGODB_URI: z.string().url().default('mongodb://localhost:27017/job-scheduler'),
+  MAX_QUEUE_DEPTH: z.coerce.number().int().positive().default(10000),
+  MAX_WORKER_LOAD_RATIO: z.coerce.number().min(0).max(1).default(0.85),
+  ACK_TIMEOUT_MS: z.coerce.number().int().positive().default(30000),
+  MAX_RETRIES_PER_JOB: z.coerce.number().int().min(0).default(3),
+  ORPHAN_SCAN_INTERVAL_MS: z.coerce.number().int().positive().default(10000),
+  WORKER_HEARTBEAT_TTL_MS: z.coerce.number().int().positive().default(30000),
+});
+
+export const env = validateEnv(JobSchedulerEnvSchema);
+
+export type Env = z.infer<typeof JobSchedulerEnvSchema>;

--- a/services/job-scheduler/src/persistence/job-repository.ts
+++ b/services/job-scheduler/src/persistence/job-repository.ts
@@ -1,6 +1,6 @@
 import { Collection, Db } from 'mongodb';
 
-import { Job, JobStatus, JOB_STATUS_NON_TERMINAL } from '../types/job.types';
+import { Job, JobStatus } from '../types/job.types';
 
 const COLLECTION = 'jobs';
 

--- a/services/job-scheduler/src/persistence/job-repository.ts
+++ b/services/job-scheduler/src/persistence/job-repository.ts
@@ -1,0 +1,150 @@
+import { Collection, Db } from 'mongodb';
+
+import { Job, JobStatus, JOB_STATUS_NON_TERMINAL } from '../types/job.types';
+
+const COLLECTION = 'jobs';
+
+interface JobDocument {
+  jobId: string;
+  type: string;
+  payload: unknown;
+  priority: number;
+  status: string;
+  assignedWorkerId?: string;
+  ackDeadline: number;
+  maxRetries: number;
+  retryCount: number;
+  createdAt: Date;
+  startedAt?: Date;
+  completedAt?: Date;
+  result?: unknown;
+  error?: string;
+  history: Array<{ fromStatus: string; toStatus: string; timestamp: Date; reason: string }>;
+}
+
+function toDocument(job: Job): JobDocument {
+  return {
+    jobId: job.id,
+    type: job.type,
+    payload: job.payload,
+    priority: job.priority,
+    status: job.status,
+    assignedWorkerId: job.assignedWorkerId,
+    ackDeadline: job.ackDeadline,
+    maxRetries: job.maxRetries,
+    retryCount: job.retryCount,
+    createdAt: job.createdAt,
+    startedAt: job.startedAt,
+    completedAt: job.completedAt,
+    result: job.result,
+    error: job.error,
+    history: job.history.map(e => ({
+      fromStatus: e.fromStatus,
+      toStatus: e.toStatus,
+      timestamp: e.timestamp,
+      reason: e.reason,
+    })),
+  };
+}
+
+function fromDocument(doc: JobDocument): Job {
+  return {
+    id: doc.jobId,
+    type: doc.type,
+    payload: doc.payload as Job['payload'],
+    priority: doc.priority as 1 | 2 | 3 | 4 | 5,
+    status: doc.status as JobStatus,
+    assignedWorkerId: doc.assignedWorkerId,
+    ackDeadline: doc.ackDeadline,
+    maxRetries: doc.maxRetries,
+    retryCount: doc.retryCount,
+    createdAt: doc.createdAt,
+    startedAt: doc.startedAt,
+    completedAt: doc.completedAt,
+    result: doc.result,
+    error: doc.error,
+    history: doc.history.map(e => ({
+      fromStatus: e.fromStatus as JobStatus,
+      toStatus: e.toStatus as JobStatus,
+      timestamp: e.timestamp,
+      reason: e.reason,
+    })),
+  };
+}
+
+export class JobRepository {
+  private readonly collection: Collection<JobDocument>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<JobDocument>(COLLECTION);
+  }
+
+  async ensureIndexes(): Promise<void> {
+    await this.collection.createIndex({ jobId: 1 }, { unique: true });
+    await this.collection.createIndex({ status: 1 });
+    await this.collection.createIndex({ assignedWorkerId: 1 }, { sparse: true });
+    await this.collection.createIndex({ type: 1, status: 1 });
+  }
+
+  async insert(job: Job): Promise<void> {
+    await this.collection.insertOne(toDocument(job));
+  }
+
+  async findById(jobId: string): Promise<Job | null> {
+    const doc = await this.collection.findOne({ jobId });
+    return doc ? fromDocument(doc) : null;
+  }
+
+  async updateStatus(jobId: string, status: JobStatus, extras?: Partial<Pick<Job, 'result' | 'error' | 'assignedWorkerId' | 'ackDeadline'>>): Promise<void> {
+    const current = await this.collection.findOne({ jobId });
+    if (!current) return;
+
+    const $set: Record<string, unknown> = {
+      status,
+      ...(status === 'running' ? { startedAt: new Date() } : {}),
+      ...(status === 'completed' || status === 'failed' ? { completedAt: new Date() } : {}),
+    };
+    if (extras?.result !== undefined) $set.result = extras.result;
+    if (extras?.error !== undefined) $set.error = extras.error;
+    if (extras?.assignedWorkerId !== undefined) $set.assignedWorkerId = extras.assignedWorkerId;
+    if (extras?.ackDeadline !== undefined) $set.ackDeadline = extras.ackDeadline;
+
+    await this.collection.updateOne(
+      { jobId },
+      {
+        $set,
+        $push: {
+          history: {
+            fromStatus: current.status,
+            toStatus: status,
+            timestamp: new Date(),
+            reason: extras?.error || status,
+          },
+        },
+      },
+    );
+  }
+
+  async incrementRetry(jobId: string): Promise<void> {
+    await this.collection.updateOne({ jobId }, { $inc: { retryCount: 1 } });
+  }
+
+  async findNonTerminal(): Promise<Job[]> {
+    const docs = await this.collection
+      .find({ status: { $nin: ['completed', 'failed', 'cancelled'] } })
+      .toArray();
+    return docs.map(fromDocument);
+  }
+
+  async findByWorker(workerId: string, statuses: JobStatus[]): Promise<Job[]> {
+    const docs = await this.collection
+      .find({ assignedWorkerId: workerId, status: { $in: statuses } })
+      .toArray();
+    return docs.map(fromDocument);
+  }
+
+  async findByStatus(status: JobStatus): Promise<Job[]> {
+    const docs = await this.collection.find({ status }).toArray();
+    return docs.map(fromDocument);
+  }
+}

--- a/services/job-scheduler/src/recovery/orphan-detector.ts
+++ b/services/job-scheduler/src/recovery/orphan-detector.ts
@@ -1,8 +1,8 @@
 import { logger } from '@trading-model/common/config/logger';
 
+import { ReAllocator } from './re-allocator';
 import { JobRepository } from '../persistence/job-repository';
 import { WorkerRegistry } from '../worker/worker-registry';
-import { ReAllocator } from './re-allocator';
 
 export class OrphanDetector {
   private intervalHandle: ReturnType<typeof setInterval> | null = null;

--- a/services/job-scheduler/src/recovery/orphan-detector.ts
+++ b/services/job-scheduler/src/recovery/orphan-detector.ts
@@ -1,0 +1,59 @@
+import { logger } from '@trading-model/common/config/logger';
+
+import { JobRepository } from '../persistence/job-repository';
+import { WorkerRegistry } from '../worker/worker-registry';
+import { ReAllocator } from './re-allocator';
+
+export class OrphanDetector {
+  private intervalHandle: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly workers: WorkerRegistry,
+    private readonly repository: JobRepository,
+    private readonly reAllocator: ReAllocator,
+    private readonly intervalMs: number,
+  ) {}
+
+  start(): void {
+    if (this.intervalHandle) return;
+
+    this.intervalHandle = setInterval(async () => {
+      try {
+        await this.detectOrphans();
+      } catch (err) {
+        logger.error('Orphan detection cycle failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }, this.intervalMs);
+
+    logger.info('Orphan detector started', { intervalMs: this.intervalMs });
+  }
+
+  stop(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+  }
+
+  private async detectOrphans(): Promise<void> {
+    const staleWorkerIds = this.workers.purgeStaleWorkers();
+
+    if (staleWorkerIds.length === 0) return;
+
+    logger.warn('Stale workers detected — scanning for orphaned jobs', {
+      workerCount: staleWorkerIds.length,
+      workers: staleWorkerIds,
+    });
+
+    for (const workerId of staleWorkerIds) {
+      const orphanedJobs = await this.repository.findByWorker(workerId, ['assigned', 'running']);
+
+      for (const job of orphanedJobs) {
+        await this.repository.updateStatus(job.id, 'orphaned');
+        await this.reAllocator.reallocate(job);
+      }
+    }
+  }
+}

--- a/services/job-scheduler/src/recovery/re-allocator.ts
+++ b/services/job-scheduler/src/recovery/re-allocator.ts
@@ -1,0 +1,55 @@
+import { logger } from '@trading-model/common/config/logger';
+
+import { env } from '../config/env';
+import { InternalQueue } from '../scheduler/internal-queue';
+import { Job } from '../types/job.types';
+import { JobRepository } from '../persistence/job-repository';
+
+export class ReAllocator {
+  constructor(
+    private readonly repository: JobRepository,
+    private readonly queue: InternalQueue,
+  ) {}
+
+  async reallocate(job: Job): Promise<void> {
+    if (job.retryCount >= job.maxRetries) {
+      await this.repository.updateStatus(job.id, 'failed', {
+        error: `Exceeded max retries (${job.maxRetries})`,
+      });
+
+      logger.warn('Job failed after max retries', {
+        jobId: job.id,
+        retryCount: job.retryCount,
+      });
+      return;
+    }
+
+    const newDeadline = Date.now() + env.ACK_TIMEOUT_MS;
+    const updatedJob: Job = {
+      ...job,
+      status: 'queued',
+      ackDeadline: newDeadline,
+      retryCount: job.retryCount + 1,
+      assignedWorkerId: undefined,
+      history: [
+        ...job.history,
+        {
+          fromStatus: 'orphaned',
+          toStatus: 'queued',
+          timestamp: new Date(),
+          reason: 're-allocated',
+        },
+      ],
+    };
+
+    this.queue.enqueue(updatedJob);
+    await this.repository.updateStatus(job.id, 'queued', {
+      ackDeadline: newDeadline,
+    });
+
+    logger.info('Job re-allocated to queue', {
+      jobId: job.id,
+      retryCount: updatedJob.retryCount,
+    });
+  }
+}

--- a/services/job-scheduler/src/recovery/re-allocator.ts
+++ b/services/job-scheduler/src/recovery/re-allocator.ts
@@ -1,9 +1,9 @@
 import { logger } from '@trading-model/common/config/logger';
 
 import { env } from '../config/env';
+import { JobRepository } from '../persistence/job-repository';
 import { InternalQueue } from '../scheduler/internal-queue';
 import { Job } from '../types/job.types';
-import { JobRepository } from '../persistence/job-repository';
 
 export class ReAllocator {
   constructor(

--- a/services/job-scheduler/src/routes/ack.controller.ts
+++ b/services/job-scheduler/src/routes/ack.controller.ts
@@ -1,0 +1,42 @@
+import { RequestHandler } from 'express';
+
+import { catchSync } from '@trading-model/common/middleware/catch-error';
+import { sendResponse } from '@trading-model/common/middleware/response-exception';
+
+import { JobScheduler } from '../scheduler/job-scheduler';
+import { CompleteJobSchema, FailJobSchema } from './ack.schema';
+
+export function createAckController(scheduler: JobScheduler) {
+  const ack: RequestHandler = catchSync(async req => {
+    await scheduler.ack(req.params.id);
+    return sendResponse({ status: 'acknowledged' }, 200);
+  });
+
+  const complete: RequestHandler = catchSync(async req => {
+    const parsed = CompleteJobSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return sendResponse(
+        { error: 'Invalid request body', details: parsed.error.flatten().fieldErrors },
+        400,
+      );
+    }
+
+    await scheduler.complete(req.params.id, parsed.data.result);
+    return sendResponse({ status: 'completed' }, 200);
+  });
+
+  const fail: RequestHandler = catchSync(async req => {
+    const parsed = FailJobSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return sendResponse(
+        { error: 'Invalid request body', details: parsed.error.flatten().fieldErrors },
+        400,
+      );
+    }
+
+    await scheduler.fail(req.params.id, parsed.data.error);
+    return sendResponse({ status: 'failed' }, 200);
+  });
+
+  return { ack, complete, fail };
+}

--- a/services/job-scheduler/src/routes/ack.controller.ts
+++ b/services/job-scheduler/src/routes/ack.controller.ts
@@ -3,12 +3,12 @@ import { RequestHandler } from 'express';
 import { catchSync } from '@trading-model/common/middleware/catch-error';
 import { sendResponse } from '@trading-model/common/middleware/response-exception';
 
-import { JobScheduler } from '../scheduler/job-scheduler';
 import { CompleteJobSchema, FailJobSchema } from './ack.schema';
+import { JobScheduler } from '../scheduler/job-scheduler';
 
 export function createAckController(scheduler: JobScheduler) {
   const ack: RequestHandler = catchSync(async req => {
-    await scheduler.ack(req.params.id);
+    await scheduler.ack(String(req.params.id));
     return sendResponse({ status: 'acknowledged' }, 200);
   });
 
@@ -21,7 +21,7 @@ export function createAckController(scheduler: JobScheduler) {
       );
     }
 
-    await scheduler.complete(req.params.id, parsed.data.result);
+    await scheduler.complete(String(req.params.id), parsed.data.result);
     return sendResponse({ status: 'completed' }, 200);
   });
 
@@ -34,7 +34,7 @@ export function createAckController(scheduler: JobScheduler) {
       );
     }
 
-    await scheduler.fail(req.params.id, parsed.data.error);
+    await scheduler.fail(String(req.params.id), parsed.data.error);
     return sendResponse({ status: 'failed' }, 200);
   });
 

--- a/services/job-scheduler/src/routes/ack.routes.ts
+++ b/services/job-scheduler/src/routes/ack.routes.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 
-import { JobScheduler } from '../scheduler/job-scheduler';
 import { createAckController } from './ack.controller';
+import { JobScheduler } from '../scheduler/job-scheduler';
 
 export function ackRoutes(scheduler: JobScheduler): Router {
   const router = Router();

--- a/services/job-scheduler/src/routes/ack.routes.ts
+++ b/services/job-scheduler/src/routes/ack.routes.ts
@@ -1,0 +1,55 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+
+import { JobScheduler } from '../scheduler/job-scheduler';
+
+const completeSchema = z.object({
+  result: z.unknown().optional(),
+});
+
+const failSchema = z.object({
+  error: z.string().min(1),
+});
+
+export function ackRoutes(scheduler: JobScheduler): Router {
+  const router = Router();
+
+  router.post('/jobs/:id/ack', async (req: Request, res: Response) => {
+    try {
+      await scheduler.ack(req.params.id);
+      res.json({ status: 'acknowledged' });
+    } catch (err) {
+      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
+    }
+  });
+
+  router.post('/jobs/:id/complete', async (req: Request, res: Response) => {
+    try {
+      const body = completeSchema.parse(req.body);
+      await scheduler.complete(req.params.id, body.result);
+      res.json({ status: 'completed' });
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        res.status(400).json({ error: 'VALIDATION_ERROR', details: err.errors });
+        return;
+      }
+      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
+    }
+  });
+
+  router.post('/jobs/:id/fail', async (req: Request, res: Response) => {
+    try {
+      const body = failSchema.parse(req.body);
+      await scheduler.fail(req.params.id, body.error);
+      res.json({ status: 'failed' });
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        res.status(400).json({ error: 'VALIDATION_ERROR', details: err.errors });
+        return;
+      }
+      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
+    }
+  });
+
+  return router;
+}

--- a/services/job-scheduler/src/routes/ack.routes.ts
+++ b/services/job-scheduler/src/routes/ack.routes.ts
@@ -1,55 +1,15 @@
-import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import { Router } from 'express';
 
 import { JobScheduler } from '../scheduler/job-scheduler';
-
-const completeSchema = z.object({
-  result: z.unknown().optional(),
-});
-
-const failSchema = z.object({
-  error: z.string().min(1),
-});
+import { createAckController } from './ack.controller';
 
 export function ackRoutes(scheduler: JobScheduler): Router {
   const router = Router();
+  const controller = createAckController(scheduler);
 
-  router.post('/jobs/:id/ack', async (req: Request, res: Response) => {
-    try {
-      await scheduler.ack(req.params.id);
-      res.json({ status: 'acknowledged' });
-    } catch (err) {
-      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
-    }
-  });
-
-  router.post('/jobs/:id/complete', async (req: Request, res: Response) => {
-    try {
-      const body = completeSchema.parse(req.body);
-      await scheduler.complete(req.params.id, body.result);
-      res.json({ status: 'completed' });
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        res.status(400).json({ error: 'VALIDATION_ERROR', details: err.errors });
-        return;
-      }
-      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
-    }
-  });
-
-  router.post('/jobs/:id/fail', async (req: Request, res: Response) => {
-    try {
-      const body = failSchema.parse(req.body);
-      await scheduler.fail(req.params.id, body.error);
-      res.json({ status: 'failed' });
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        res.status(400).json({ error: 'VALIDATION_ERROR', details: err.errors });
-        return;
-      }
-      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
-    }
-  });
+  router.post('/jobs/:id/ack', controller.ack);
+  router.post('/jobs/:id/complete', controller.complete);
+  router.post('/jobs/:id/fail', controller.fail);
 
   return router;
 }

--- a/services/job-scheduler/src/routes/ack.schema.ts
+++ b/services/job-scheduler/src/routes/ack.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const CompleteJobSchema = z.object({
+  result: z.unknown().optional(),
+});
+
+export const FailJobSchema = z.object({
+  error: z.string().min(1),
+});

--- a/services/job-scheduler/src/routes/health.controller.ts
+++ b/services/job-scheduler/src/routes/health.controller.ts
@@ -1,0 +1,36 @@
+import { RequestHandler } from 'express';
+
+import { catchSync } from '@trading-model/common/middleware/catch-error';
+import { sendResponse } from '@trading-model/common/middleware/response-exception';
+
+import { BackPressure } from '../scheduler/back-pressure';
+import { InternalQueue } from '../scheduler/internal-queue';
+import { WorkerRegistry } from '../worker/worker-registry';
+
+export function createHealthController(
+  queue: InternalQueue,
+  backPressure: BackPressure,
+  workers: WorkerRegistry,
+) {
+  const ping: RequestHandler = catchSync(async () => {
+    return sendResponse({ status: 'ok', timestamp: new Date().toISOString() }, 200);
+  });
+
+  const health: RequestHandler = catchSync(async () => {
+    const queueDepth = queue.depth();
+
+    return sendResponse(
+      {
+        status: 'ok',
+        queueDepth,
+        canAccept: backPressure.canAccept(),
+        workerCount: workers.count(),
+        averageLoad: workers.averageLoad(),
+        timestamp: new Date().toISOString(),
+      },
+      200,
+    );
+  });
+
+  return { ping, health };
+}

--- a/services/job-scheduler/src/routes/health.routes.ts
+++ b/services/job-scheduler/src/routes/health.routes.ts
@@ -1,8 +1,9 @@
-import { Router, Request, Response } from 'express';
+import { Router } from 'express';
 
 import { BackPressure } from '../scheduler/back-pressure';
 import { InternalQueue } from '../scheduler/internal-queue';
 import { WorkerRegistry } from '../worker/worker-registry';
+import { createHealthController } from './health.controller';
 
 export function healthRoutes(
   queue: InternalQueue,
@@ -10,23 +11,10 @@ export function healthRoutes(
   workers: WorkerRegistry,
 ): Router {
   const router = Router();
+  const controller = createHealthController(queue, backPressure, workers);
 
-  router.get('/ping', (_req: Request, res: Response) => {
-    res.json({ status: 'ok', timestamp: new Date().toISOString() });
-  });
-
-  router.get('/health', (_req: Request, res: Response) => {
-    const queueDepth = queue.depth();
-
-    res.json({
-      status: 'ok',
-      queueDepth,
-      canAccept: backPressure.canAccept(),
-      workerCount: workers.count(),
-      averageLoad: workers.averageLoad(),
-      timestamp: new Date().toISOString(),
-    });
-  });
+  router.get('/ping', controller.ping);
+  router.get('/health', controller.health);
 
   return router;
 }

--- a/services/job-scheduler/src/routes/health.routes.ts
+++ b/services/job-scheduler/src/routes/health.routes.ts
@@ -1,0 +1,32 @@
+import { Router, Request, Response } from 'express';
+
+import { BackPressure } from '../scheduler/back-pressure';
+import { InternalQueue } from '../scheduler/internal-queue';
+import { WorkerRegistry } from '../worker/worker-registry';
+
+export function healthRoutes(
+  queue: InternalQueue,
+  backPressure: BackPressure,
+  workers: WorkerRegistry,
+): Router {
+  const router = Router();
+
+  router.get('/ping', (_req: Request, res: Response) => {
+    res.json({ status: 'ok', timestamp: new Date().toISOString() });
+  });
+
+  router.get('/health', (_req: Request, res: Response) => {
+    const queueDepth = queue.depth();
+
+    res.json({
+      status: 'ok',
+      queueDepth,
+      canAccept: backPressure.canAccept(),
+      workerCount: workers.count(),
+      averageLoad: workers.averageLoad(),
+      timestamp: new Date().toISOString(),
+    });
+  });
+
+  return router;
+}

--- a/services/job-scheduler/src/routes/health.routes.ts
+++ b/services/job-scheduler/src/routes/health.routes.ts
@@ -1,9 +1,9 @@
 import { Router } from 'express';
 
+import { createHealthController } from './health.controller';
 import { BackPressure } from '../scheduler/back-pressure';
 import { InternalQueue } from '../scheduler/internal-queue';
 import { WorkerRegistry } from '../worker/worker-registry';
-import { createHealthController } from './health.controller';
 
 export function healthRoutes(
   queue: InternalQueue,

--- a/services/job-scheduler/src/routes/job.controller.ts
+++ b/services/job-scheduler/src/routes/job.controller.ts
@@ -1,0 +1,60 @@
+import { RequestHandler } from 'express';
+
+import { catchSync } from '@trading-model/common/middleware/catch-error';
+import { sendResponse } from '@trading-model/common/middleware/response-exception';
+
+import { JobScheduler } from '../scheduler/job-scheduler';
+import { SubmitJobSchema } from './job.schema';
+
+export function createJobController(scheduler: JobScheduler) {
+  const submit: RequestHandler = catchSync(async req => {
+    const parsed = SubmitJobSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return sendResponse(
+        { error: 'Invalid request body', details: parsed.error.flatten().fieldErrors },
+        400,
+      );
+    }
+
+    const { type, payload, priority, maxRetries } = parsed.data;
+
+    try {
+      const jobId = await scheduler.submit(type, payload, priority as 1 | 2 | 3 | 4 | 5, maxRetries);
+      return sendResponse({ jobId, status: 'queued' }, 201);
+    } catch (err) {
+      if (err instanceof Error && (err as Error & { code: string }).code === 'BACK_PRESSURE') {
+        const retryAfter = (err as Error & { retryAfter: number }).retryAfter ?? 30;
+        return sendResponse(
+          {
+            error: 'BACK_PRESSURE',
+            message: `Job scheduler at capacity. Retry after ${retryAfter} seconds.`,
+            retryAfter,
+          },
+          429,
+        );
+      }
+      throw err;
+    }
+  });
+
+  const getById: RequestHandler = catchSync(async req => {
+    const job = await scheduler.repository.findById(req.params.id);
+    if (!job) return sendResponse({ error: 'Job not found' }, 404);
+
+    return sendResponse(job, 200);
+  });
+
+  const cancel: RequestHandler = catchSync(async req => {
+    try {
+      await scheduler.cancel(req.params.id);
+      return sendResponse({ status: 'cancelled' }, 200);
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('Cannot cancel')) {
+        return sendResponse({ error: 'CONFLICT', message: err.message }, 409);
+      }
+      throw err;
+    }
+  });
+
+  return { submit, getById, cancel };
+}

--- a/services/job-scheduler/src/routes/job.controller.ts
+++ b/services/job-scheduler/src/routes/job.controller.ts
@@ -3,8 +3,8 @@ import { RequestHandler } from 'express';
 import { catchSync } from '@trading-model/common/middleware/catch-error';
 import { sendResponse } from '@trading-model/common/middleware/response-exception';
 
-import { JobScheduler } from '../scheduler/job-scheduler';
 import { SubmitJobSchema } from './job.schema';
+import { JobScheduler } from '../scheduler/job-scheduler';
 
 export function createJobController(scheduler: JobScheduler) {
   const submit: RequestHandler = catchSync(async req => {
@@ -38,7 +38,7 @@ export function createJobController(scheduler: JobScheduler) {
   });
 
   const getById: RequestHandler = catchSync(async req => {
-    const job = await scheduler.repository.findById(req.params.id);
+    const job = await scheduler.repository.findById(String(req.params.id));
     if (!job) return sendResponse({ error: 'Job not found' }, 404);
 
     return sendResponse(job, 200);
@@ -46,7 +46,7 @@ export function createJobController(scheduler: JobScheduler) {
 
   const cancel: RequestHandler = catchSync(async req => {
     try {
-      await scheduler.cancel(req.params.id);
+      await scheduler.cancel(String(req.params.id));
       return sendResponse({ status: 'cancelled' }, 200);
     } catch (err) {
       if (err instanceof Error && err.message.includes('Cannot cancel')) {

--- a/services/job-scheduler/src/routes/job.routes.ts
+++ b/services/job-scheduler/src/routes/job.routes.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 
-import { JobScheduler } from '../scheduler/job-scheduler';
 import { createJobController } from './job.controller';
+import { JobScheduler } from '../scheduler/job-scheduler';
 
 export function jobRoutes(scheduler: JobScheduler): Router {
   const router = Router();

--- a/services/job-scheduler/src/routes/job.routes.ts
+++ b/services/job-scheduler/src/routes/job.routes.ts
@@ -1,76 +1,15 @@
-import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import { Router } from 'express';
 
 import { JobScheduler } from '../scheduler/job-scheduler';
-
-const submitJobSchema = z.object({
-  type: z.string().min(1),
-  payload: z.unknown(),
-  priority: z.number().int().min(1).max(5).default(3),
-  maxRetries: z.number().int().min(0).default(3),
-});
+import { createJobController } from './job.controller';
 
 export function jobRoutes(scheduler: JobScheduler): Router {
   const router = Router();
+  const controller = createJobController(scheduler);
 
-  router.post('/jobs', async (req: Request, res: Response) => {
-    try {
-      const body = submitJobSchema.parse(req.body);
-
-      const jobId = await scheduler.submit(
-        body.type,
-        body.payload,
-        body.priority as 1 | 2 | 3 | 4 | 5,
-        body.maxRetries,
-      );
-
-      res.status(201).json({ jobId, status: 'queued' });
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        res.status(400).json({ error: 'VALIDATION_ERROR', details: err.errors });
-        return;
-      }
-
-      if (err instanceof Error && (err as Error & { code: string }).code === 'BACK_PRESSURE') {
-        const retryAfter = (err as Error & { retryAfter: number }).retryAfter ?? 30;
-        res.set('Retry-After', String(retryAfter));
-        res.status(429).json({
-          error: 'BACK_PRESSURE',
-          message: 'Job scheduler at capacity. Retry after ' + retryAfter + ' seconds.',
-          retryAfter,
-        });
-        return;
-      }
-
-      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
-    }
-  });
-
-  router.get('/jobs/:id', async (req: Request, res: Response) => {
-    try {
-      const job = await scheduler.repository.findById(req.params.id);
-      if (!job) {
-        res.status(404).json({ error: 'NOT_FOUND', message: 'Job not found' });
-        return;
-      }
-      res.json(job);
-    } catch (err) {
-      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
-    }
-  });
-
-  router.post('/jobs/:id/cancel', async (req: Request, res: Response) => {
-    try {
-      await scheduler.cancel(req.params.id);
-      res.json({ status: 'cancelled' });
-    } catch (err) {
-      if (err instanceof Error && err.message.includes('Cannot cancel')) {
-        res.status(409).json({ error: 'CONFLICT', message: err.message });
-        return;
-      }
-      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
-    }
-  });
+  router.post('/jobs', controller.submit);
+  router.get('/jobs/:id', controller.getById);
+  router.post('/jobs/:id/cancel', controller.cancel);
 
   return router;
 }

--- a/services/job-scheduler/src/routes/job.routes.ts
+++ b/services/job-scheduler/src/routes/job.routes.ts
@@ -1,0 +1,76 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+
+import { JobScheduler } from '../scheduler/job-scheduler';
+
+const submitJobSchema = z.object({
+  type: z.string().min(1),
+  payload: z.unknown(),
+  priority: z.number().int().min(1).max(5).default(3),
+  maxRetries: z.number().int().min(0).default(3),
+});
+
+export function jobRoutes(scheduler: JobScheduler): Router {
+  const router = Router();
+
+  router.post('/jobs', async (req: Request, res: Response) => {
+    try {
+      const body = submitJobSchema.parse(req.body);
+
+      const jobId = await scheduler.submit(
+        body.type,
+        body.payload,
+        body.priority as 1 | 2 | 3 | 4 | 5,
+        body.maxRetries,
+      );
+
+      res.status(201).json({ jobId, status: 'queued' });
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        res.status(400).json({ error: 'VALIDATION_ERROR', details: err.errors });
+        return;
+      }
+
+      if (err instanceof Error && (err as Error & { code: string }).code === 'BACK_PRESSURE') {
+        const retryAfter = (err as Error & { retryAfter: number }).retryAfter ?? 30;
+        res.set('Retry-After', String(retryAfter));
+        res.status(429).json({
+          error: 'BACK_PRESSURE',
+          message: 'Job scheduler at capacity. Retry after ' + retryAfter + ' seconds.',
+          retryAfter,
+        });
+        return;
+      }
+
+      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
+    }
+  });
+
+  router.get('/jobs/:id', async (req: Request, res: Response) => {
+    try {
+      const job = await scheduler.repository.findById(req.params.id);
+      if (!job) {
+        res.status(404).json({ error: 'NOT_FOUND', message: 'Job not found' });
+        return;
+      }
+      res.json(job);
+    } catch (err) {
+      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
+    }
+  });
+
+  router.post('/jobs/:id/cancel', async (req: Request, res: Response) => {
+    try {
+      await scheduler.cancel(req.params.id);
+      res.json({ status: 'cancelled' });
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('Cannot cancel')) {
+        res.status(409).json({ error: 'CONFLICT', message: err.message });
+        return;
+      }
+      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
+    }
+  });
+
+  return router;
+}

--- a/services/job-scheduler/src/routes/job.schema.ts
+++ b/services/job-scheduler/src/routes/job.schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const SubmitJobSchema = z.object({
+  type: z.string().min(1),
+  payload: z.unknown(),
+  priority: z.number().int().min(1).max(5).default(3),
+  maxRetries: z.number().int().min(0).default(3),
+});
+
+export const JobIdParamsSchema = z.object({
+  id: z.string().min(1),
+});

--- a/services/job-scheduler/src/routes/worker.controller.ts
+++ b/services/job-scheduler/src/routes/worker.controller.ts
@@ -1,0 +1,56 @@
+import { RequestHandler } from 'express';
+
+import { catchSync } from '@trading-model/common/middleware/catch-error';
+import { sendResponse } from '@trading-model/common/middleware/response-exception';
+
+import { WorkerRegistry } from '../worker/worker-registry';
+import { RegisterWorkerSchema, WorkerHeartbeatSchema } from './worker.schema';
+
+export function createWorkerController(workers: WorkerRegistry) {
+  const register: RequestHandler = catchSync(async req => {
+    const parsed = RegisterWorkerSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return sendResponse(
+        { error: 'Invalid request body', details: parsed.error.flatten().fieldErrors },
+        400,
+      );
+    }
+
+    const { workerId, address, port, capabilities, maxConcurrency } = parsed.data;
+
+    workers.register(workerId, {
+      workerId,
+      address,
+      port,
+      capabilities,
+      maxConcurrency,
+      currentLoad: 0,
+    });
+
+    return sendResponse({ status: 'registered', workerId }, 201);
+  });
+
+  const heartbeat: RequestHandler = catchSync(async req => {
+    const parsed = WorkerHeartbeatSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return sendResponse(
+        { error: 'Invalid request body', details: parsed.error.flatten().fieldErrors },
+        400,
+      );
+    }
+
+    const { workerId, currentLoad } = parsed.data;
+
+    workers.heartbeat(workerId);
+    workers.updateLoad(workerId, currentLoad);
+
+    return sendResponse({ status: 'ok' }, 200);
+  });
+
+  const list: RequestHandler = catchSync(async () => {
+    const all = workers.getAllActive();
+    return sendResponse({ count: all.length, workers: all }, 200);
+  });
+
+  return { register, heartbeat, list };
+}

--- a/services/job-scheduler/src/routes/worker.controller.ts
+++ b/services/job-scheduler/src/routes/worker.controller.ts
@@ -3,8 +3,8 @@ import { RequestHandler } from 'express';
 import { catchSync } from '@trading-model/common/middleware/catch-error';
 import { sendResponse } from '@trading-model/common/middleware/response-exception';
 
-import { WorkerRegistry } from '../worker/worker-registry';
 import { RegisterWorkerSchema, WorkerHeartbeatSchema } from './worker.schema';
+import { WorkerRegistry } from '../worker/worker-registry';
 
 export function createWorkerController(workers: WorkerRegistry) {
   const register: RequestHandler = catchSync(async req => {

--- a/services/job-scheduler/src/routes/worker.routes.ts
+++ b/services/job-scheduler/src/routes/worker.routes.ts
@@ -1,0 +1,68 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+
+import { WorkerRegistry } from '../worker/worker-registry';
+
+const registerSchema = z.object({
+  workerId: z.string().min(1),
+  address: z.string().min(1),
+  port: z.number().int().positive(),
+  capabilities: z.array(z.string()).default([]),
+  maxConcurrency: z.number().int().positive().default(1),
+});
+
+const heartbeatSchema = z.object({
+  workerId: z.string().min(1),
+  currentLoad: z.number().min(0).default(0),
+});
+
+export function workerRoutes(workers: WorkerRegistry): Router {
+  const router = Router();
+
+  router.post('/workers/register', (req: Request, res: Response) => {
+    try {
+      const body = registerSchema.parse(req.body);
+
+      workers.register(body.workerId, {
+        workerId: body.workerId,
+        address: body.address,
+        port: body.port,
+        capabilities: body.capabilities,
+        maxConcurrency: body.maxConcurrency,
+        currentLoad: 0,
+      });
+
+      res.status(201).json({ status: 'registered', workerId: body.workerId });
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        res.status(400).json({ error: 'VALIDATION_ERROR', details: err.errors });
+        return;
+      }
+      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
+    }
+  });
+
+  router.post('/workers/heartbeat', (req: Request, res: Response) => {
+    try {
+      const body = heartbeatSchema.parse(req.body);
+
+      workers.heartbeat(body.workerId);
+      workers.updateLoad(body.workerId, body.currentLoad);
+
+      res.json({ status: 'ok' });
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        res.status(400).json({ error: 'VALIDATION_ERROR', details: err.errors });
+        return;
+      }
+      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
+    }
+  });
+
+  router.get('/workers', (_req: Request, res: Response) => {
+    const all = workers.getAllActive();
+    res.json({ count: all.length, workers: all });
+  });
+
+  return router;
+}

--- a/services/job-scheduler/src/routes/worker.routes.ts
+++ b/services/job-scheduler/src/routes/worker.routes.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 
-import { WorkerRegistry } from '../worker/worker-registry';
 import { createWorkerController } from './worker.controller';
+import { WorkerRegistry } from '../worker/worker-registry';
 
 export function workerRoutes(workers: WorkerRegistry): Router {
   const router = Router();

--- a/services/job-scheduler/src/routes/worker.routes.ts
+++ b/services/job-scheduler/src/routes/worker.routes.ts
@@ -1,68 +1,15 @@
-import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import { Router } from 'express';
 
 import { WorkerRegistry } from '../worker/worker-registry';
-
-const registerSchema = z.object({
-  workerId: z.string().min(1),
-  address: z.string().min(1),
-  port: z.number().int().positive(),
-  capabilities: z.array(z.string()).default([]),
-  maxConcurrency: z.number().int().positive().default(1),
-});
-
-const heartbeatSchema = z.object({
-  workerId: z.string().min(1),
-  currentLoad: z.number().min(0).default(0),
-});
+import { createWorkerController } from './worker.controller';
 
 export function workerRoutes(workers: WorkerRegistry): Router {
   const router = Router();
+  const controller = createWorkerController(workers);
 
-  router.post('/workers/register', (req: Request, res: Response) => {
-    try {
-      const body = registerSchema.parse(req.body);
-
-      workers.register(body.workerId, {
-        workerId: body.workerId,
-        address: body.address,
-        port: body.port,
-        capabilities: body.capabilities,
-        maxConcurrency: body.maxConcurrency,
-        currentLoad: 0,
-      });
-
-      res.status(201).json({ status: 'registered', workerId: body.workerId });
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        res.status(400).json({ error: 'VALIDATION_ERROR', details: err.errors });
-        return;
-      }
-      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
-    }
-  });
-
-  router.post('/workers/heartbeat', (req: Request, res: Response) => {
-    try {
-      const body = heartbeatSchema.parse(req.body);
-
-      workers.heartbeat(body.workerId);
-      workers.updateLoad(body.workerId, body.currentLoad);
-
-      res.json({ status: 'ok' });
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        res.status(400).json({ error: 'VALIDATION_ERROR', details: err.errors });
-        return;
-      }
-      res.status(500).json({ error: 'INTERNAL_ERROR', message: String(err) });
-    }
-  });
-
-  router.get('/workers', (_req: Request, res: Response) => {
-    const all = workers.getAllActive();
-    res.json({ count: all.length, workers: all });
-  });
+  router.post('/workers/register', controller.register);
+  router.post('/workers/heartbeat', controller.heartbeat);
+  router.get('/workers', controller.list);
 
   return router;
 }

--- a/services/job-scheduler/src/routes/worker.schema.ts
+++ b/services/job-scheduler/src/routes/worker.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const RegisterWorkerSchema = z.object({
+  workerId: z.string().min(1),
+  address: z.string().min(1),
+  port: z.number().int().positive(),
+  capabilities: z.array(z.string()).default([]),
+  maxConcurrency: z.number().int().positive().default(1),
+});
+
+export const WorkerHeartbeatSchema = z.object({
+  workerId: z.string().min(1),
+  currentLoad: z.number().min(0).default(0),
+});

--- a/services/job-scheduler/src/scheduler/back-pressure.ts
+++ b/services/job-scheduler/src/scheduler/back-pressure.ts
@@ -1,0 +1,40 @@
+export class BackPressure {
+  private queueDepth = 0;
+  private readonly workerLoads: Map<string, number> = new Map();
+
+  constructor(
+    private readonly maxQueueDepth: number,
+    private readonly maxWorkerLoadRatio: number,
+  ) {}
+
+  updateQueueDepth(depth: number): void {
+    this.queueDepth = depth;
+  }
+
+  updateWorkerLoad(workerId: string, load: number): void {
+    this.workerLoads.set(workerId, load);
+  }
+
+  removeWorker(workerId: string): void {
+    this.workerLoads.delete(workerId);
+  }
+
+  canAccept(): boolean {
+    if (this.queueDepth >= this.maxQueueDepth) {
+      return false;
+    }
+    if (this.workerLoads.size === 0) {
+      return true;
+    }
+    for (const load of this.workerLoads.values()) {
+      if (load < this.maxWorkerLoadRatio) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  retryAfterSeconds(): number {
+    return Math.ceil(this.queueDepth / 100) * 5;
+  }
+}

--- a/services/job-scheduler/src/scheduler/internal-queue.ts
+++ b/services/job-scheduler/src/scheduler/internal-queue.ts
@@ -1,0 +1,72 @@
+import { QueuedJob, Job } from '../types/job.types';
+
+export class InternalQueue {
+  private readonly queues: Map<number, QueuedJob[]> = new Map();
+  private readonly ackTimers: Map<string, NodeJS.Timeout> = new Map();
+  private readonly ackTimeoutMs: number;
+  private onAckTimeoutCallback: ((jobId: string) => void) | null = null;
+
+  constructor(ackTimeoutMs: number) {
+    this.ackTimeoutMs = ackTimeoutMs;
+  }
+
+  setOnAckTimeout(callback: (jobId: string) => void): void {
+    this.onAckTimeoutCallback = callback;
+  }
+
+  enqueue(job: Job): void {
+    const priority = job.priority;
+    if (!this.queues.has(priority)) {
+      this.queues.set(priority, []);
+    }
+    this.queues.get(priority)!.push({
+      job,
+      state: 'queued',
+      deliveryAttempts: 0,
+      expiresAt: 0,
+    });
+  }
+
+  dequeue(): QueuedJob | null {
+    for (let p = 1; p <= 5; p++) {
+      const queue = this.queues.get(p);
+      if (queue && queue.length > 0) {
+        return queue.shift()!;
+      }
+    }
+    return null;
+  }
+
+  markDelivered(jobId: string): void {
+    const timer = setTimeout(() => {
+      this.ackTimers.delete(jobId);
+      if (this.onAckTimeoutCallback) {
+        this.onAckTimeoutCallback(jobId);
+      }
+    }, this.ackTimeoutMs);
+    this.ackTimers.set(jobId, timer);
+  }
+
+  ack(jobId: string): void {
+    const timer = this.ackTimers.get(jobId);
+    if (timer) {
+      clearTimeout(timer);
+      this.ackTimers.delete(jobId);
+    }
+  }
+
+  depth(): number {
+    let total = 0;
+    for (const q of this.queues.values()) {
+      total += q.length;
+    }
+    return total;
+  }
+
+  stop(): void {
+    for (const timer of this.ackTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.ackTimers.clear();
+  }
+}

--- a/services/job-scheduler/src/scheduler/job-scheduler.ts
+++ b/services/job-scheduler/src/scheduler/job-scheduler.ts
@@ -1,0 +1,298 @@
+import { randomUUID } from 'node:crypto';
+
+import { logger } from '@trading-model/common/config/logger';
+
+import { env } from '../config/env';
+import { Job, JobEvent, JobStatus } from '../types/job.types';
+import { JobRepository } from '../persistence/job-repository';
+import { WorkerRegistry } from '../worker/worker-registry';
+import { WorkerProtocol } from '../worker/worker-protocol';
+import { InternalQueue } from './internal-queue';
+import { BackPressure } from './back-pressure';
+import { OrphanDetector } from '../recovery/orphan-detector';
+import { ReAllocator } from '../recovery/re-allocator';
+
+export class JobScheduler {
+  readonly queue: InternalQueue;
+  readonly backPressure: BackPressure;
+  readonly workers: WorkerRegistry;
+  readonly repository: JobRepository;
+  readonly reAllocator: ReAllocator;
+  readonly orphanDetector: OrphanDetector;
+  private workerProtocol: WorkerProtocol | null = null;
+
+  constructor(repository: JobRepository) {
+    this.queue = new InternalQueue(env.ACK_TIMEOUT_MS);
+    this.backPressure = new BackPressure(env.MAX_QUEUE_DEPTH, env.MAX_WORKER_LOAD_RATIO);
+    this.workers = new WorkerRegistry(env.WORKER_HEARTBEAT_TTL_MS);
+    this.repository = repository;
+    this.reAllocator = new ReAllocator(repository, this.queue);
+    this.orphanDetector = new OrphanDetector(
+      this.workers,
+      repository,
+      this.reAllocator,
+      env.ORPHAN_SCAN_INTERVAL_MS,
+    );
+
+    this.queue.setOnAckTimeout((jobId) => {
+      this.handleAckTimeout(jobId);
+    });
+  }
+
+  setWorkerProtocol(protocol: WorkerProtocol): void {
+    this.workerProtocol = protocol;
+  }
+
+  async submit(
+    type: string,
+    payload: unknown,
+    priority: 1 | 2 | 3 | 4 | 5 = 3,
+    maxRetries: number = env.MAX_RETRIES_PER_JOB,
+  ): Promise<string> {
+    if (!this.backPressure.canAccept()) {
+      logger.warn('Back pressure active — rejecting job submission');
+      throw Object.assign(
+        new Error('Job scheduler at capacity'),
+        { code: 'BACK_PRESSURE', retryAfter: this.backPressure.retryAfterSeconds() },
+      );
+    }
+
+    const jobId = randomUUID();
+    const now = new Date();
+
+    const job: Job = {
+      id: jobId,
+      type,
+      payload,
+      priority,
+      status: 'pending',
+      ackDeadline: 0,
+      maxRetries,
+      retryCount: 0,
+      createdAt: now,
+      history: [],
+    };
+
+    await this.repository.insert(job);
+    this.enqueueJob(job);
+
+    logger.info('Job submitted', { jobId, type, priority });
+    return jobId;
+  }
+
+  private enqueueJob(job: Job): void {
+    const updated: Job = { ...job, status: 'queued' };
+    this.queue.enqueue(updated);
+    this.backPressure.updateQueueDepth(this.queue.depth());
+    this.repository.updateStatus(job.id, 'queued').catch((err) => {
+      logger.error('Failed to persist queued status', { jobId: job.id, error: String(err) });
+    });
+    this.distributeNext();
+  }
+
+  private distributeNext(): void {
+    const queued = this.queue.dequeue();
+    if (!queued) return;
+
+    const worker = this.workers.findBestWorker(queued.job.type);
+    if (!worker) {
+      this.queue.enqueue(queued.job);
+      return;
+    }
+
+    const deadline = Date.now() + env.ACK_TIMEOUT_MS;
+    const assignedJob: Job = {
+      ...queued.job,
+      status: 'assigned',
+      assignedWorkerId: worker.workerId,
+      ackDeadline: deadline,
+    };
+
+    this.queue.markDelivered(assignedJob.id);
+
+    if (this.workerProtocol) {
+      this.workerProtocol.sendToWorker(worker.workerId, {
+        type: 'job.assigned',
+        job: {
+          id: assignedJob.id,
+          type: assignedJob.type,
+          payload: assignedJob.payload,
+          ackDeadline: deadline,
+        },
+      });
+    }
+
+    worker.currentLoad += 1;
+    this.backPressure.updateWorkerLoad(worker.workerId, worker.currentLoad / worker.maxConcurrency);
+
+    this.repository.updateStatus(assignedJob.id, 'assigned', {
+      assignedWorkerId: worker.workerId,
+      ackDeadline: deadline,
+    }).catch((err) => {
+      logger.error('Failed to persist assigned status', { jobId: assignedJob.id, error: String(err) });
+    });
+
+    logger.info('Job assigned to worker', {
+      jobId: assignedJob.id,
+      workerId: worker.workerId,
+    });
+  }
+
+  private handleAckTimeout(jobId: string): void {
+    logger.warn('ACK timeout for job', { jobId });
+
+    this.repository.findById(jobId).then((job) => {
+      if (!job || job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') return;
+
+      const workerId = job.assignedWorkerId;
+      if (workerId) {
+        const worker = this.workers.get(workerId);
+        if (worker) {
+          worker.currentLoad = Math.max(0, worker.currentLoad - 1);
+          this.backPressure.updateWorkerLoad(workerId, worker.currentLoad / worker.maxConcurrency);
+        }
+      }
+
+      this.repository.updateStatus(jobId, 'orphaned').then(() => {
+        this.reAllocator.reallocate(job);
+      }).catch((err) => {
+        logger.error('Failed to persist orphaned status on ACK timeout', {
+          jobId,
+          error: String(err),
+        });
+      });
+    }).catch((err) => {
+      logger.error('Failed to find job on ACK timeout', {
+        jobId,
+        error: String(err),
+      });
+    });
+  }
+
+  async ack(jobId: string): Promise<void> {
+    this.queue.ack(jobId);
+    await this.repository.updateStatus(jobId, 'running');
+
+    logger.info('Job acknowledged by worker', { jobId });
+  }
+
+  async complete(jobId: string, result: unknown): Promise<void> {
+    this.queue.ack(jobId);
+    await this.repository.updateStatus(jobId, 'completed', { result });
+
+    const job = await this.repository.findById(jobId);
+    if (job?.assignedWorkerId) {
+      const worker = this.workers.get(job.assignedWorkerId);
+      if (worker) {
+        worker.currentLoad = Math.max(0, worker.currentLoad - 1);
+        this.backPressure.updateWorkerLoad(
+          job.assignedWorkerId,
+          worker.currentLoad / worker.maxConcurrency,
+        );
+      }
+    }
+
+    logger.info('Job completed', { jobId });
+    this.distributeNext();
+  }
+
+  async fail(jobId: string, error: string): Promise<void> {
+    this.queue.ack(jobId);
+
+    const job = await this.repository.findById(jobId);
+    if (!job) return;
+
+    if (job.assignedWorkerId) {
+      const worker = this.workers.get(job.assignedWorkerId);
+      if (worker) {
+        worker.currentLoad = Math.max(0, worker.currentLoad - 1);
+        this.backPressure.updateWorkerLoad(
+          job.assignedWorkerId,
+          worker.currentLoad / worker.maxConcurrency,
+        );
+      }
+    }
+
+    if (job.retryCount >= job.maxRetries) {
+      await this.repository.updateStatus(jobId, 'failed', { error });
+
+      logger.warn('Job failed permanently', { jobId, retryCount: job.retryCount, error });
+    } else {
+      const newDeadline = Date.now() + env.ACK_TIMEOUT_MS;
+      const updatedJob: Job = {
+        ...job,
+        status: 'queued',
+        ackDeadline: newDeadline,
+        retryCount: job.retryCount + 1,
+        assignedWorkerId: undefined,
+      };
+
+      this.queue.enqueue(updatedJob);
+      await this.repository.incrementRetry(jobId);
+      await this.repository.updateStatus(jobId, 'queued', {
+        ackDeadline: newDeadline,
+      });
+
+      logger.info('Job re-queued after failure', { jobId, retryCount: updatedJob.retryCount });
+      this.distributeNext();
+    }
+  }
+
+  async cancel(jobId: string): Promise<void> {
+    const job = await this.repository.findById(jobId);
+    if (!job) return;
+
+    if (job.status === 'running' || job.status === 'completed') {
+      throw new Error('Cannot cancel a running or completed job');
+    }
+
+    this.queue.ack(jobId);
+    await this.repository.updateStatus(jobId, 'cancelled');
+
+    if (job.assignedWorkerId) {
+      const worker = this.workers.get(job.assignedWorkerId);
+      if (worker) {
+        worker.currentLoad = Math.max(0, worker.currentLoad - 1);
+      }
+    }
+
+    logger.info('Job cancelled', { jobId });
+  }
+
+  onWorkerDisconnect(workerId: string): void {
+    this.backPressure.removeWorker(workerId);
+  }
+
+  async start(): Promise<void> {
+    const nonTerminal = await this.repository.findNonTerminal();
+
+    for (const job of nonTerminal) {
+      if (job.status === 'queued' || job.status === 'pending') {
+        this.queue.enqueue({ ...job, status: 'queued' });
+      } else if (job.status === 'assigned' || job.status === 'running') {
+        await this.repository.updateStatus(job.id, 'orphaned');
+        await this.reAllocator.reallocate(job);
+      } else if (job.status === 'orphaned') {
+        await this.reAllocator.reallocate(job);
+      }
+    }
+
+    this.backPressure.updateQueueDepth(this.queue.depth());
+
+    logger.info('Job scheduler started — recovered jobs from persistence', {
+      recovered: nonTerminal.length,
+    });
+
+    this.orphanDetector.start();
+  }
+
+  async stop(): Promise<void> {
+    this.orphanDetector.stop();
+    this.queue.stop();
+    if (this.workerProtocol) {
+      this.workerProtocol.close();
+    }
+
+    logger.info('Job scheduler stopped');
+  }
+}

--- a/services/job-scheduler/src/scheduler/job-scheduler.ts
+++ b/services/job-scheduler/src/scheduler/job-scheduler.ts
@@ -2,15 +2,15 @@ import { randomUUID } from 'node:crypto';
 
 import { logger } from '@trading-model/common/config/logger';
 
-import { env } from '../config/env';
-import { Job, JobEvent, JobStatus } from '../types/job.types';
-import { JobRepository } from '../persistence/job-repository';
-import { WorkerRegistry } from '../worker/worker-registry';
-import { WorkerProtocol } from '../worker/worker-protocol';
-import { InternalQueue } from './internal-queue';
 import { BackPressure } from './back-pressure';
+import { InternalQueue } from './internal-queue';
+import { env } from '../config/env';
+import { JobRepository } from '../persistence/job-repository';
 import { OrphanDetector } from '../recovery/orphan-detector';
 import { ReAllocator } from '../recovery/re-allocator';
+import { Job } from '../types/job.types';
+import { WorkerProtocol } from '../worker/worker-protocol';
+import { WorkerRegistry } from '../worker/worker-registry';
 
 export class JobScheduler {
   readonly queue: InternalQueue;

--- a/services/job-scheduler/src/types/job.types.ts
+++ b/services/job-scheduler/src/types/job.types.ts
@@ -1,0 +1,65 @@
+export type JobStatus =
+  | 'pending'
+  | 'queued'
+  | 'assigned'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'orphaned';
+
+export interface JobEvent {
+  fromStatus: JobStatus;
+  toStatus: JobStatus;
+  timestamp: Date;
+  reason: string;
+}
+
+export interface Job<T = unknown> {
+  id: string;
+  type: string;
+  payload: T;
+  priority: 1 | 2 | 3 | 4 | 5;
+  status: JobStatus;
+  assignedWorkerId?: string;
+  ackDeadline: number;
+  maxRetries: number;
+  retryCount: number;
+  createdAt: Date;
+  startedAt?: Date;
+  completedAt?: Date;
+  result?: unknown;
+  error?: string;
+  history: JobEvent[];
+}
+
+export interface QueuedJob<T = unknown> {
+  job: Job<T>;
+  state: 'queued' | 'delivered' | 'acknowledged';
+  deliveryAttempts: number;
+  expiresAt: number;
+  assignedAt?: Date;
+}
+
+export interface SchedulerScaleUpEvent {
+  event: 'scheduler.scale-up';
+  jobType: string;
+  queueDepth: number;
+  availableWorkers: number;
+  suggestedCount: number;
+}
+
+export interface SchedulerScaleDownEvent {
+  event: 'scheduler.scale-down';
+  jobType: string;
+  workerCount: number;
+  avgLoad: number;
+}
+
+export const JOB_STATUS_NON_TERMINAL: JobStatus[] = [
+  'pending',
+  'queued',
+  'assigned',
+  'running',
+  'orphaned',
+];

--- a/services/job-scheduler/src/types/worker.types.ts
+++ b/services/job-scheduler/src/types/worker.types.ts
@@ -1,0 +1,61 @@
+export type WorkerStatus = 'active' | 'draining' | 'offline';
+
+export interface WorkerRegistration {
+  workerId: string;
+  address: string;
+  port: number;
+  capabilities: string[];
+  maxConcurrency: number;
+  currentLoad: number;
+  lastHeartbeat: Date;
+  status: WorkerStatus;
+}
+
+export interface WorkerWsRegisterMessage {
+  type: 'register';
+  workerId: string;
+  address: string;
+  port: number;
+  capabilities: string[];
+  maxConcurrency: number;
+}
+
+export interface WorkerWsHeartbeatMessage {
+  type: 'heartbeat';
+  workerId: string;
+  currentLoad: number;
+}
+
+export interface WorkerWsDisconnectMessage {
+  type: 'disconnect';
+  workerId: string;
+  reason?: string;
+}
+
+export type WorkerIncomingMessage =
+  | WorkerWsRegisterMessage
+  | WorkerWsHeartbeatMessage
+  | WorkerWsDisconnectMessage;
+
+export interface SchedulerWsJobAssignedMessage {
+  type: 'job.assigned';
+  job: {
+    id: string;
+    type: string;
+    payload: unknown;
+    ackDeadline: number;
+  };
+}
+
+export interface SchedulerWsHeartbeatAckMessage {
+  type: 'heartbeat.ack';
+}
+
+export interface SchedulerWsDrainMessage {
+  type: 'drain';
+}
+
+export type SchedulerOutgoingMessage =
+  | SchedulerWsJobAssignedMessage
+  | SchedulerWsHeartbeatAckMessage
+  | SchedulerWsDrainMessage;

--- a/services/job-scheduler/src/worker/worker-protocol.ts
+++ b/services/job-scheduler/src/worker/worker-protocol.ts
@@ -1,0 +1,114 @@
+import { Duplex } from 'stream';
+
+import WebSocket, { WebSocketServer } from 'ws';
+
+import { logger } from '@trading-model/common/config/logger';
+
+import { SchedulerOutgoingMessage, WorkerIncomingMessage } from '../types/worker.types';
+import { WorkerRegistry } from './worker-registry';
+
+export class WorkerProtocol {
+  private readonly wss: WebSocketServer;
+  private readonly connections: Map<string, WebSocket> = new Map();
+
+  constructor(
+    server: Duplex,
+    private readonly workerRegistry: WorkerRegistry,
+    private readonly onWorkerDisconnect: (workerId: string) => void,
+  ) {
+    this.wss = new WebSocketServer({ server });
+
+    this.wss.on('connection', (ws: WebSocket) => {
+      ws.on('message', (data: WebSocket.Data) => {
+        try {
+          const message: WorkerIncomingMessage = JSON.parse(data.toString());
+
+          switch (message.type) {
+            case 'register':
+              this.handleRegister(message, ws);
+              break;
+            case 'heartbeat':
+              this.handleHeartbeat(message);
+              break;
+            case 'disconnect':
+              this.handleDisconnect(message);
+              break;
+          }
+        } catch (err) {
+          logger.error('Invalid WebSocket message from worker', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      });
+
+      ws.on('close', () => {
+        for (const [workerId, conn] of this.connections) {
+          if (conn === ws) {
+            this.connections.delete(workerId);
+            this.workerRegistry.setStatus(workerId, 'draining');
+            this.onWorkerDisconnect(workerId);
+            break;
+          }
+        }
+      });
+    });
+  }
+
+  private handleRegister(message: WorkerIncomingMessage & { type: 'register' }, ws: WebSocket): void {
+    this.workerRegistry.register(message.workerId, {
+      workerId: message.workerId,
+      address: message.address,
+      port: message.port,
+      capabilities: message.capabilities,
+      maxConcurrency: message.maxConcurrency,
+      currentLoad: 0,
+    });
+    this.connections.set(message.workerId, ws);
+
+    logger.info('Worker registered via WebSocket', { workerId: message.workerId });
+  }
+
+  private handleHeartbeat(message: WorkerIncomingMessage & { type: 'heartbeat' }): void {
+    this.workerRegistry.heartbeat(message.workerId);
+    this.workerRegistry.updateLoad(message.workerId, message.currentLoad);
+
+    const ws = this.connections.get(message.workerId);
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'heartbeat.ack' }));
+    }
+  }
+
+  private handleDisconnect(message: WorkerIncomingMessage & { type: 'disconnect' }): void {
+    this.connections.delete(message.workerId);
+    this.workerRegistry.unregister(message.workerId);
+    this.onWorkerDisconnect(message.workerId);
+
+    logger.info('Worker disconnected', { workerId: message.workerId, reason: message.reason });
+  }
+
+  sendToWorker(workerId: string, message: SchedulerOutgoingMessage): void {
+    const ws = this.connections.get(workerId);
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(message));
+    }
+  }
+
+  sendDrain(workerId: string): void {
+    this.sendToWorker(workerId, { type: 'drain' });
+  }
+
+  broadcastDrain(): void {
+    for (const [workerId] of this.connections) {
+      this.sendDrain(workerId);
+    }
+  }
+
+  close(): void {
+    this.broadcastDrain();
+    for (const ws of this.connections.values()) {
+      ws.close();
+    }
+    this.connections.clear();
+    this.wss.close();
+  }
+}

--- a/services/job-scheduler/src/worker/worker-protocol.ts
+++ b/services/job-scheduler/src/worker/worker-protocol.ts
@@ -1,18 +1,18 @@
-import { Duplex } from 'stream';
+import https from 'node:https';
 
 import WebSocket, { WebSocketServer } from 'ws';
 
 import { logger } from '@trading-model/common/config/logger';
 
-import { SchedulerOutgoingMessage, WorkerIncomingMessage } from '../types/worker.types';
 import { WorkerRegistry } from './worker-registry';
+import { SchedulerOutgoingMessage, WorkerIncomingMessage } from '../types/worker.types';
 
 export class WorkerProtocol {
   private readonly wss: WebSocketServer;
   private readonly connections: Map<string, WebSocket> = new Map();
 
   constructor(
-    server: Duplex,
+    server: https.Server,
     private readonly workerRegistry: WorkerRegistry,
     private readonly onWorkerDisconnect: (workerId: string) => void,
   ) {

--- a/services/job-scheduler/src/worker/worker-registry.ts
+++ b/services/job-scheduler/src/worker/worker-registry.ts
@@ -1,0 +1,97 @@
+import { WorkerRegistration, WorkerStatus } from '../types/worker.types';
+
+export class WorkerRegistry {
+  private readonly workers: Map<string, WorkerRegistration> = new Map();
+  private readonly heartbeatTtlMs: number;
+
+  constructor(heartbeatTtlMs: number) {
+    this.heartbeatTtlMs = heartbeatTtlMs;
+  }
+
+  register(workerId: string, registration: Omit<WorkerRegistration, 'lastHeartbeat' | 'status'>): void {
+    this.workers.set(workerId, {
+      ...registration,
+      lastHeartbeat: new Date(),
+      status: 'active',
+    });
+  }
+
+  unregister(workerId: string): void {
+    this.workers.delete(workerId);
+  }
+
+  get(workerId: string): WorkerRegistration | undefined {
+    return this.workers.get(workerId);
+  }
+
+  heartbeat(workerId: string): void {
+    const worker = this.workers.get(workerId);
+    if (worker) {
+      worker.lastHeartbeat = new Date();
+    }
+  }
+
+  updateLoad(workerId: string, currentLoad: number): void {
+    const worker = this.workers.get(workerId);
+    if (worker) {
+      worker.currentLoad = currentLoad;
+    }
+  }
+
+  setStatus(workerId: string, status: WorkerStatus): void {
+    const worker = this.workers.get(workerId);
+    if (worker) {
+      worker.status = status;
+    }
+  }
+
+  findBestWorker(jobType: string): WorkerRegistration | null {
+    let best: WorkerRegistration | null = null;
+    let bestLoad = Infinity;
+
+    for (const worker of this.workers.values()) {
+      if (worker.status !== 'active') continue;
+      if (!worker.capabilities.includes(jobType)) continue;
+      if (worker.currentLoad >= worker.maxConcurrency) continue;
+      if (worker.currentLoad < bestLoad) {
+        best = worker;
+        bestLoad = worker.currentLoad;
+      }
+    }
+    return best;
+  }
+
+  purgeStaleWorkers(): string[] {
+    const now = Date.now();
+    const stale: string[] = [];
+    for (const [id, worker] of this.workers) {
+      if (now - worker.lastHeartbeat.getTime() > this.heartbeatTtlMs) {
+        worker.status = 'offline';
+        stale.push(id);
+      }
+    }
+    for (const id of stale) {
+      this.workers.delete(id);
+    }
+    return stale;
+  }
+
+  count(): number {
+    return this.workers.size;
+  }
+
+  averageLoad(): number {
+    if (this.workers.size === 0) return 0;
+    let total = 0;
+    for (const worker of this.workers.values()) {
+      if (worker.maxConcurrency > 0) {
+        total += worker.currentLoad / worker.maxConcurrency;
+      }
+    }
+    return total / this.workers.size;
+  }
+
+  getAllActive(): WorkerRegistration[] {
+    return Array.from(this.workers.values()).filter(w => w.status === 'active');
+  }
+}

--- a/services/job-scheduler/tests/fixtures/job.fixture.ts
+++ b/services/job-scheduler/tests/fixtures/job.fixture.ts
@@ -1,0 +1,31 @@
+import type { Job, JobEvent, QueuedJob } from '../../src/types/job.types';
+
+export const createJobEvent = (overrides?: Partial<JobEvent>): JobEvent => ({
+  fromStatus: 'pending',
+  toStatus: 'queued',
+  timestamp: new Date(),
+  reason: 'created',
+  ...overrides,
+});
+
+export const createJob = (overrides?: Partial<Job>): Job => ({
+  id: 'test-job-1',
+  type: 'test-job-type',
+  payload: { key: 'value' },
+  priority: 3,
+  status: 'pending',
+  ackDeadline: 0,
+  maxRetries: 3,
+  retryCount: 0,
+  createdAt: new Date(),
+  history: [],
+  ...overrides,
+});
+
+export const createQueuedJob = (overrides?: Partial<QueuedJob>): QueuedJob => ({
+  job: createJob(),
+  state: 'queued',
+  deliveryAttempts: 0,
+  expiresAt: 0,
+  ...overrides,
+});

--- a/services/job-scheduler/tests/fixtures/worker.fixture.ts
+++ b/services/job-scheduler/tests/fixtures/worker.fixture.ts
@@ -1,0 +1,13 @@
+import type { WorkerRegistration } from '../../src/types/worker.types';
+
+export const createWorkerRegistration = (overrides?: Partial<WorkerRegistration>): WorkerRegistration => ({
+  workerId: 'test-worker-1',
+  address: '192.168.1.10',
+  port: 9000,
+  capabilities: ['test-job-type', 'another-type'],
+  maxConcurrency: 5,
+  currentLoad: 0,
+  lastHeartbeat: new Date(),
+  status: 'active',
+  ...overrides,
+});

--- a/services/job-scheduler/tests/helpers/express.ts
+++ b/services/job-scheduler/tests/helpers/express.ts
@@ -1,0 +1,10 @@
+export const createReq = (overrides: Record<string, unknown> = {}): any => ({
+  body: {},
+  params: {},
+  headers: {},
+  ...overrides,
+});
+
+export const createRes = (): any => ({});
+
+export const createNext = () => undefined;

--- a/services/job-scheduler/tests/unit/app/index.spec.ts
+++ b/services/job-scheduler/tests/unit/app/index.spec.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeAll, jest } from '@jest/globals';
+
+const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+jest.mock('@trading-model/common/config/logger', () => ({
+  logger: mockLogger,
+}));
+
+let capturedOptions: any;
+
+jest.mock('@trading-model/common/server/bootstrap', () => ({
+  createBootstrap: jest.fn((options: any) => {
+    capturedOptions = options;
+    return { server: null, shutdown: jest.fn() };
+  }),
+}));
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    MONGODB_URI: 'mongodb://localhost:27017/test',
+    PORT: 3000,
+    MAX_QUEUE_DEPTH: 10000,
+    ACK_TIMEOUT_MS: 30000,
+  },
+}));
+
+const mockAddressManager = { stop: jest.fn() };
+jest.mock('../../../src/config/address-manager', () => ({
+  bootstrapAddressManager: jest.fn(() => mockAddressManager),
+}));
+
+const mockRepositoryInstance = {
+  ensureIndexes: jest.fn<any>(),
+  insert: jest.fn<any>(),
+  findById: jest.fn<any>(),
+  updateStatus: jest.fn<any>(),
+  incrementRetry: jest.fn<any>(),
+  findNonTerminal: jest.fn<any>(),
+  findByWorker: jest.fn<any>(),
+  findByStatus: jest.fn<any>(),
+};
+
+jest.mock('../../../src/persistence/job-repository', () => ({
+  JobRepository: jest.fn(() => mockRepositoryInstance),
+}));
+
+const mockSchedulerInstance = {
+  workers: { register: jest.fn(), get: jest.fn(), unregister: jest.fn() },
+  setWorkerProtocol: jest.fn<any>(),
+  start: jest.fn<any>(),
+  stop: jest.fn<any>(),
+  onWorkerDisconnect: jest.fn(),
+};
+
+jest.mock('../../../src/scheduler/job-scheduler', () => ({
+  JobScheduler: jest.fn(() => mockSchedulerInstance),
+}));
+
+const mockWorkerProtocolInstance = { close: jest.fn() };
+
+jest.mock('../../../src/worker/worker-protocol', () => ({
+  WorkerProtocol: jest.fn(() => mockWorkerProtocolInstance),
+}));
+
+const mockHttpServer = { raw: 'mock-raw-server' };
+jest.mock('../../../src/app/server', () => ({
+  createServer: jest.fn(() => mockHttpServer),
+}));
+
+const mockDb = { collection: jest.fn() };
+const mockMongoClient = {
+  connect: jest.fn<any>(),
+  db: jest.fn(() => mockDb),
+  close: jest.fn<any>(),
+};
+
+jest.mock('mongodb', () => ({
+  MongoClient: jest.fn(() => mockMongoClient),
+}));
+
+import { createBootstrap } from '@trading-model/common/server/bootstrap';
+import { bootstrapAddressManager } from '../../../src/config/address-manager';
+import { JobRepository } from '../../../src/persistence/job-repository';
+import { JobScheduler } from '../../../src/scheduler/job-scheduler';
+import { WorkerProtocol } from '../../../src/worker/worker-protocol';
+import { createServer } from '../../../src/app/server';
+
+const mockCreateBootstrap = createBootstrap as jest.Mock;
+
+import '../../../src/app/index';
+
+describe('Job Scheduler entry point (index.ts)', () => {
+  beforeAll(() => {
+    expect(capturedOptions).toBeDefined();
+  });
+
+  it('should call createBootstrap with name "Job Scheduler"', () => {
+    expect(mockCreateBootstrap).toHaveBeenCalledTimes(1);
+    expect(capturedOptions.name).toBe('Job Scheduler');
+  });
+
+  it('should handle onStop when all resources are null', async () => {
+    await capturedOptions.onStop();
+
+    expect(mockSchedulerInstance.stop).not.toHaveBeenCalled();
+    expect(mockWorkerProtocolInstance.close).not.toHaveBeenCalled();
+    expect(mockAddressManager.stop).not.toHaveBeenCalled();
+    expect(mockMongoClient.close).not.toHaveBeenCalled();
+  });
+
+  describe('createServer callback', () => {
+    it('should create all resources and return server', async () => {
+      const server = await capturedOptions.createServer();
+
+      expect(mockMongoClient.connect).toHaveBeenCalledTimes(1);
+      expect(mockMongoClient.db).toHaveBeenCalledTimes(1);
+      expect(JobRepository).toHaveBeenCalledWith(mockDb);
+      expect(mockRepositoryInstance.ensureIndexes).toHaveBeenCalledTimes(1);
+      expect(JobScheduler).toHaveBeenCalledWith(mockRepositoryInstance);
+      expect(createServer).toHaveBeenCalledWith(expect.objectContaining({
+        workers: mockSchedulerInstance.workers,
+        setWorkerProtocol: mockSchedulerInstance.setWorkerProtocol,
+        start: mockSchedulerInstance.start,
+      }));
+      expect(WorkerProtocol).toHaveBeenCalledWith(
+        'mock-raw-server',
+        expect.objectContaining({ register: expect.any(Function) }),
+        expect.any(Function),
+      );
+      expect(mockSchedulerInstance.setWorkerProtocol).toHaveBeenCalledWith(
+        mockWorkerProtocolInstance,
+      );
+      expect(mockSchedulerInstance.start).toHaveBeenCalledTimes(1);
+      expect(server).toBe(mockHttpServer);
+    });
+
+    it('should pass onWorkerDisconnect callback to WorkerProtocol', async () => {
+      const [, , disconnectCallback] = (WorkerProtocol as unknown as jest.Mock).mock.calls[0];
+
+      (disconnectCallback as any)('worker-1');
+
+      expect(mockSchedulerInstance.onWorkerDisconnect).toHaveBeenCalledWith('worker-1');
+    });
+  });
+
+  describe('onStart callback', () => {
+    it('should bootstrap address manager and log service info', () => {
+      capturedOptions.onStart();
+
+      expect(bootstrapAddressManager).toHaveBeenCalledTimes(1);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Job Scheduler fully operational',
+        expect.objectContaining({
+          port: 3000,
+          maxQueueDepth: 10000,
+          ackTimeoutMs: 30000,
+        }),
+      );
+    });
+  });
+
+  describe('onStop callback', () => {
+    it('should stop scheduler, close worker protocol, stop address manager, close mongo client', async () => {
+      await capturedOptions.onStop();
+
+      expect(mockSchedulerInstance.stop).toHaveBeenCalledTimes(1);
+      expect(mockWorkerProtocolInstance.close).toHaveBeenCalledTimes(1);
+      expect(mockAddressManager.stop).toHaveBeenCalledTimes(1);
+      expect(mockMongoClient.close).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/services/job-scheduler/tests/unit/app/server.spec.ts
+++ b/services/job-scheduler/tests/unit/app/server.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+const mockApp = {
+  use: jest.fn(),
+};
+
+const mockServer = {
+  raw: mockApp,
+};
+
+const mockTlsConfig = {
+  key: '/some/key.pem',
+  cert: '/some/cert.pem',
+  ca: '/some/ca.pem',
+};
+
+const mockJobRoutes = jest.fn();
+const mockAckRoutes = jest.fn();
+const mockWorkerRoutes = jest.fn();
+const mockHealthRoutes = jest.fn();
+const mockAddressManagerRoutes = jest.fn();
+
+jest.mock('@trading-model/common/server/create-secure-server', () => ({
+  createSecureServer: jest.fn(() => Promise.resolve(mockServer)),
+}));
+
+jest.mock('@trading-model/common/server/load-tls-config', () => ({
+  loadTlsConfig: jest.fn(() => mockTlsConfig),
+}));
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    PORT: 3000,
+    NODE_ENV: 'test',
+    TLS_KEY_PATH: '/some/key.pem',
+    TLS_CERT_PATH: '/some/cert.pem',
+    TLS_CA_PATH: '/some/ca.pem',
+    APP_NAME: 'job-scheduler',
+    SERVICE_NAME: 'jobs',
+    INSTANCE_ID: 'instance-1',
+    ADDRESS_MANAGER_URL: 'https://address-manager:3000',
+  },
+}));
+
+jest.mock('../../../src/routes/ack.routes', () => ({
+  ackRoutes: jest.fn(() => mockAckRoutes),
+}));
+
+jest.mock('../../../src/routes/health.routes', () => ({
+  healthRoutes: jest.fn(() => mockHealthRoutes),
+}));
+
+jest.mock('../../../src/routes/job.routes', () => ({
+  jobRoutes: jest.fn(() => mockJobRoutes),
+}));
+
+jest.mock('../../../src/routes/worker.routes', () => ({
+  workerRoutes: jest.fn(() => mockWorkerRoutes),
+}));
+
+jest.mock('../../../src/config/address-manager', () => ({
+  AddressManagerRoutes: jest.fn(),
+}));
+
+import { createSecureServer } from '@trading-model/common/server/create-secure-server';
+import { loadTlsConfig } from '@trading-model/common/server/load-tls-config';
+import { createServer } from '../../../src/app/server';
+import { ackRoutes } from '../../../src/routes/ack.routes';
+import { healthRoutes } from '../../../src/routes/health.routes';
+import { jobRoutes } from '../../../src/routes/job.routes';
+import { workerRoutes } from '../../../src/routes/worker.routes';
+
+describe('createServer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create a secure server and register all routes', async () => {
+    const scheduler = { workers: 'workers-mock', queue: 'queue-mock', backPressure: 'back-pressure-mock' } as any;
+
+    const server = await createServer(scheduler);
+
+    expect(server).toBe(mockServer);
+    expect(createSecureServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        port: 3000,
+        tls: mockTlsConfig,
+        trustProxy: true,
+      }),
+    );
+
+    expect(loadTlsConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TLS_KEY_PATH: '/some/key.pem',
+        TLS_CERT_PATH: '/some/cert.pem',
+        TLS_CA_PATH: '/some/ca.pem',
+      }),
+    );
+
+    const secureServerOptions = (createSecureServer as jest.Mock).mock.calls[0][0] as any;
+
+    secureServerOptions.routes(mockApp);
+
+    expect(jobRoutes).toHaveBeenCalledWith(scheduler);
+    expect(ackRoutes).toHaveBeenCalledWith(scheduler);
+    expect(workerRoutes).toHaveBeenCalledWith(scheduler.workers);
+    expect(healthRoutes).toHaveBeenCalledWith(scheduler.queue, scheduler.backPressure, scheduler.workers);
+
+    expect(mockApp.use).toHaveBeenCalledWith('/', mockJobRoutes);
+    expect(mockApp.use).toHaveBeenCalledWith('/', mockAckRoutes);
+    expect(mockApp.use).toHaveBeenCalledWith('/', mockWorkerRoutes);
+    expect(mockApp.use).toHaveBeenCalledWith('/', mockHealthRoutes);
+  });
+});

--- a/services/job-scheduler/tests/unit/config/address-manager.spec.ts
+++ b/services/job-scheduler/tests/unit/config/address-manager.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+const mockAddressManager = {
+  start: jest.fn(),
+  listenExpress: jest.fn(),
+};
+
+jest.mock('@trading-model/address-manager/create-address-manager', () => ({
+  createAddressManager: jest.fn(() => mockAddressManager),
+}));
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    NODE_ENV: 'test',
+    PORT: 3000,
+    TLS_KEY_PATH: '/some/key.pem',
+    TLS_CERT_PATH: '/some/cert.pem',
+    TLS_CA_PATH: '/some/ca.pem',
+    APP_NAME: 'job-scheduler',
+    SERVICE_NAME: 'jobs',
+    INSTANCE_ID: 'instance-1',
+    ADDRESS_MANAGER_URL: 'https://address-manager:3000',
+    CACHE_TTL_MS: 30000,
+    SERVICE_PING_TIMEOUT_MS: 2000,
+    DISCOVERY_TIMEOUT_MS: 5000,
+    TOKEN_REFRESH_INTERVAL_MS: 60000,
+    TTL_REFRESH_INTERVAL_MS: 15000,
+    MONGODB_URI: 'mongodb://localhost:27017/job-scheduler',
+    MAX_QUEUE_DEPTH: 10000,
+    MAX_WORKER_LOAD_RATIO: 0.85,
+    ACK_TIMEOUT_MS: 30000,
+    MAX_RETRIES_PER_JOB: 3,
+    ORPHAN_SCAN_INTERVAL_MS: 10000,
+    WORKER_HEARTBEAT_TTL_MS: 30000,
+  },
+}));
+
+describe('address-manager config', () => {
+  it('should export AddressManagerRoutes, bootstrapAddressManager, and AddressManager', () => {
+    const addressManagerModule = require('../../../src/config/address-manager');
+
+    expect(addressManagerModule.AddressManagerRoutes).toBeDefined();
+    expect(addressManagerModule.AddressManagerRoutes).toBe(mockAddressManager.listenExpress);
+    expect(addressManagerModule.bootstrapAddressManager).toBeDefined();
+    expect(addressManagerModule.bootstrapAddressManager).toBe(mockAddressManager.start);
+    expect(addressManagerModule.AddressManager).toBeDefined();
+    expect(addressManagerModule.AddressManager).toBe(mockAddressManager);
+  });
+});

--- a/services/job-scheduler/tests/unit/config/env.spec.ts
+++ b/services/job-scheduler/tests/unit/config/env.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+const REQUIRED_ENV: Record<string, string> = {
+  NODE_ENV: 'test',
+  TLS_KEY_PATH: '/some/key.pem',
+  TLS_CERT_PATH: '/some/cert.pem',
+  TLS_CA_PATH: '/some/ca.pem',
+  APP_NAME: 'job-scheduler',
+  SERVICE_NAME: 'jobs',
+  INSTANCE_ID: 'instance-1',
+  ADDRESS_MANAGER_URL: 'https://address-manager:3000',
+};
+
+describe('env validation', () => {
+  it('should succeed when all required env vars are set', () => {
+    jest.isolateModules(() => {
+      Object.assign(process.env, REQUIRED_ENV);
+
+      const { env } = require('../../../src/config/env');
+
+      expect(env.NODE_ENV).toBe('test');
+      expect(env.TLS_KEY_PATH).toBe('/some/key.pem');
+      expect(env.TLS_CERT_PATH).toBe('/some/cert.pem');
+      expect(env.TLS_CA_PATH).toBe('/some/ca.pem');
+      expect(env.APP_NAME).toBe('job-scheduler');
+      expect(env.SERVICE_NAME).toBe('jobs');
+      expect(env.INSTANCE_ID).toBe('instance-1');
+      expect(env.ADDRESS_MANAGER_URL).toBe('https://address-manager:3000');
+    });
+  });
+
+  it('should throw when required env var TLS_KEY_PATH is missing', () => {
+    jest.isolateModules(() => {
+      Object.assign(process.env, REQUIRED_ENV);
+      delete process.env.TLS_KEY_PATH;
+
+      expect(() => {
+        require('../../../src/config/env');
+      }).toThrow();
+    });
+  });
+});

--- a/services/job-scheduler/tests/unit/persistence/job-repository.spec.ts
+++ b/services/job-scheduler/tests/unit/persistence/job-repository.spec.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+const mockCollection = {
+  insertOne: jest.fn<any>(),
+  findOne: jest.fn<any>(),
+  updateOne: jest.fn<any>(),
+  find: jest.fn<any>(),
+  createIndex: jest.fn<any>(),
+};
+
+const mockDb = {
+  collection: jest.fn<any>().mockReturnValue(mockCollection),
+};
+
+jest.mock('mongodb', () => ({
+  Db: jest.fn(),
+  Collection: jest.fn(),
+}));
+
+import { JobRepository } from '../../../src/persistence/job-repository';
+import { Job, JobStatus } from '../../../src/types/job.types';
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: 'job-1',
+    type: 'test-type',
+    payload: { foo: 'bar' },
+    priority: 3,
+    status: 'queued',
+    assignedWorkerId: undefined,
+    ackDeadline: Date.now() + 30000,
+    maxRetries: 3,
+    retryCount: 0,
+    createdAt: new Date(),
+    startedAt: undefined,
+    completedAt: undefined,
+    result: undefined,
+    error: undefined,
+    history: [],
+    ...overrides,
+  };
+}
+
+describe('JobRepository', () => {
+  let repository: JobRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCollection.find.mockReturnValue({ toArray: jest.fn<any>() });
+    repository = new JobRepository(mockDb as any);
+  });
+
+  describe('constructor', () => {
+    it('should call db.collection with "jobs"', () => {
+      expect(mockDb.collection).toHaveBeenCalledWith('jobs');
+    });
+  });
+
+  describe('ensureIndexes', () => {
+    it('should create 4 indexes', async () => {
+      mockCollection.createIndex.mockResolvedValue(undefined);
+
+      await repository.ensureIndexes();
+
+      expect(mockCollection.createIndex).toHaveBeenCalledTimes(4);
+      expect(mockCollection.createIndex).toHaveBeenCalledWith({ jobId: 1 }, { unique: true });
+      expect(mockCollection.createIndex).toHaveBeenCalledWith({ status: 1 });
+      expect(mockCollection.createIndex).toHaveBeenCalledWith({ assignedWorkerId: 1 }, { sparse: true });
+      expect(mockCollection.createIndex).toHaveBeenCalledWith({ type: 1, status: 1 });
+    });
+  });
+
+  describe('insert', () => {
+    it('should call insertOne with a document', async () => {
+      mockCollection.insertOne.mockResolvedValue({ insertedId: 'job-1' });
+      const job = makeJob();
+
+      await repository.insert(job);
+
+      expect(mockCollection.insertOne).toHaveBeenCalledTimes(1);
+      const doc = mockCollection.insertOne.mock.calls[0][0] as any;
+      expect(doc.jobId).toBe('job-1');
+      expect(doc.type).toBe('test-type');
+      expect(doc.payload).toEqual({ foo: 'bar' });
+      expect(doc.priority).toBe(3);
+      expect(doc.status).toBe('queued');
+    });
+
+    it('should map history entries correctly', async () => {
+      mockCollection.insertOne.mockResolvedValue({ insertedId: 'job-1' });
+      const job = makeJob({
+        history: [
+          { fromStatus: 'pending', toStatus: 'queued', timestamp: new Date('2025-01-01'), reason: 'submitted' },
+        ],
+      });
+
+      await repository.insert(job);
+
+      const doc = mockCollection.insertOne.mock.calls[0][0] as any;
+      expect(doc.history).toHaveLength(1);
+      expect(doc.history[0].fromStatus).toBe('pending');
+      expect(doc.history[0].toStatus).toBe('queued');
+    });
+  });
+
+  describe('findById', () => {
+    it('should return null when not found', async () => {
+      mockCollection.findOne.mockResolvedValue(null);
+
+      const result = await repository.findById('nonexistent');
+
+      expect(result).toBeNull();
+      expect(mockCollection.findOne).toHaveBeenCalledWith({ jobId: 'nonexistent' });
+    });
+
+    it('should return a Job when found', async () => {
+      const doc = {
+        jobId: 'job-1',
+        type: 'test-type',
+        payload: { foo: 'bar' },
+        priority: 3,
+        status: 'queued',
+        assignedWorkerId: 'worker-1',
+        ackDeadline: 12345,
+        maxRetries: 3,
+        retryCount: 1,
+        createdAt: new Date('2025-01-01'),
+        startedAt: new Date('2025-01-02'),
+        completedAt: undefined,
+        result: { data: 'ok' },
+        error: undefined,
+        history: [
+          { fromStatus: 'pending', toStatus: 'queued', timestamp: new Date('2025-01-01T00:00:00Z'), reason: 'submitted' },
+        ],
+      };
+      mockCollection.findOne.mockResolvedValue(doc);
+
+      const result = await repository.findById('job-1');
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('job-1');
+      expect(result!.type).toBe('test-type');
+      expect(result!.priority).toBe(3);
+      expect(result!.status).toBe('queued');
+      expect(result!.ackDeadline).toBe(12345);
+      expect(result!.retryCount).toBe(1);
+      expect(result!.assignedWorkerId).toBe('worker-1');
+      expect(result!.startedAt).toBeInstanceOf(Date);
+      expect(result!.result).toEqual({ data: 'ok' });
+      expect(result!.history).toHaveLength(1);
+      expect(result!.history[0].fromStatus).toBe('pending');
+      expect(result!.history[0].toStatus).toBe('queued');
+    });
+  });
+
+  describe('updateStatus', () => {
+    beforeEach(() => {
+      const currentDoc = {
+        jobId: 'job-1',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'queued',
+        assignedWorkerId: undefined,
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+      };
+      mockCollection.findOne.mockResolvedValue(currentDoc);
+      mockCollection.updateOne.mockResolvedValue({ modifiedCount: 1 });
+    });
+
+    it('should do nothing when job is not found', async () => {
+      mockCollection.findOne.mockResolvedValue(null);
+
+      await repository.updateStatus('nonexistent', 'running');
+
+      expect(mockCollection.updateOne).not.toHaveBeenCalled();
+    });
+
+    it('should set startedAt when status is running', async () => {
+      await repository.updateStatus('job-1', 'running');
+
+      expect(mockCollection.updateOne).toHaveBeenCalledWith(
+        { jobId: 'job-1' },
+        expect.objectContaining({
+          $set: expect.objectContaining({ status: 'running', startedAt: expect.any(Date) }),
+        }),
+      );
+    });
+
+    it('should set completedAt when status is completed', async () => {
+      await repository.updateStatus('job-1', 'completed');
+
+      expect(mockCollection.updateOne).toHaveBeenCalledWith(
+        { jobId: 'job-1' },
+        expect.objectContaining({
+          $set: expect.objectContaining({ status: 'completed', completedAt: expect.any(Date) }),
+        }),
+      );
+    });
+
+    it('should set completedAt when status is failed', async () => {
+      await repository.updateStatus('job-1', 'failed');
+
+      expect(mockCollection.updateOne).toHaveBeenCalledWith(
+        { jobId: 'job-1' },
+        expect.objectContaining({
+          $set: expect.objectContaining({ status: 'failed', completedAt: expect.any(Date) }),
+        }),
+      );
+    });
+
+    it('should not set startedAt or completedAt for queued status', async () => {
+      await repository.updateStatus('job-1', 'queued');
+
+      const $set = (mockCollection.updateOne.mock.calls[0][1] as any).$set;
+      expect($set.startedAt).toBeUndefined();
+      expect($set.completedAt).toBeUndefined();
+    });
+
+    it('should pass extras to $set', async () => {
+      const extras = {
+        result: { data: 'ok' },
+        error: 'something failed',
+        assignedWorkerId: 'worker-1',
+        ackDeadline: 99999,
+      };
+
+      await repository.updateStatus('job-1', 'failed', extras);
+
+      expect(mockCollection.updateOne).toHaveBeenCalledWith(
+        { jobId: 'job-1' },
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            result: { data: 'ok' },
+            error: 'something failed',
+            assignedWorkerId: 'worker-1',
+            ackDeadline: 99999,
+          }),
+        }),
+      );
+    });
+
+    it('should push history entry with fromStatus, toStatus, timestamp and reason', async () => {
+      await repository.updateStatus('job-1', 'running', { error: 'n/a' });
+
+      const $push = (mockCollection.updateOne.mock.calls[0][1] as any).$push;
+      expect($push.history.fromStatus).toBe('queued');
+      expect($push.history.toStatus).toBe('running');
+      expect($push.history.timestamp).toBeInstanceOf(Date);
+      expect($push.history.reason).toBe('n/a');
+    });
+  });
+
+  describe('incrementRetry', () => {
+    it('should call updateOne with $inc retryCount', async () => {
+      mockCollection.updateOne.mockResolvedValue({ modifiedCount: 1 });
+
+      await repository.incrementRetry('job-1');
+
+      expect(mockCollection.updateOne).toHaveBeenCalledWith(
+        { jobId: 'job-1' },
+        { $inc: { retryCount: 1 } },
+      );
+    });
+  });
+
+  describe('findNonTerminal', () => {
+    it('should query with $nin statuses', async () => {
+      const docs = [
+        { jobId: 'j1', type: 't', payload: {}, priority: 3, status: 'queued', ackDeadline: 0, maxRetries: 3, retryCount: 0, createdAt: new Date(), history: [] },
+        { jobId: 'j2', type: 't', payload: {}, priority: 3, status: 'running', ackDeadline: 0, maxRetries: 3, retryCount: 0, createdAt: new Date(), history: [] },
+      ];
+      const toArray = jest.fn<any>().mockResolvedValue(docs);
+      mockCollection.find.mockReturnValue({ toArray });
+
+      const results = await repository.findNonTerminal();
+
+      expect(mockCollection.find).toHaveBeenCalledWith({
+        status: { $nin: ['completed', 'failed', 'cancelled'] },
+      });
+      expect(results).toHaveLength(2);
+      expect(results[0].id).toBe('j1');
+      expect(results[1].status).toBe('running');
+    });
+  });
+
+  describe('findByWorker', () => {
+    it('should query with assignedWorkerId and $in statuses', async () => {
+      const docs = [
+        { jobId: 'j1', type: 't', payload: {}, priority: 3, status: 'running', ackDeadline: 0, maxRetries: 3, retryCount: 0, createdAt: new Date(), history: [] },
+      ];
+      const toArray = jest.fn<any>().mockResolvedValue(docs);
+      mockCollection.find.mockReturnValue({ toArray });
+
+      const results = await repository.findByWorker('worker-1', ['assigned', 'running']);
+
+      expect(mockCollection.find).toHaveBeenCalledWith({
+        assignedWorkerId: 'worker-1',
+        status: { $in: ['assigned', 'running'] },
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('j1');
+    });
+  });
+
+  describe('findByStatus', () => {
+    it('should query by status', async () => {
+      const docs = [
+        { jobId: 'j1', type: 't', payload: {}, priority: 3, status: 'queued', ackDeadline: 0, maxRetries: 3, retryCount: 0, createdAt: new Date(), history: [] },
+      ];
+      const toArray = jest.fn<any>().mockResolvedValue(docs);
+      mockCollection.find.mockReturnValue({ toArray });
+
+      const results = await repository.findByStatus('queued');
+
+      expect(mockCollection.find).toHaveBeenCalledWith({ status: 'queued' });
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('j1');
+    });
+  });
+});

--- a/services/job-scheduler/tests/unit/recovery/orphan-detector.spec.ts
+++ b/services/job-scheduler/tests/unit/recovery/orphan-detector.spec.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, jest, afterEach } from '@jest/globals';
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    ACK_TIMEOUT_MS: 30000,
+    MAX_QUEUE_DEPTH: 10000,
+    MAX_WORKER_LOAD_RATIO: 0.85,
+    MAX_RETRIES_PER_JOB: 3,
+    ORPHAN_SCAN_INTERVAL_MS: 10000,
+    WORKER_HEARTBEAT_TTL_MS: 30000,
+  },
+}));
+
+import { OrphanDetector } from '../../../src/recovery/orphan-detector';
+import { ReAllocator } from '../../../src/recovery/re-allocator';
+import { WorkerRegistry } from '../../../src/worker/worker-registry';
+import { JobRepository } from '../../../src/persistence/job-repository';
+import { InternalQueue } from '../../../src/scheduler/internal-queue';
+import { createJob } from '../../fixtures/job.fixture';
+
+describe('OrphanDetector', () => {
+  let registry: WorkerRegistry;
+  let reAllocator: ReAllocator;
+  let mockRepository: jest.Mocked<JobRepository>;
+  let mockQueue: InternalQueue;
+  let orphanDetector: OrphanDetector;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    mockRepository = {
+      insert: jest.fn(),
+      findById: jest.fn(),
+      updateStatus: jest.fn(),
+      incrementRetry: jest.fn(),
+      findNonTerminal: jest.fn(),
+      findByWorker: jest.fn(),
+      findByStatus: jest.fn(),
+      ensureIndexes: jest.fn(),
+    } as unknown as jest.Mocked<JobRepository>;
+
+    mockQueue = new InternalQueue(30000);
+    registry = new WorkerRegistry(5000);
+    reAllocator = new ReAllocator(mockRepository, mockQueue);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('start / stop', () => {
+    it('should start and stop the detection interval', () => {
+      orphanDetector = new OrphanDetector(registry, mockRepository, reAllocator, 10000);
+
+      orphanDetector.start();
+      expect(jest.getTimerCount()).toBeGreaterThan(0);
+
+      orphanDetector.stop();
+      // After stop, no new timers will fire
+      jest.advanceTimersByTime(10000);
+      expect(mockRepository.findByWorker).not.toHaveBeenCalled();
+    });
+
+    it('should not start multiple intervals', () => {
+      orphanDetector = new OrphanDetector(registry, mockRepository, reAllocator, 10000);
+
+      orphanDetector.start();
+      orphanDetector.start();
+
+      jest.advanceTimersByTime(10000);
+      expect(mockRepository.findByWorker).toHaveBeenCalledTimes(0);
+    });
+
+    it('should not throw when stopping without having started', () => {
+      orphanDetector = new OrphanDetector(registry, mockRepository, reAllocator, 10000);
+
+      expect(() => orphanDetector.stop()).not.toThrow();
+    });
+  });
+
+  describe('detection cycle', () => {
+    it('should detect orphaned jobs from stale workers', () => {
+      registry.register('stale-worker', {
+        workerId: 'stale-worker',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      jest.advanceTimersByTime(10000); // exceed heartbeat TTL
+
+      mockRepository.findByWorker.mockResolvedValue([createJob({ id: 'orphan-1' })]);
+
+      orphanDetector = new OrphanDetector(registry, mockRepository, reAllocator, 5000);
+      orphanDetector.start();
+
+      jest.advanceTimersByTime(5000);
+
+      expect(mockRepository.findByWorker).toHaveBeenCalledWith('stale-worker', ['assigned', 'running']);
+    });
+
+    it('should log error but not crash when detection fails', () => {
+      mockRepository.findByWorker.mockRejectedValue(new Error('DB error'));
+
+      registry.register('bad-worker', {
+        workerId: 'bad-worker',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      jest.advanceTimersByTime(10000);
+
+      orphanDetector = new OrphanDetector(registry, mockRepository, reAllocator, 5000);
+      orphanDetector.start();
+
+      expect(() => {
+        jest.advanceTimersByTime(5000);
+      }).not.toThrow();
+    });
+
+    it('should handle non-Error rejection in detection cycle', () => {
+      mockRepository.findByWorker.mockRejectedValue('string error');
+
+      registry.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      jest.advanceTimersByTime(10000);
+
+      orphanDetector = new OrphanDetector(registry, mockRepository, reAllocator, 5000);
+      orphanDetector.start();
+
+      expect(() => {
+        jest.advanceTimersByTime(5000);
+      }).not.toThrow();
+    });
+  });
+});

--- a/services/job-scheduler/tests/unit/recovery/re-allocator.spec.ts
+++ b/services/job-scheduler/tests/unit/recovery/re-allocator.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    ACK_TIMEOUT_MS: 30000,
+    MAX_QUEUE_DEPTH: 10000,
+    MAX_WORKER_LOAD_RATIO: 0.85,
+    MAX_RETRIES_PER_JOB: 3,
+    ORPHAN_SCAN_INTERVAL_MS: 10000,
+    WORKER_HEARTBEAT_TTL_MS: 30000,
+  },
+}));
+
+import { ReAllocator } from '../../../src/recovery/re-allocator';
+import { InternalQueue } from '../../../src/scheduler/internal-queue';
+import { JobRepository } from '../../../src/persistence/job-repository';
+import { createJob } from '../../fixtures/job.fixture';
+
+describe('ReAllocator', () => {
+  let reAllocator: ReAllocator;
+  let mockRepository: jest.Mocked<JobRepository>;
+  let mockQueue: InternalQueue;
+
+  beforeEach(() => {
+    mockRepository = {
+      insert: jest.fn(),
+      findById: jest.fn(),
+      updateStatus: jest.fn(),
+      incrementRetry: jest.fn(),
+      findNonTerminal: jest.fn(),
+      findByWorker: jest.fn(),
+      findByStatus: jest.fn(),
+      ensureIndexes: jest.fn(),
+    } as unknown as jest.Mocked<JobRepository>;
+
+    mockQueue = new InternalQueue(30000);
+    reAllocator = new ReAllocator(mockRepository, mockQueue);
+  });
+
+  describe('reallocate', () => {
+    it('should mark job as failed when maxRetries exceeded', async () => {
+      const job = createJob({ retryCount: 3, maxRetries: 3 });
+
+      await reAllocator.reallocate(job);
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(
+        job.id,
+        'failed',
+        expect.objectContaining({ error: expect.stringContaining('max retries') }),
+      );
+    });
+
+    it('should re-enqueue job when retries remain', async () => {
+      const job = createJob({ id: 'rejob-1', retryCount: 0, maxRetries: 3 });
+
+      await reAllocator.reallocate(job);
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(
+        job.id,
+        'queued',
+        expect.objectContaining({ ackDeadline: expect.any(Number) }),
+      );
+      expect(mockQueue.depth()).toBe(1);
+    });
+  });
+});

--- a/services/job-scheduler/tests/unit/routes/ack.controller.spec.ts
+++ b/services/job-scheduler/tests/unit/routes/ack.controller.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+import { createReq, createRes, createNext } from '../../helpers/express';
+
+jest.mock('@trading-model/common/middleware/catch-error', () => ({
+  catchSync: (fn: any) => fn,
+}));
+
+jest.mock('@trading-model/common/middleware/response-exception', () => {
+  const sendResponse = (data: any, status: number) => ({ status, data });
+  return { sendResponse };
+});
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    ACK_TIMEOUT_MS: 30000,
+    MAX_QUEUE_DEPTH: 10000,
+    MAX_WORKER_LOAD_RATIO: 0.85,
+    MAX_RETRIES_PER_JOB: 3,
+    ORPHAN_SCAN_INTERVAL_MS: 10000,
+    WORKER_HEARTBEAT_TTL_MS: 30000,
+  },
+}));
+
+import { JobScheduler } from '../../../src/scheduler/job-scheduler';
+import { createAckController } from '../../../src/routes/ack.controller';
+
+function createMockScheduler(): jest.Mocked<JobScheduler> {
+  return {
+    submit: jest.fn<(...args: any[]) => any>(),
+    cancel: jest.fn<(...args: any[]) => any>(),
+    ack: jest.fn<(...args: any[]) => any>(),
+    complete: jest.fn<(...args: any[]) => any>(),
+    fail: jest.fn<(...args: any[]) => any>(),
+    queue: {} as any,
+    backPressure: {} as any,
+    workers: {} as any,
+    reAllocator: {} as any,
+    orphanDetector: {} as any,
+    repository: {
+      findById: jest.fn<(...args: any[]) => any>(),
+      insert: jest.fn<(...args: any[]) => any>(),
+      updateStatus: jest.fn<(...args: any[]) => any>(),
+      incrementRetry: jest.fn<(...args: any[]) => any>(),
+      findNonTerminal: jest.fn<(...args: any[]) => any>(),
+      findByWorker: jest.fn<(...args: any[]) => any>(),
+      findByStatus: jest.fn<(...args: any[]) => any>(),
+      ensureIndexes: jest.fn<(...args: any[]) => any>(),
+    },
+    setWorkerProtocol: jest.fn<(...args: any[]) => any>(),
+    start: jest.fn<(...args: any[]) => any>(),
+    stop: jest.fn<(...args: any[]) => any>(),
+    onWorkerDisconnect: jest.fn<(...args: any[]) => any>(),
+  } as unknown as jest.Mocked<JobScheduler>;
+}
+
+describe('AckController', () => {
+  let scheduler: jest.Mocked<JobScheduler>;
+  let controller: ReturnType<typeof createAckController>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    scheduler = createMockScheduler();
+    controller = createAckController(scheduler);
+  });
+
+  describe('ack', () => {
+    it('should acknowledge a job and return 200', async () => {
+      (scheduler.ack as any).mockResolvedValue(undefined);
+
+      const result = await controller.ack(
+        createReq({ params: { id: 'job-1' } }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 200, data: { status: 'acknowledged' } });
+      expect(scheduler.ack).toHaveBeenCalledWith('job-1');
+    });
+  });
+
+  describe('complete', () => {
+    it('should reject empty body with 400', async () => {
+      const result = await controller.complete(
+        createReq({ params: { id: 'job-1' }, body: null }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 400 });
+    });
+
+    it('should complete a job and return 200', async () => {
+      (scheduler.complete as any).mockResolvedValue(undefined);
+
+      const result = await controller.complete(
+        createReq({ params: { id: 'job-1' }, body: { result: { data: 42 } } }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 200, data: { status: 'completed' } });
+      expect(scheduler.complete).toHaveBeenCalledWith('job-1', { data: 42 });
+    });
+  });
+
+  describe('fail', () => {
+    it('should reject empty body with 400', async () => {
+      const result = await controller.fail(
+        createReq({ params: { id: 'job-1' }, body: null }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 400 });
+    });
+
+    it('should reject missing error field', async () => {
+      const result = await controller.fail(
+        createReq({ params: { id: 'job-1' }, body: {} }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 400 });
+    });
+
+    it('should fail a job and return 200', async () => {
+      (scheduler.fail as any).mockResolvedValue(undefined);
+
+      const result = await controller.fail(
+        createReq({ params: { id: 'job-1' }, body: { error: 'timeout' } }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 200, data: { status: 'failed' } });
+      expect(scheduler.fail).toHaveBeenCalledWith('job-1', 'timeout');
+    });
+  });
+});

--- a/services/job-scheduler/tests/unit/routes/ack.routes.spec.ts
+++ b/services/job-scheduler/tests/unit/routes/ack.routes.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+jest.mock('../../../src/routes/ack.controller', () => ({
+  createAckController: jest.fn(),
+}));
+
+const mockRouter = {
+  post: jest.fn(),
+};
+
+jest.mock('express', () => ({
+  Router: () => mockRouter,
+}));
+
+import { ackRoutes } from '../../../src/routes/ack.routes';
+import { createAckController } from '../../../src/routes/ack.controller';
+
+describe('ackRoutes', () => {
+  it('should register all ack routes', () => {
+    const mockController = {
+      ack: 'ack-handler',
+      complete: 'complete-handler',
+      fail: 'fail-handler',
+    };
+    (createAckController as jest.Mock).mockReturnValue(mockController);
+
+    const router = ackRoutes(null as any);
+
+    expect(router).toBe(mockRouter);
+    expect(mockRouter.post).toHaveBeenCalledWith('/jobs/:id/ack', 'ack-handler');
+    expect(mockRouter.post).toHaveBeenCalledWith('/jobs/:id/complete', 'complete-handler');
+    expect(mockRouter.post).toHaveBeenCalledWith('/jobs/:id/fail', 'fail-handler');
+  });
+});

--- a/services/job-scheduler/tests/unit/routes/health.controller.spec.ts
+++ b/services/job-scheduler/tests/unit/routes/health.controller.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+import { createReq, createRes, createNext } from '../../helpers/express';
+
+jest.mock('@trading-model/common/middleware/catch-error', () => ({
+  catchSync: (fn: any) => fn,
+}));
+
+jest.mock('@trading-model/common/middleware/response-exception', () => {
+  const sendResponse = (data: any, status: number) => ({ status, data });
+  return { sendResponse };
+});
+
+import { InternalQueue } from '../../../src/scheduler/internal-queue';
+import { BackPressure } from '../../../src/scheduler/back-pressure';
+import { WorkerRegistry } from '../../../src/worker/worker-registry';
+import { createHealthController } from '../../../src/routes/health.controller';
+
+describe('HealthController', () => {
+  let queue: InternalQueue;
+  let backPressure: BackPressure;
+  let workers: WorkerRegistry;
+  let controller: ReturnType<typeof createHealthController>;
+
+  beforeEach(() => {
+    queue = new InternalQueue(30000);
+    backPressure = new BackPressure(100, 0.85);
+    workers = new WorkerRegistry(30000);
+    controller = createHealthController(queue, backPressure, workers);
+  });
+
+  describe('ping', () => {
+    it('should return 200 with status ok', async () => {
+      const result = await controller.ping(createReq(), createRes(), createNext);
+
+      expect(result).toMatchObject({ status: 200 });
+      expect((result as any).data).toHaveProperty('status', 'ok');
+      expect((result as any).data).toHaveProperty('timestamp');
+    });
+  });
+
+  describe('health', () => {
+    it('should return 200 with health metrics', async () => {
+      queue.enqueue({ id: 'j1', type: 't', payload: {}, priority: 3, status: 'queued', ackDeadline: 0, maxRetries: 3, retryCount: 0, createdAt: new Date(), history: [] });
+
+      const result = await controller.health(createReq(), createRes(), createNext);
+
+      expect(result).toMatchObject({ status: 200 });
+      expect((result as any).data).toMatchObject({
+        status: 'ok',
+        queueDepth: 1,
+        canAccept: true,
+        workerCount: 0,
+        averageLoad: 0,
+      });
+      expect((result as any).data).toHaveProperty('timestamp');
+    });
+  });
+});

--- a/services/job-scheduler/tests/unit/routes/health.routes.spec.ts
+++ b/services/job-scheduler/tests/unit/routes/health.routes.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+jest.mock('../../../src/routes/health.controller', () => ({
+  createHealthController: jest.fn(),
+}));
+
+const mockRouter = {
+  get: jest.fn(),
+};
+
+jest.mock('express', () => ({
+  Router: () => mockRouter,
+}));
+
+import { healthRoutes } from '../../../src/routes/health.routes';
+import { createHealthController } from '../../../src/routes/health.controller';
+
+describe('healthRoutes', () => {
+  it('should register all health routes', () => {
+    const mockController = {
+      ping: 'ping-handler',
+      health: 'health-handler',
+    };
+    (createHealthController as jest.Mock).mockReturnValue(mockController);
+
+    const router = healthRoutes(null as any, null as any, null as any);
+
+    expect(router).toBe(mockRouter);
+    expect(mockRouter.get).toHaveBeenCalledWith('/ping', 'ping-handler');
+    expect(mockRouter.get).toHaveBeenCalledWith('/health', 'health-handler');
+  });
+});

--- a/services/job-scheduler/tests/unit/routes/job.controller.spec.ts
+++ b/services/job-scheduler/tests/unit/routes/job.controller.spec.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+import { createReq, createRes, createNext } from '../../helpers/express';
+
+jest.mock('@trading-model/common/middleware/catch-error', () => ({
+  catchSync: (fn: any) => fn,
+}));
+
+jest.mock('@trading-model/common/middleware/response-exception', () => {
+  const sendResponse = (data: any, status: number) => ({ status, data });
+  return { sendResponse };
+});
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    ACK_TIMEOUT_MS: 30000,
+    MAX_QUEUE_DEPTH: 10000,
+    MAX_WORKER_LOAD_RATIO: 0.85,
+    MAX_RETRIES_PER_JOB: 3,
+    ORPHAN_SCAN_INTERVAL_MS: 10000,
+    WORKER_HEARTBEAT_TTL_MS: 30000,
+  },
+}));
+
+import { JobScheduler } from '../../../src/scheduler/job-scheduler';
+import { createJobController } from '../../../src/routes/job.controller';
+
+function createMockScheduler(): jest.Mocked<JobScheduler> {
+  return {
+    submit: jest.fn<(...args: any[]) => any>(),
+    cancel: jest.fn<(...args: any[]) => any>(),
+    ack: jest.fn<(...args: any[]) => any>(),
+    complete: jest.fn<(...args: any[]) => any>(),
+    fail: jest.fn<(...args: any[]) => any>(),
+    queue: {} as any,
+    backPressure: {} as any,
+    workers: {} as any,
+    reAllocator: {} as any,
+    orphanDetector: {} as any,
+    repository: {
+      findById: jest.fn<(...args: any[]) => any>(),
+      insert: jest.fn<(...args: any[]) => any>(),
+      updateStatus: jest.fn<(...args: any[]) => any>(),
+      incrementRetry: jest.fn<(...args: any[]) => any>(),
+      findNonTerminal: jest.fn<(...args: any[]) => any>(),
+      findByWorker: jest.fn<(...args: any[]) => any>(),
+      findByStatus: jest.fn<(...args: any[]) => any>(),
+      ensureIndexes: jest.fn<(...args: any[]) => any>(),
+    },
+    setWorkerProtocol: jest.fn<(...args: any[]) => any>(),
+    start: jest.fn<(...args: any[]) => any>(),
+    stop: jest.fn<(...args: any[]) => any>(),
+    onWorkerDisconnect: jest.fn<(...args: any[]) => any>(),
+  } as unknown as jest.Mocked<JobScheduler>;
+}
+
+describe('JobController', () => {
+  let scheduler: jest.Mocked<JobScheduler>;
+  let controller: ReturnType<typeof createJobController>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    scheduler = createMockScheduler();
+    controller = createJobController(scheduler);
+  });
+
+  describe('submit', () => {
+    it('should reject invalid body with 400', async () => {
+      const result = await controller.submit(
+        createReq({ body: null }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 400 });
+    });
+
+    it('should reject empty type with 400', async () => {
+      const result = await controller.submit(
+        createReq({ body: { type: '' } }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 400 });
+    });
+
+    it('should return 201 with jobId on success', async () => {
+      (scheduler.submit as any).mockResolvedValue('new-job-id');
+
+      const result = await controller.submit(
+        createReq({ body: { type: 'test-type', payload: {} } }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 201, data: { jobId: 'new-job-id', status: 'queued' } });
+    });
+
+    it('should return 429 on back pressure', async () => {
+      (scheduler.submit as any).mockRejectedValue(
+        Object.assign(new Error('Job scheduler at capacity'), {
+          code: 'BACK_PRESSURE',
+          retryAfter: 30,
+        }),
+      );
+
+      const result = await controller.submit(
+        createReq({ body: { type: 'test-type', payload: {} } }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 429, data: { error: 'BACK_PRESSURE' } });
+    });
+
+    it('should return 429 with default retryAfter when not provided', async () => {
+      (scheduler.submit as any).mockRejectedValue(
+        Object.assign(new Error('Job scheduler at capacity'), {
+          code: 'BACK_PRESSURE',
+        }),
+      );
+
+      const result = await controller.submit(
+        createReq({ body: { type: 'test', payload: {} } }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 429, data: { retryAfter: 30 } });
+    });
+  });
+
+  describe('getById', () => {
+    it('should return 404 when job not found', async () => {
+      (scheduler.repository.findById as any).mockResolvedValue(null);
+
+      const result = await controller.getById(
+        createReq({ params: { id: 'unknown' } }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 404 });
+    });
+
+    it('should return job data on success', async () => {
+      const mockJob = { id: 'job-1', type: 'test', status: 'queued' };
+      (scheduler.repository.findById as any).mockResolvedValue(mockJob);
+
+      const result = await controller.getById(
+        createReq({ params: { id: 'job-1' } }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 200, data: mockJob });
+    });
+  });
+
+  describe('cancel', () => {
+    it('should return 409 when cancellation is not allowed', async () => {
+      (scheduler.cancel as any).mockRejectedValue(new Error('Cannot cancel a running or completed job'));
+
+      const result = await controller.cancel(
+        createReq({ params: { id: 'running-job' } }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 409 });
+    });
+
+    it('should return 200 on successful cancellation', async () => {
+      (scheduler.cancel as any).mockResolvedValue(undefined);
+
+      const result = await controller.cancel(
+        createReq({ params: { id: 'queued-job' } }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 200, data: { status: 'cancelled' } });
+    });
+  });
+});
+
+describe('JobController — rethrow errors', () => {
+  let scheduler: jest.Mocked<JobScheduler>;
+  let controller: ReturnType<typeof createJobController>;
+
+  beforeEach(() => {
+    scheduler = createMockScheduler();
+    controller = createJobController(scheduler);
+  });
+
+  it('should re-throw non-BACK_PRESSURE errors in submit', async () => {
+    (scheduler.submit as any).mockRejectedValue(new Error('DB connection failed'));
+
+    await expect(
+      controller.submit(
+        createReq({ body: { type: 'test', payload: {} } }),
+        createRes(),
+        createNext,
+      ),
+    ).rejects.toThrow('DB connection failed');
+  });
+
+  it('should re-throw non-cancellation errors in cancel', async () => {
+    (scheduler.cancel as any).mockRejectedValue(new Error('DB connection failed'));
+
+    await expect(
+      controller.cancel(
+        createReq({ params: { id: 'job-1' } }),
+        createRes(),
+        createNext,
+      ),
+    ).rejects.toThrow('DB connection failed');
+  });
+});

--- a/services/job-scheduler/tests/unit/routes/job.routes.spec.ts
+++ b/services/job-scheduler/tests/unit/routes/job.routes.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+jest.mock('../../../src/routes/job.controller', () => ({
+  createJobController: jest.fn(),
+}));
+
+const mockRouter = {
+  post: jest.fn(),
+  get: jest.fn(),
+};
+
+jest.mock('express', () => ({
+  Router: () => mockRouter,
+}));
+
+import { jobRoutes } from '../../../src/routes/job.routes';
+import { createJobController } from '../../../src/routes/job.controller';
+
+describe('jobRoutes', () => {
+  it('should register all job routes', () => {
+    const mockController = {
+      submit: 'submit-handler',
+      getById: 'get-by-id-handler',
+      cancel: 'cancel-handler',
+    };
+    (createJobController as jest.Mock).mockReturnValue(mockController);
+
+    const router = jobRoutes(null as any);
+
+    expect(router).toBe(mockRouter);
+    expect(mockRouter.post).toHaveBeenCalledWith('/jobs', 'submit-handler');
+    expect(mockRouter.get).toHaveBeenCalledWith('/jobs/:id', 'get-by-id-handler');
+    expect(mockRouter.post).toHaveBeenCalledWith('/jobs/:id/cancel', 'cancel-handler');
+  });
+});

--- a/services/job-scheduler/tests/unit/routes/worker.controller.spec.ts
+++ b/services/job-scheduler/tests/unit/routes/worker.controller.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+import { createReq, createRes, createNext } from '../../helpers/express';
+
+jest.mock('@trading-model/common/middleware/catch-error', () => ({
+  catchSync: (fn: any) => fn,
+}));
+
+jest.mock('@trading-model/common/middleware/response-exception', () => {
+  const sendResponse = (data: any, status: number) => ({ status, data });
+  return { sendResponse };
+});
+
+import { WorkerRegistry } from '../../../src/worker/worker-registry';
+import { createWorkerController } from '../../../src/routes/worker.controller';
+
+describe('WorkerController', () => {
+  let workers: WorkerRegistry;
+  let controller: ReturnType<typeof createWorkerController>;
+
+  beforeEach(() => {
+    workers = new WorkerRegistry(30000);
+    controller = createWorkerController(workers);
+  });
+
+  describe('register', () => {
+    it('should reject invalid body with 400', async () => {
+      const result = await controller.register(
+        createReq({ body: null }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 400 });
+    });
+
+    it('should register a worker and return 201', async () => {
+      const payload = {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+      };
+
+      const result = await controller.register(
+        createReq({ body: payload }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 201, data: { status: 'registered', workerId: 'worker-1' } });
+      expect(workers.count()).toBe(1);
+    });
+
+    it('should reject missing address', async () => {
+      const result = await controller.register(
+        createReq({ body: { workerId: 'w1', port: 9000 } }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 400 });
+    });
+  });
+
+  describe('heartbeat', () => {
+    it('should reject invalid body with 400', async () => {
+      const result = await controller.heartbeat(
+        createReq({ body: null }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 400 });
+    });
+
+    it('should update heartbeat and return 200', async () => {
+      workers.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      const result = await controller.heartbeat(
+        createReq({ body: { workerId: 'worker-1', currentLoad: 2 } }),
+        createRes(),
+        createNext,
+      );
+
+      expect(result).toMatchObject({ status: 200, data: { status: 'ok' } });
+      expect(workers.get('worker-1')!.currentLoad).toBe(2);
+    });
+  });
+
+  describe('list', () => {
+    it('should return empty list when no workers', async () => {
+      const result = await controller.list(createReq(), createRes(), createNext);
+
+      expect(result).toMatchObject({ status: 200, data: { count: 0, workers: [] } });
+    });
+
+    it('should return only active workers', async () => {
+      workers.register('active-w', {
+        workerId: 'active-w',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+      workers.register('inactive-w', {
+        workerId: 'inactive-w',
+        address: '10.0.0.2',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+      workers.setStatus('inactive-w', 'offline');
+
+      const result = await controller.list(createReq(), createRes(), createNext);
+
+      expect(result).toMatchObject({ status: 200, data: { count: 1 } });
+    });
+  });
+});

--- a/services/job-scheduler/tests/unit/routes/worker.routes.spec.ts
+++ b/services/job-scheduler/tests/unit/routes/worker.routes.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+jest.mock('../../../src/routes/worker.controller', () => ({
+  createWorkerController: jest.fn(),
+}));
+
+const mockRouter = {
+  post: jest.fn(),
+  get: jest.fn(),
+};
+
+jest.mock('express', () => ({
+  Router: () => mockRouter,
+}));
+
+import { workerRoutes } from '../../../src/routes/worker.routes';
+import { createWorkerController } from '../../../src/routes/worker.controller';
+
+describe('workerRoutes', () => {
+  it('should register all worker routes', () => {
+    const mockController = {
+      register: 'register-handler',
+      heartbeat: 'heartbeat-handler',
+      list: 'list-handler',
+    };
+    (createWorkerController as jest.Mock).mockReturnValue(mockController);
+
+    const router = workerRoutes(null as any);
+
+    expect(router).toBe(mockRouter);
+    expect(mockRouter.post).toHaveBeenCalledWith('/workers/register', 'register-handler');
+    expect(mockRouter.post).toHaveBeenCalledWith('/workers/heartbeat', 'heartbeat-handler');
+    expect(mockRouter.get).toHaveBeenCalledWith('/workers', 'list-handler');
+  });
+});

--- a/services/job-scheduler/tests/unit/scheduler/back-pressure.spec.ts
+++ b/services/job-scheduler/tests/unit/scheduler/back-pressure.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+import { BackPressure } from '../../../src/scheduler/back-pressure';
+
+describe('BackPressure', () => {
+  let backPressure: BackPressure;
+
+  beforeEach(() => {
+    backPressure = new BackPressure(100, 0.85);
+  });
+
+  describe('canAccept', () => {
+    it('should return true when queue is empty and no workers', () => {
+      expect(backPressure.canAccept()).toBe(true);
+    });
+
+    it('should return true when queue depth is below threshold', () => {
+      backPressure.updateQueueDepth(50);
+      expect(backPressure.canAccept()).toBe(true);
+    });
+
+    it('should return false when queue depth exceeds max', () => {
+      backPressure.updateQueueDepth(100);
+      expect(backPressure.canAccept()).toBe(false);
+    });
+
+    it('should return true when all workers are below load ratio', () => {
+      backPressure.updateWorkerLoad('worker-1', 0.5);
+      backPressure.updateWorkerLoad('worker-2', 0.6);
+      expect(backPressure.canAccept()).toBe(true);
+    });
+
+    it('should return false when all workers are above load ratio', () => {
+      backPressure.updateWorkerLoad('worker-1', 0.9);
+      backPressure.updateWorkerLoad('worker-2', 0.95);
+      expect(backPressure.canAccept()).toBe(false);
+    });
+
+    it('should return true when some workers are below load ratio', () => {
+      backPressure.updateWorkerLoad('worker-1', 0.9);
+      backPressure.updateWorkerLoad('worker-2', 0.5);
+      expect(backPressure.canAccept()).toBe(true);
+    });
+  });
+
+  describe('retryAfterSeconds', () => {
+    it('should return 5s for queue depth under 100', () => {
+      backPressure.updateQueueDepth(50);
+      expect(backPressure.retryAfterSeconds()).toBe(5);
+    });
+
+    it('should return 15s for queue depth around 210', () => {
+      backPressure.updateQueueDepth(210);
+      expect(backPressure.retryAfterSeconds()).toBe(15);
+    });
+  });
+
+  describe('updateQueueDepth', () => {
+    it('should update the internal queue depth', () => {
+      backPressure.updateQueueDepth(50);
+      expect(backPressure.canAccept()).toBe(true);
+
+      backPressure.updateQueueDepth(150);
+      expect(backPressure.canAccept()).toBe(false);
+    });
+  });
+
+  describe('updateWorkerLoad / removeWorker', () => {
+    it('should update individual worker loads', () => {
+      backPressure.updateWorkerLoad('worker-1', 0.9);
+      backPressure.updateWorkerLoad('worker-2', 0.5);
+
+      expect(backPressure.canAccept()).toBe(true);
+    });
+
+    it('should allow acceptance when a removed worker was the bottleneck', () => {
+      backPressure.updateWorkerLoad('worker-1', 0.9);
+      expect(backPressure.canAccept()).toBe(false);
+
+      backPressure.removeWorker('worker-1');
+      expect(backPressure.canAccept()).toBe(true);
+    });
+  });
+});

--- a/services/job-scheduler/tests/unit/scheduler/internal-queue.spec.ts
+++ b/services/job-scheduler/tests/unit/scheduler/internal-queue.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, jest, afterEach } from '@jest/globals';
+
+import { InternalQueue } from '../../../src/scheduler/internal-queue';
+import { createJob } from '../../fixtures/job.fixture';
+
+describe('InternalQueue', () => {
+  let queue: InternalQueue;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    queue = new InternalQueue(30000);
+  });
+
+  afterEach(() => {
+    queue.stop();
+    jest.useRealTimers();
+  });
+
+  describe('enqueue', () => {
+    it('should add a job to the correct priority queue', () => {
+      const job = createJob({ priority: 1 });
+      queue.enqueue(job);
+
+      expect(queue.depth()).toBe(1);
+    });
+
+    it('should enqueue jobs at different priorities', () => {
+      queue.enqueue(createJob({ priority: 1 }));
+      queue.enqueue(createJob({ priority: 5 }));
+
+      expect(queue.depth()).toBe(2);
+    });
+  });
+
+  describe('dequeue', () => {
+    it('should return null when queue is empty', () => {
+      expect(queue.dequeue()).toBeNull();
+    });
+
+    it('should return the highest priority job first', () => {
+      queue.enqueue(createJob({ id: 'low', priority: 5 }));
+      queue.enqueue(createJob({ id: 'high', priority: 1 }));
+
+      const result = queue.dequeue();
+      expect(result).not.toBeNull();
+      expect(result!.job.id).toBe('high');
+    });
+
+    it('should return jobs in FIFO order within the same priority', () => {
+      queue.enqueue(createJob({ id: 'first', priority: 3 }));
+      queue.enqueue(createJob({ id: 'second', priority: 3 }));
+
+      expect(queue.dequeue()!.job.id).toBe('first');
+      expect(queue.dequeue()!.job.id).toBe('second');
+    });
+
+    it('should remove the job from the queue', () => {
+      queue.enqueue(createJob({ priority: 3 }));
+      queue.dequeue();
+
+      expect(queue.depth()).toBe(0);
+    });
+  });
+
+  describe('markDelivered / ack', () => {
+    it('should call onAckTimeout when ack is not called within timeout', () => {
+      const onTimeout = jest.fn();
+      queue.setOnAckTimeout(onTimeout);
+
+      queue.enqueue(createJob({ id: 'job-1' }));
+      queue.markDelivered('job-1');
+
+      jest.advanceTimersByTime(30000);
+
+      expect(onTimeout).toHaveBeenCalledWith('job-1');
+    });
+
+    it('should not call onAckTimeout when ack is called in time', () => {
+      const onTimeout = jest.fn();
+      queue.setOnAckTimeout(onTimeout);
+
+      queue.markDelivered('job-1');
+      queue.ack('job-1');
+
+      jest.advanceTimersByTime(30000);
+
+      expect(onTimeout).not.toHaveBeenCalled();
+    });
+
+    it('should not fail when ack is called for unknown jobId', () => {
+      expect(() => queue.ack('unknown')).not.toThrow();
+    });
+  });
+
+  describe('depth', () => {
+    it('should return 0 for empty queue', () => {
+      expect(queue.depth()).toBe(0);
+    });
+
+    it('should return total count across all priorities', () => {
+      queue.enqueue(createJob({ priority: 1 }));
+      queue.enqueue(createJob({ priority: 2 }));
+      queue.enqueue(createJob({ priority: 5 }));
+
+      expect(queue.depth()).toBe(3);
+    });
+  });
+
+  describe('markDelivered without callback', () => {
+    it('should not throw when ack timeout fires without callback set', () => {
+      queue.markDelivered('job-1');
+      expect(() => { jest.advanceTimersByTime(30000); }).not.toThrow();
+    });
+  });
+
+  describe('stop', () => {
+    it('should clear all pending ack timers', () => {
+      const onTimeout = jest.fn();
+      queue.setOnAckTimeout(onTimeout);
+
+      queue.markDelivered('job-1');
+      queue.markDelivered('job-2');
+      queue.stop();
+
+      jest.advanceTimersByTime(30000);
+
+      expect(onTimeout).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/services/job-scheduler/tests/unit/scheduler/job-scheduler.spec.ts
+++ b/services/job-scheduler/tests/unit/scheduler/job-scheduler.spec.ts
@@ -1,0 +1,856 @@
+import { describe, it, expect, beforeEach, jest, afterEach } from '@jest/globals';
+
+jest.mock('@trading-model/common/config/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    ACK_TIMEOUT_MS: 30000,
+    MAX_QUEUE_DEPTH: 10000,
+    MAX_WORKER_LOAD_RATIO: 0.85,
+    MAX_RETRIES_PER_JOB: 3,
+    ORPHAN_SCAN_INTERVAL_MS: 10000,
+    WORKER_HEARTBEAT_TTL_MS: 30000,
+  },
+}));
+
+import { JobScheduler } from '../../../src/scheduler/job-scheduler';
+import { JobRepository } from '../../../src/persistence/job-repository';
+import type { WorkerProtocol } from '../../../src/worker/worker-protocol';
+
+type MockLogger = { info: jest.Mock; warn: jest.Mock; error: jest.Mock; debug: jest.Mock };
+const mockLogger = (jest.requireMock('@trading-model/common/config/logger') as { logger: MockLogger }).logger;
+
+describe('JobScheduler', () => {
+  let scheduler: JobScheduler;
+  let mockRepository: jest.Mocked<JobRepository>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    mockRepository = {
+      insert: jest.fn(),
+      findById: jest.fn(),
+      updateStatus: jest.fn(),
+      incrementRetry: jest.fn(),
+      findNonTerminal: jest.fn(),
+      findByWorker: jest.fn(),
+      findByStatus: jest.fn(),
+      ensureIndexes: jest.fn(),
+    } as unknown as jest.Mocked<JobRepository>;
+
+    scheduler = new JobScheduler(mockRepository);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('submit', () => {
+    it('should create and enqueue a job', async () => {
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      const jobId = await scheduler.submit('test-type', { data: 1 }, 3, 3);
+
+      expect(jobId).toBeDefined();
+      expect(typeof jobId).toBe('string');
+      expect(mockRepository.insert).toHaveBeenCalled();
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(
+        jobId,
+        'queued',
+      );
+    });
+
+    it('should throw BACK_PRESSURE when queue is full', async () => {
+      scheduler.backPressure.updateQueueDepth(99999);
+
+      await expect(
+        scheduler.submit('test-type', {}),
+      ).rejects.toThrow('Job scheduler at capacity');
+    });
+
+    it('should log error when enqueueJob updateStatus fails', async () => {
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockRejectedValue(new Error('DB error'));
+
+      await scheduler.submit('test-type', {});
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to persist queued status',
+        expect.objectContaining({ error: 'Error: DB error' }),
+      );
+    });
+  });
+
+  describe('ack', () => {
+    it('should update job status to running', async () => {
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.ack('job-1');
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith('job-1', 'running');
+    });
+  });
+
+  describe('complete', () => {
+    it('should update job status to completed', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 1,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-1',
+        assignedWorkerId: 'w1',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: Date.now() + 30000,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.complete('job-1', { result: 'ok' });
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(
+        'job-1',
+        'completed',
+        expect.objectContaining({ result: { result: 'ok' } }),
+      );
+    });
+
+    it('should handle complete without assignedWorkerId', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-no-worker',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.complete('job-no-worker', { ok: true });
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(
+        'job-no-worker',
+        'completed',
+        expect.any(Object),
+      );
+    });
+
+    it('should handle complete when worker is not found in registry', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-worker-gone',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: 'nonexistent',
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await expect(scheduler.complete('job-worker-gone', {})).resolves.not.toThrow();
+    });
+  });
+
+  describe('fail', () => {
+    it('should re-enqueue job when retries remain', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-retry',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        result: undefined,
+        error: undefined,
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.fail('job-retry', 'timeout');
+
+      expect(mockRepository.incrementRetry).toHaveBeenCalledWith('job-retry');
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(
+        'job-retry',
+        'queued',
+        expect.any(Object),
+      );
+      expect(scheduler.queue.depth()).toBe(1);
+    });
+
+    it('should mark job as failed when max retries exceeded', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-fail',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 3,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        result: undefined,
+        error: undefined,
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.fail('job-fail', 'fatal');
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(
+        'job-fail',
+        'failed',
+        expect.objectContaining({ error: 'fatal' }),
+      );
+    });
+
+    it('should do nothing for unknown job', async () => {
+      mockRepository.findById.mockResolvedValue(null);
+
+      await expect(
+        scheduler.fail('unknown', 'error'),
+      ).resolves.not.toThrow();
+    });
+
+    it('should decrement worker load when failing with assigned worker', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-worker',
+        assignedWorkerId: 'w1',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.fail('job-worker', 'error');
+
+      expect(scheduler.workers.get('w1')!.currentLoad).toBe(1);
+    });
+
+    it('should handle fail when worker is not found in registry', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-worker-gone',
+        assignedWorkerId: 'nonexistent',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await expect(scheduler.fail('job-worker-gone', 'error')).resolves.not.toThrow();
+    });
+  });
+
+  describe('cancel', () => {
+    it('should cancel a queued job', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-cancel',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'queued',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        result: undefined,
+        error: undefined,
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.cancel('job-cancel');
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith('job-cancel', 'cancelled');
+    });
+
+    it('should throw for running job', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-running',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        result: undefined,
+        error: undefined,
+      } as any);
+
+      await expect(scheduler.cancel('job-running')).rejects.toThrow('Cannot cancel');
+    });
+
+    it('should decrement worker load when cancelling assigned job', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-assigned',
+        assignedWorkerId: 'w1',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'queued',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.cancel('job-assigned');
+
+      expect(scheduler.workers.get('w1')!.currentLoad).toBe(2);
+    });
+
+    it('should do nothing for unknown job', async () => {
+      mockRepository.findById.mockResolvedValue(null);
+
+      await expect(scheduler.cancel('unknown')).resolves.not.toThrow();
+    });
+
+    it('should handle cancel when worker is not found in registry', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-cancel-worker',
+        assignedWorkerId: 'nonexistent',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'queued',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await expect(scheduler.cancel('job-cancel-worker')).resolves.not.toThrow();
+    });
+  });
+
+  describe('start', () => {
+    it('should recover non-terminal jobs on startup', async () => {
+      const queuedJob = {
+        id: 'recover-queued',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'queued' as const,
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        result: undefined,
+        error: undefined,
+      };
+
+      mockRepository.findNonTerminal.mockResolvedValue([queuedJob] as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.start();
+
+      expect(scheduler.queue.depth()).toBe(1);
+      expect(scheduler.queue.depth()).toBeGreaterThan(0);
+    });
+
+    it('should recover assigned and running jobs as orphaned', async () => {
+      const assignedJob = {
+        id: 'recover-assigned',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'assigned' as const,
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: 'w1',
+      };
+
+      mockRepository.findNonTerminal.mockResolvedValue([assignedJob] as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.start();
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith('recover-assigned', 'orphaned');
+    });
+
+    it('should recover orphaned jobs via reAllocator', async () => {
+      const orphanedJob = {
+        id: 'recover-orphan',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'orphaned' as const,
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+      };
+
+      mockRepository.findNonTerminal.mockResolvedValue([orphanedJob] as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.start();
+
+      expect(scheduler.queue.depth()).toBe(1);
+    });
+
+    it('should skip jobs with unknown status during recovery', async () => {
+      const unknownJob = {
+        id: 'recover-unknown',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'unknown' as any,
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+      };
+
+      mockRepository.findNonTerminal.mockResolvedValue([unknownJob] as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await expect(scheduler.start()).resolves.not.toThrow();
+    });
+  });
+
+  describe('onWorkerDisconnect', () => {
+    it('should remove worker from back pressure tracking', () => {
+      scheduler.backPressure.updateWorkerLoad('w1', 0.9);
+      expect(scheduler.backPressure.canAccept()).toBe(false);
+
+      scheduler.onWorkerDisconnect('w1');
+      expect(scheduler.backPressure.canAccept()).toBe(true);
+    });
+  });
+
+  describe('setWorkerProtocol', () => {
+    it('should store the worker protocol reference', async () => {
+      const protocol = { sendToWorker: jest.fn() } as unknown as WorkerProtocol;
+      scheduler.setWorkerProtocol(protocol);
+
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {});
+
+      expect(protocol.sendToWorker).toHaveBeenCalled();
+    });
+  });
+
+  describe('stop', () => {
+    it('should stop orphan detector, queue, and close protocol', async () => {
+      const protocol = { close: jest.fn() } as unknown as WorkerProtocol;
+      scheduler.setWorkerProtocol(protocol);
+
+      await scheduler.stop();
+
+      expect(protocol.close).toHaveBeenCalled();
+    });
+
+    it('should stop without worker protocol', async () => {
+      await expect(scheduler.stop()).resolves.not.toThrow();
+    });
+  });
+
+  describe('handleAckTimeout', () => {
+    async function triggerAckTimeout(jobMocks: { findById?: any; updateStatus?: any } = {}) {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      if (jobMocks.findById) {
+        mockRepository.findById.mockResolvedValue(jobMocks.findById);
+      }
+      if (jobMocks.updateStatus !== undefined) {
+        mockRepository.updateStatus.mockResolvedValue(jobMocks.updateStatus);
+      }
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+
+    it('should mark job as orphaned on ACK timeout', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-timeout',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'assigned',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: 'w1',
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith('ACK timeout for job', expect.any(Object));
+    });
+
+    it('should ignore completed jobs on ACK timeout', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-done',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'completed',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+      } as any);
+
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockRepository.updateStatus).not.toHaveBeenCalledWith('job-done', 'orphaned');
+    });
+
+    it('should decrement load for timed-out assigned worker', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 2,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-assigned',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'assigned',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: 'w1',
+      } as any);
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(scheduler.workers.get('w1')!.currentLoad).toBe(2);
+    });
+
+    it('should handle ACK timeout without assignedWorkerId', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-no-worker',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'assigned',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+      } as any);
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith('ACK timeout for job', expect.any(Object));
+    });
+
+    it('should handle ACK timeout when worker is not found in registry', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-orphan',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'assigned',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: 'nonexistent',
+      } as any);
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith('ACK timeout for job', expect.any(Object));
+    });
+
+    it('should log error when updateStatus fails on ACK timeout', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-ack-fail',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'assigned',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: 'w1',
+      } as any);
+      mockRepository.insert.mockResolvedValue(undefined);
+      let callIdx = 0;
+      mockRepository.updateStatus.mockImplementation(() => {
+        callIdx++;
+        if (callIdx === 3) return Promise.reject(new Error('orphan persist failed'));
+        return Promise.resolve(undefined);
+      });
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to persist orphaned status on ACK timeout',
+        expect.objectContaining({ error: 'Error: orphan persist failed' }),
+      );
+    });
+
+    it('should log error when findById fails on ACK timeout', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.findById.mockRejectedValue(new Error('DB find failed'));
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to find job on ACK timeout',
+        expect.objectContaining({ error: 'Error: DB find failed' }),
+      );
+    });
+  });
+
+  describe('distributeNext error handling', () => {
+    it('should log error when updateStatus fails during assignment', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      mockRepository.insert.mockResolvedValue(undefined);
+      let callIdx = 0;
+      mockRepository.updateStatus.mockImplementation(() => {
+        callIdx++;
+        if (callIdx === 2) return Promise.reject(new Error('DB write failed'));
+        return Promise.resolve(undefined);
+      });
+
+      await scheduler.submit('test-type', {});
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to persist assigned status',
+        expect.objectContaining({ error: 'Error: DB write failed' }),
+      );
+    });
+  });
+});

--- a/services/job-scheduler/tests/unit/types/job.types.spec.ts
+++ b/services/job-scheduler/tests/unit/types/job.types.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { JOB_STATUS_NON_TERMINAL } from '../../../src/types/job.types';
+
+describe('JOB_STATUS_NON_TERMINAL', () => {
+  it('should contain all expected non-terminal statuses', () => {
+    expect(JOB_STATUS_NON_TERMINAL).toEqual([
+      'pending',
+      'queued',
+      'assigned',
+      'running',
+      'orphaned',
+    ]);
+  });
+
+  it('should exclude terminal statuses', () => {
+    expect(JOB_STATUS_NON_TERMINAL).not.toContain('completed');
+    expect(JOB_STATUS_NON_TERMINAL).not.toContain('failed');
+    expect(JOB_STATUS_NON_TERMINAL).not.toContain('cancelled');
+  });
+});

--- a/services/job-scheduler/tests/unit/worker/worker-protocol.spec.ts
+++ b/services/job-scheduler/tests/unit/worker/worker-protocol.spec.ts
@@ -1,0 +1,457 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('@trading-model/common/config/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('ws', () => {
+  const MockWebSocket = jest.fn(() => ({
+    on: jest.fn(),
+    send: jest.fn(),
+    readyState: 1,
+    close: jest.fn(),
+  }));
+  (MockWebSocket as any).OPEN = 1;
+  (MockWebSocket as any).CONNECTING = 0;
+  (MockWebSocket as any).CLOSING = 2;
+  (MockWebSocket as any).CLOSED = 3;
+
+  const MockWebSocketServer = jest.fn(() => ({
+    on: jest.fn(),
+    close: jest.fn(),
+  }));
+
+  return {
+    __esModule: true,
+    default: MockWebSocket,
+    WebSocketServer: MockWebSocketServer,
+  };
+});
+
+import { logger } from '@trading-model/common/config/logger';
+import WebSocket, { WebSocketServer } from 'ws';
+
+import { WorkerProtocol } from '../../../src/worker/worker-protocol';
+import { WorkerRegistry } from '../../../src/worker/worker-registry';
+
+const MockWebSocketServer = WebSocketServer as unknown as jest.Mock;
+
+describe('WorkerProtocol', () => {
+  let protocol: WorkerProtocol;
+  let mockRegistry: jest.Mocked<WorkerRegistry>;
+  let onWorkerDisconnect: jest.Mock;
+  let wssInstance: any;
+  let connectionHandler: Function;
+
+  function createWs(overrides: Partial<{ readyState: number }> = {}) {
+    return {
+      on: jest.fn(),
+      send: jest.fn(),
+      readyState: 1,
+      close: jest.fn(),
+      ...overrides,
+    };
+  }
+
+  function simulateConnection(ws: any) {
+    connectionHandler(ws);
+  }
+
+  function getMessageHandler(ws: any): jest.Mock {
+    return (ws.on as jest.Mock).mock.calls.find((c: any) => c[0] === 'message')![1] as unknown as jest.Mock;
+  }
+
+  function getCloseHandler(ws: any): jest.Mock {
+    return (ws.on as jest.Mock).mock.calls.find((c: any) => c[0] === 'close')![1] as unknown as jest.Mock;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockRegistry = {
+      register: jest.fn(),
+      unregister: jest.fn(),
+      heartbeat: jest.fn(),
+      updateLoad: jest.fn(),
+      setStatus: jest.fn(),
+      get: jest.fn(),
+      findBestWorker: jest.fn(),
+      purgeStaleWorkers: jest.fn(),
+      count: jest.fn(),
+      averageLoad: jest.fn(),
+      getAllActive: jest.fn(),
+    } as unknown as jest.Mocked<WorkerRegistry>;
+
+    onWorkerDisconnect = jest.fn();
+
+    protocol = new WorkerProtocol(
+      {} as any,
+      mockRegistry,
+      onWorkerDisconnect,
+    );
+
+    wssInstance = MockWebSocketServer.mock.results[0].value;
+    connectionHandler = (wssInstance.on as jest.Mock).mock.calls.find(
+      (c: any) => c[0] === 'connection',
+    )![1] as unknown as Function;
+  });
+
+  describe('constructor', () => {
+    it('should create a WebSocketServer with the provided server', () => {
+      expect(MockWebSocketServer).toHaveBeenCalledWith({ server: {} });
+    });
+
+    it('should register a connection handler on the WebSocketServer', () => {
+      expect(wssInstance.on).toHaveBeenCalledWith('connection', expect.any(Function));
+    });
+  });
+
+  describe('on connection', () => {
+    it('should set up message and close handlers on the WebSocket', () => {
+      const ws = createWs();
+
+      simulateConnection(ws);
+
+      expect(ws.on).toHaveBeenCalledWith('message', expect.any(Function));
+      expect(ws.on).toHaveBeenCalledWith('close', expect.any(Function));
+    });
+
+    describe('message handling', () => {
+      it('should handle register message', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler(JSON.stringify({
+          type: 'register',
+          workerId: 'w1',
+          address: '10.0.0.1',
+          port: 9000,
+          capabilities: ['type-a'],
+          maxConcurrency: 5,
+        }));
+
+        expect(mockRegistry.register).toHaveBeenCalledWith('w1', {
+          workerId: 'w1',
+          address: '10.0.0.1',
+          port: 9000,
+          capabilities: ['type-a'],
+          maxConcurrency: 5,
+          currentLoad: 0,
+        });
+        expect(logger.info).toHaveBeenCalledWith('Worker registered via WebSocket', {
+          workerId: 'w1',
+        });
+      });
+
+      it('should handle heartbeat message', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler(JSON.stringify({
+          type: 'register',
+          workerId: 'w1',
+          address: '10.0.0.1',
+          port: 9000,
+          capabilities: ['type-a'],
+          maxConcurrency: 5,
+        }));
+
+        jest.clearAllMocks();
+
+        messageHandler(JSON.stringify({
+          type: 'heartbeat',
+          workerId: 'w1',
+          currentLoad: 3,
+        }));
+
+        expect(mockRegistry.heartbeat).toHaveBeenCalledWith('w1');
+        expect(mockRegistry.updateLoad).toHaveBeenCalledWith('w1', 3);
+        expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'heartbeat.ack' }));
+      });
+
+      it('should not send heartbeat ack when connection is not OPEN', () => {
+        const ws = createWs({ readyState: 2 });
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler(JSON.stringify({
+          type: 'register',
+          workerId: 'w1',
+          address: '10.0.0.1',
+          port: 9000,
+          capabilities: [],
+          maxConcurrency: 5,
+        }));
+
+        jest.clearAllMocks();
+
+        messageHandler(JSON.stringify({
+          type: 'heartbeat',
+          workerId: 'w1',
+          currentLoad: 1,
+        }));
+
+        expect(ws.send).not.toHaveBeenCalled();
+      });
+
+      it('should handle disconnect message', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler(JSON.stringify({
+          type: 'register',
+          workerId: 'w1',
+          address: '10.0.0.1',
+          port: 9000,
+          capabilities: [],
+          maxConcurrency: 5,
+        }));
+
+        jest.clearAllMocks();
+
+        messageHandler(JSON.stringify({
+          type: 'disconnect',
+          workerId: 'w1',
+          reason: 'shutting down',
+        }));
+
+        expect(mockRegistry.unregister).toHaveBeenCalledWith('w1');
+        expect(onWorkerDisconnect).toHaveBeenCalledWith('w1');
+        expect(logger.info).toHaveBeenCalledWith('Worker disconnected', {
+          workerId: 'w1',
+          reason: 'shutting down',
+        });
+      });
+
+      it('should log error on invalid JSON', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler('not-json');
+
+        expect(logger.error).toHaveBeenCalledWith('Invalid WebSocket message from worker', {
+          error: expect.any(String),
+        });
+      });
+
+      it('should log error with String(err) when thrown value is not an Error', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler({ toString: () => { throw 'primitive-error'; } });
+
+        expect(logger.error).toHaveBeenCalledWith('Invalid WebSocket message from worker', {
+          error: 'primitive-error',
+        });
+      });
+
+      it('should do nothing for unknown message type', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler(JSON.stringify({ type: 'unknown' }));
+
+        expect(mockRegistry.register).not.toHaveBeenCalled();
+        expect(mockRegistry.heartbeat).not.toHaveBeenCalled();
+        expect(mockRegistry.unregister).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('close handling', () => {
+      it('should mark worker as draining and call onWorkerDisconnect', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+        const closeHandler = getCloseHandler(ws);
+
+        messageHandler(JSON.stringify({
+          type: 'register',
+          workerId: 'w1',
+          address: '10.0.0.1',
+          port: 9000,
+          capabilities: [],
+          maxConcurrency: 5,
+        }));
+
+        jest.clearAllMocks();
+
+        closeHandler();
+
+        expect(mockRegistry.setStatus).toHaveBeenCalledWith('w1', 'draining');
+        expect(onWorkerDisconnect).toHaveBeenCalledWith('w1');
+      });
+
+      it('should do nothing when closing a non-registered connection', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const closeHandler = getCloseHandler(ws);
+
+        closeHandler();
+
+        expect(mockRegistry.setStatus).not.toHaveBeenCalled();
+        expect(onWorkerDisconnect).not.toHaveBeenCalled();
+      });
+
+      it('should not match close for a different WebSocket than the one in the map', () => {
+        const ws1 = createWs();
+        simulateConnection(ws1);
+        getMessageHandler(ws1)(JSON.stringify({
+          type: 'register',
+          workerId: 'w1',
+          address: '10.0.0.1',
+          port: 9000,
+          capabilities: [],
+          maxConcurrency: 5,
+        }));
+
+        const ws2 = createWs();
+        simulateConnection(ws2);
+        const closeHandler2 = getCloseHandler(ws2);
+
+        jest.clearAllMocks();
+
+        closeHandler2();
+
+        expect(mockRegistry.setStatus).not.toHaveBeenCalled();
+        expect(onWorkerDisconnect).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('sendToWorker', () => {
+    it('should send JSON message to the worker connection', () => {
+      const ws = createWs();
+      simulateConnection(ws);
+      const messageHandler = getMessageHandler(ws);
+
+      messageHandler(JSON.stringify({
+        type: 'register',
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+      }));
+
+      protocol.sendToWorker('w1', { type: 'drain' });
+
+      expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'drain' }));
+    });
+
+    it('should not send if worker connection does not exist', () => {
+      const ws = createWs();
+      simulateConnection(ws);
+
+      protocol.sendToWorker('nonexistent', { type: 'drain' });
+
+      expect(ws.send).not.toHaveBeenCalled();
+    });
+
+    it('should not send if connection is not OPEN', () => {
+      const ws = createWs({ readyState: 2 });
+      simulateConnection(ws);
+      const messageHandler = getMessageHandler(ws);
+
+      messageHandler(JSON.stringify({
+        type: 'register',
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+      }));
+
+      protocol.sendToWorker('w1', { type: 'drain' });
+
+      expect(ws.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendDrain', () => {
+    it('should call sendToWorker with drain type', () => {
+      jest.spyOn(protocol, 'sendToWorker');
+
+      protocol.sendDrain('w1');
+
+      expect(protocol.sendToWorker).toHaveBeenCalledWith('w1', { type: 'drain' });
+    });
+  });
+
+  describe('broadcastDrain', () => {
+    it('should call sendDrain for all connections', () => {
+      jest.spyOn(protocol, 'sendDrain');
+
+      const ws1 = createWs();
+      simulateConnection(ws1);
+      getMessageHandler(ws1)(JSON.stringify({
+        type: 'register',
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+      }));
+
+      const ws2 = createWs();
+      simulateConnection(ws2);
+      getMessageHandler(ws2)(JSON.stringify({
+        type: 'register',
+        workerId: 'w2',
+        address: '10.0.0.2',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+      }));
+
+      jest.clearAllMocks();
+
+      protocol.broadcastDrain();
+
+      expect(protocol.sendDrain).toHaveBeenCalledWith('w1');
+      expect(protocol.sendDrain).toHaveBeenCalledWith('w2');
+    });
+  });
+
+  describe('close', () => {
+    it('should broadcast drain, close all connections, clear map, and close server', () => {
+      jest.spyOn(protocol, 'broadcastDrain');
+
+      const ws1 = createWs();
+      simulateConnection(ws1);
+      getMessageHandler(ws1)(JSON.stringify({
+        type: 'register',
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+      }));
+
+      const ws2 = createWs();
+      simulateConnection(ws2);
+      getMessageHandler(ws2)(JSON.stringify({
+        type: 'register',
+        workerId: 'w2',
+        address: '10.0.0.2',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+      }));
+
+      jest.clearAllMocks();
+
+      protocol.close();
+
+      expect(protocol.broadcastDrain).toHaveBeenCalledTimes(1);
+      expect(ws1.close).toHaveBeenCalledTimes(1);
+      expect(ws2.close).toHaveBeenCalledTimes(1);
+      expect(wssInstance.close).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/services/job-scheduler/tests/unit/worker/worker-registry.spec.ts
+++ b/services/job-scheduler/tests/unit/worker/worker-registry.spec.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, beforeEach, jest, afterEach } from '@jest/globals';
+
+import { WorkerRegistry } from '../../../src/worker/worker-registry';
+
+describe('WorkerRegistry', () => {
+  let registry: WorkerRegistry;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    registry = new WorkerRegistry(10000);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('register', () => {
+    it('should add a worker to the registry', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      expect(registry.count()).toBe(1);
+    });
+  });
+
+  describe('unregister', () => {
+    it('should remove a worker from the registry', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+      registry.unregister('worker-1');
+
+      expect(registry.count()).toBe(0);
+    });
+  });
+
+  describe('get', () => {
+    it('should return undefined for unknown worker', () => {
+      expect(registry.get('unknown')).toBeUndefined();
+    });
+
+    it('should return the worker registration', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      const worker = registry.get('worker-1');
+      expect(worker).toBeDefined();
+      expect(worker!.status).toBe('active');
+    });
+  });
+
+  describe('heartbeat', () => {
+    it('should update lastHeartbeat for a registered worker', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      const before = registry.get('worker-1')!.lastHeartbeat.getTime();
+      jest.advanceTimersByTime(1000);
+      registry.heartbeat('worker-1');
+      const after = registry.get('worker-1')!.lastHeartbeat.getTime();
+
+      expect(after).toBeGreaterThan(before);
+    });
+
+    it('should not fail for unknown worker', () => {
+      expect(() => registry.heartbeat('unknown')).not.toThrow();
+    });
+  });
+
+  describe('updateLoad', () => {
+    it('should update the current load of a worker', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      registry.updateLoad('worker-1', 3);
+      expect(registry.get('worker-1')!.currentLoad).toBe(3);
+    });
+
+    it('should not throw for unknown worker', () => {
+      expect(() => registry.updateLoad('unknown', 5)).not.toThrow();
+    });
+  });
+
+  describe('setStatus', () => {
+    it('should update the status of a worker', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      registry.setStatus('worker-1', 'draining');
+      expect(registry.get('worker-1')!.status).toBe('draining');
+    });
+
+    it('should not throw for unknown worker', () => {
+      expect(() => registry.setStatus('unknown', 'offline')).not.toThrow();
+    });
+  });
+
+  describe('findBestWorker', () => {
+    it('should return null when no workers are registered', () => {
+      expect(registry.findBestWorker('type-a')).toBeNull();
+    });
+
+    it('should return null when no worker supports the job type', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-b'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      expect(registry.findBestWorker('type-a')).toBeNull();
+    });
+
+    it('should skip draining workers', () => {
+      registry.register('draining-worker', {
+        workerId: 'draining-worker',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+      registry.setStatus('draining-worker', 'draining');
+
+      expect(registry.findBestWorker('type-a')).toBeNull();
+    });
+
+    it('should skip workers at max concurrency', () => {
+      registry.register('busy-worker', {
+        workerId: 'busy-worker',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 2,
+        currentLoad: 2,
+      });
+
+      expect(registry.findBestWorker('type-a')).toBeNull();
+    });
+
+    it('should return the least loaded compatible worker', () => {
+      registry.register('busy', {
+        workerId: 'busy',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 10,
+        currentLoad: 8,
+      });
+      registry.register('free', {
+        workerId: 'free',
+        address: '10.0.0.2',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 10,
+        currentLoad: 2,
+      });
+
+      const best = registry.findBestWorker('type-a');
+      expect(best).not.toBeNull();
+      expect(best!.workerId).toBe('free');
+    });
+
+    it('should skip workers with higher load than current best', () => {
+      registry.register('good', {
+        workerId: 'good',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 10,
+        currentLoad: 2,
+      });
+      registry.register('worse', {
+        workerId: 'worse',
+        address: '10.0.0.2',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 10,
+        currentLoad: 5,
+      });
+
+      const best = registry.findBestWorker('type-a');
+      expect(best!.workerId).toBe('good');
+    });
+  });
+
+  describe('purgeStaleWorkers', () => {
+    it('should return empty array when all workers are active', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+      registry.heartbeat('worker-1');
+
+      const stale = registry.purgeStaleWorkers();
+      expect(stale).toEqual([]);
+    });
+
+    it('should purge workers with expired heartbeats', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      jest.advanceTimersByTime(15000);
+
+      const stale = registry.purgeStaleWorkers();
+      expect(stale).toContain('worker-1');
+      expect(registry.count()).toBe(0);
+    });
+  });
+
+  describe('count', () => {
+    it('should return 0 for empty registry', () => {
+      expect(registry.count()).toBe(0);
+    });
+
+    it('should return the number of registered workers', () => {
+      registry.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 1,
+        currentLoad: 0,
+      });
+      registry.register('w2', {
+        workerId: 'w2',
+        address: '10.0.0.2',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 1,
+        currentLoad: 0,
+      });
+
+      expect(registry.count()).toBe(2);
+    });
+  });
+
+  describe('averageLoad', () => {
+    it('should return 0 for empty registry', () => {
+      expect(registry.averageLoad()).toBe(0);
+    });
+
+    it('should calculate the average load ratio', () => {
+      registry.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 10,
+        currentLoad: 5,
+      });
+      registry.register('w2', {
+        workerId: 'w2',
+        address: '10.0.0.2',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 10,
+        currentLoad: 3,
+      });
+
+      expect(registry.averageLoad()).toBeCloseTo(0.4, 5);
+    });
+
+    it('should handle worker with maxConcurrency of 0', () => {
+      registry.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 0,
+        currentLoad: 0,
+      });
+
+      expect(registry.averageLoad()).toBe(0);
+    });
+  });
+
+  describe('getAllActive', () => {
+    it('should return only active workers', () => {
+      registry.register('active-w', {
+        workerId: 'active-w',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+      registry.register('draining-w', {
+        workerId: 'draining-w',
+        address: '10.0.0.2',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+      registry.setStatus('draining-w', 'draining');
+
+      const active = registry.getAllActive();
+      expect(active).toHaveLength(1);
+      expect(active[0].workerId).toBe('active-w');
+    });
+  });
+});

--- a/services/job-scheduler/tsconfig.json
+++ b/services/job-scheduler/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "node16",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node16",
+    "types": ["node"],
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "tests"]
+}


### PR DESCRIPTION
# Description

Job Scheduler service complet avec orchestration centralisée des jobs, file prioritaire, ACK, reprise sur panne, back pressure explicite, WebSocket pour les workers, et couverture de tests à 100%.

## Type of Change

- [x] :sparkles: feat — New feature
- [x] :recycle: refactor — Code restructuring
- [x] :white_check_mark: test — Tests
- [x] :bug: fix — Bug fix

## Changes

### Commit 1 — :sparkles:(job-scheduler): add job scheduler service

**22 fichiers, +1444 lignes** — Service complet d'orchestration de jobs :

- **Scheduler central** (`src/scheduler/job-scheduler.ts`) : soumission, assignation, ACK, completion, fail, cancel, start/stop
- **File prioritaire** (`src/scheduler/internal-queue.ts`) : 5 niveaux de priorité, timers d'ACK, callback de timeout
- **Back pressure** (`src/scheduler/back-pressure.ts`) : contrôle de charge par profondeur de file + ratio worker
- **Worker Registry** (`src/worker/worker-registry.ts`) : enregistrement, eligibilité, findBestWorker (load balancing)
- **Worker Protocol** (`src/worker/worker-protocol.ts`) : WebSocket push vers workers, heartbeat, reconnexion
- **Persistence** (`src/persistence/job-repository.ts`) : MongoDB (insert, findById, updateStatus, incrementRetry, etc.)
- **Recovery** : Orphan Detector (scan périodique) + Re-Allocator (re-try avec backoff exponentiel)
- **Configuration** : env.ts (Zod schema) + address-manager.ts
- **Routes** : REST endpoints pour jobs, ACK, workers, health
- **Types** : job.types.ts, worker.types.ts
- **Infra** : Dockerfile, package.json, tsconfig.json
- **Packages communs** : ajout de `JobSchedulerService` dans `services.types.ts`

### Commit 2 — :recycle:(job-scheduler): refactor routes into controller + schema + thin route pattern

**18 fichiers, +270/-205 lignes** — Refactoring des routes suivant le pattern exact du projet :

- Extraction des controllers (ack.controller.ts, health.controller.ts, job.controller.ts, worker.controller.ts)
- Schemas Zod séparés (ack.schema.ts, job.schema.ts, worker.schema.ts)
- Routes réduites à ~15 lignes chacune (délégation pure)
- Exposition de `raw: https.Server` dans `HttpServer` (common/server-factory.ts) pour WebSocket
- Controllers avec `catchSync` + `sendResponse()` (aligné sur discovery-server et message-manager)
- Corrections de types (`readonly`, `string | string[]`)

### Commit 3 — :white_check_mark:(job-scheduler): fix tests and reach 100% coverage

**33 fichiers, +3668/-16 lignes** — Couverture de tests complète :

- **7 nouveaux fichiers de test** : types/job.types, config/env, config/address-manager, app/server, app/index, persistence/job-repository, worker/worker-protocol
- **Couverture de branches** pour internal-queue, orphan-detector, worker-registry, job.controller, job-scheduler
- **Tests fixture** : job.fixture.ts, worker.fixture.ts
- **Test helpers** : express.ts (Request/Response/NextFunction mocks)
- **Corrections** : `String(req.params.id)` pour les types `string | string[]`, mock de `env` dans 5 tests, remplacement de `new JobScheduler()` par des objets mock dans les controllers
- **167 tests, 100% coverage** (statements, branches, functions, lines)

## Breaking Changes

- [ ] Yes
- [x] No

## Tests

- [x] Existing tests pass (167 tests)
- [x] New tests added (100% coverage global)
- [x] `npm run build` — Success
- [x] `npm run test:coverage` — All tests pass

## Checklist

- [x] `npm run build` — Success
- [x] `npm run test:coverage` — All tests pass, 100% coverage global
- [x] Commit messages follow [gitmoji convention](../docs/standards/COMMIT.md)
- [x] Code follows [project standards](../docs/standards/WRITING.md)
