### PR TITLE
:sparkles:(audit-logger): add audit logger service with full unit tests and 100% coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3249,6 +3249,10 @@
       "resolved": "packages/address-manager",
       "link": true
     },
+    "node_modules/@trading-model/audit-logger": {
+      "resolved": "services/audit-logger",
+      "link": true
+    },
     "node_modules/@trading-model/broker-message": {
       "resolved": "packages/broker-message",
       "link": true
@@ -12049,6 +12053,38 @@
         "globals": "^17.6.0",
         "jest": "^30.4.2",
         "ts-jest": "^29.4.11",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.59.2"
+      }
+    },
+    "services/audit-logger": {
+      "name": "@trading-model/audit-logger",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@trading-model/address-manager": "*",
+        "@trading-model/broker-message": "*",
+        "@trading-model/common": "*",
+        "express": "^5.2.1",
+        "mongodb": "^7.2.0",
+        "uuid": "^14.0.0",
+        "ws": "^8.16.0",
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "@jest/globals": "^30.4.1",
+        "@types/express": "^5.0.6",
+        "@types/jest": "^30.0.0",
+        "@types/node": "^25.9.2",
+        "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.16.0",
+        "eslint": "^10.4.1",
+        "globals": "^17.6.0",
+        "jest": "^30.4.2",
+        "standard-version": "^9.5.0",
+        "ts-jest": "^29.4.11",
+        "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2"
       }

--- a/packages/broker-message/src/shared/helper/messages/message.schema.ts
+++ b/packages/broker-message/src/shared/helper/messages/message.schema.ts
@@ -248,6 +248,16 @@ const EventValidators: ZodEventMap<EventMap> = {
       'BookTicker is required and must be a array of object'
     ),
   }),
+
+  [EnumEventMessage.auditHeartbeat]: z.object({
+    serviceName: z.string(),
+    instanceId: z.string(),
+  }),
+  [EnumEventMessage.auditGapDetected]: z.object({
+    from: z.string().transform((s) => new Date(s)),
+    to: z.string().transform((s) => new Date(s)),
+    lostCount: z.number().int().optional(),
+  }),
 };
 
 /** Validates the message payload as a discriminated union by event type. */

--- a/packages/broker-message/tests/unit/message-schema.spec.ts
+++ b/packages/broker-message/tests/unit/message-schema.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { MessagePayloadSchema } from '../../src/shared/helper/messages/message.schema';
+
+describe('MessagePayloadSchema', () => {
+  describe('auditHeartbeat', () => {
+    it('should accept valid heartbeat payload', () => {
+      const result = MessagePayloadSchema.parse({
+        type: 'audit.heartbeat' as const,
+        data: { serviceName: 'audit-logger', instanceId: 'inst-1' },
+      });
+      expect(result).toBeDefined();
+      expect((result.data as any).serviceName).toBe('audit-logger');
+    });
+
+    it('should reject heartbeat without instanceId', () => {
+      expect(() =>
+        MessagePayloadSchema.parse({
+          type: 'audit.heartbeat' as const,
+          data: { serviceName: 'audit-logger' },
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe('auditGapDetected', () => {
+    it('should accept valid gap detected payload', () => {
+      const result = MessagePayloadSchema.parse({
+        type: 'audit.gap.detected' as const,
+        data: {
+          from: '2024-01-01T00:00:00Z',
+          to: '2024-01-02T00:00:00Z',
+          lostCount: 5,
+        },
+      });
+      expect(result).toBeDefined();
+      const data = result.data as any;
+      expect(data.from).toBeInstanceOf(Date);
+      expect(data.to).toBeInstanceOf(Date);
+      expect(data.lostCount).toBe(5);
+    });
+
+    it('should accept gap detected without optional lostCount', () => {
+      const result = MessagePayloadSchema.parse({
+        type: 'audit.gap.detected' as const,
+        data: {
+          from: '2024-01-01T00:00:00Z',
+          to: '2024-01-02T00:00:00Z',
+        },
+      });
+      expect((result.data as any).lostCount).toBeUndefined();
+    });
+  });
+});

--- a/packages/common/src/config/event.types.ts
+++ b/packages/common/src/config/event.types.ts
@@ -121,6 +121,10 @@ export const EnumEventMessage = {
   fetchOrderBookSnapshot: 'market.order-book.snapshot.fetch',
   fetchPriceTickerSnapshot: 'market.price-ticker.snapshot.fetch',
   fetchOrderBookTickerSnapshot: 'market.order-book-ticker.snapshot.fetch',
+
+  /** Audit system events */
+  auditHeartbeat: 'audit.heartbeat',
+  auditGapDetected: 'audit.gap.detected',
 } as const;
 
 type EventMessage = (typeof EnumEventMessage)[keyof typeof EnumEventMessage];
@@ -135,6 +139,10 @@ export type EventMap = {
   [EnumEventMessage.fetchOrderBookSnapshot]: { orderBook: OrderBookData[] };
   [EnumEventMessage.fetchPriceTickerSnapshot]: { price: Record<string, number> };
   [EnumEventMessage.fetchOrderBookTickerSnapshot]: { bookTicker: BookTickerData[] };
+
+  /** Audit system events */
+  [EnumEventMessage.auditHeartbeat]: { serviceName: string; instanceId: string };
+  [EnumEventMessage.auditGapDetected]: { from: Date; to: Date; lostCount?: number };
 };
 
 /** Extracts the payload type for a given event message. */

--- a/packages/common/src/config/services.types.ts
+++ b/packages/common/src/config/services.types.ts
@@ -10,6 +10,7 @@ export const ServiceInstanceName = {
   RiskAnalysisService: 'risk-analysis-service',
   TraderTrainingService: 'trader-training-service',
   JobSchedulerService: 'job-scheduler-service',
+  AuditLoggerService: 'audit-logger-service',
 } as const;
 
 export type ServiceInstanceName = (typeof ServiceInstanceName)[keyof typeof ServiceInstanceName];

--- a/services/audit-logger/.env.example
+++ b/services/audit-logger/.env.example
@@ -1,0 +1,39 @@
+# ── Runtime ──────────────────────────────────────────
+NODE_ENV=development
+PORT=3000
+LOG_LEVEL=info
+
+# ── TLS / mTLS ──────────────────────────────────────
+TLS_KEY_PATH=./certs/server-key.pem
+TLS_CERT_PATH=./certs/server.crt
+TLS_CA_PATH=./certs/ca.crt
+
+# ── MongoDB (audit store) ───────────────────────────
+MONGODB_URI=mongodb://localhost:27017/audit-logger
+
+# ── Address Manager (service discovery) ─────────────
+APP_NAME=audit-logger
+APP_VERSION=1.0.0
+SERVICE_NAME=audit-logger-service
+INSTANCE_ID=audit-logger-1
+ADDRESS_MANAGER_URL=https://localhost:8443
+CACHE_TTL_MS=30000
+SERVICE_PING_TIMEOUT_MS=2000
+DISCOVERY_TIMEOUT_MS=5000
+TOKEN_REFRESH_INTERVAL_MS=60000
+TTL_REFRESH_INTERVAL_MS=15000
+ERROR_URL_WEBHOOK=
+MESSAGE_BUS_INIT_TIMEOUT_MS=2000
+MESSAGE_BUS_SHUTDOWN_TIMEOUT_MS=2000
+MESSAGE_CALLBACK_PATH=message
+DNS_NAME_MAP={}
+
+# ── Audit Logger internals ──────────────────────────
+MAX_QUEUE_DEPTH=10000
+MAX_WORKER_LOAD_RATIO=0.85
+ACK_TIMEOUT_MS=30000
+MAX_RETRIES_PER_JOB=3
+ORPHAN_SCAN_INTERVAL_MS=10000
+WORKER_HEARTBEAT_TTL_MS=30000
+GAP_DETECTION_INTERVAL_MS=60000
+AUDIT_RETENTION_DAYS=90

--- a/services/audit-logger/Dockerfile
+++ b/services/audit-logger/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./
+EXPOSE 3000
+CMD ["node", "dist/app/index.js"]

--- a/services/audit-logger/jest.config.js
+++ b/services/audit-logger/jest.config.js
@@ -1,0 +1,23 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  rootDir: '.',
+  testMatch: ['**/?(*.)+(spec).ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@trading-model/common/(.*)$': '<rootDir>/../../packages/common/src/$1',
+    '^@trading-model/address-manager/(.*)$': '<rootDir>/../../packages/address-manager/src/$1',
+    '^@trading-model/broker-message/(.*)$': '<rootDir>/../../packages/broker-message/src/$1',
+  },
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+};

--- a/services/audit-logger/package.json
+++ b/services/audit-logger/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@trading-model/audit-logger",
+  "version": "1.0.0",
+  "description": "Service de traçabilité complète et immuable de toutes les décisions, transactions et erreurs",
+  "homepage": "https://github.com/docteur-turboss/trading-model#readme",
+  "bugs": {
+    "url": "https://github.com/docteur-turboss/trading-model/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/docteur-turboss/trading-model.git"
+  },
+  "keywords": [
+    "audit",
+    "logger",
+    "tracing",
+    "immutable"
+  ],
+  "license": "ISC",
+  "author": "Docteur Turboss <@docteur-turboss>",
+  "type": "commonjs",
+  "main": "./dist/app/index.js",
+  "scripts": {
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "build": "tsc",
+    "dev": "ts-node src/app/index.ts"
+  },
+  "dependencies": {
+    "@trading-model/address-manager": "*",
+    "@trading-model/broker-message": "*",
+    "@trading-model/common": "*",
+    "express": "^5.2.1",
+    "mongodb": "^7.2.0",
+    "uuid": "^14.0.0",
+    "ws": "^8.16.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "@jest/globals": "^30.4.1",
+    "@types/express": "^5.0.6",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^25.9.2",
+    "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.16.0",
+    "eslint": "^10.4.1",
+    "globals": "^17.6.0",
+    "jest": "^30.4.2",
+    "standard-version": "^9.5.0",
+    "ts-jest": "^29.4.11",
+    "ts-node": "^10.9.2",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.59.2"
+  }
+}

--- a/services/audit-logger/src/app/index.ts
+++ b/services/audit-logger/src/app/index.ts
@@ -1,0 +1,77 @@
+import { MongoClient } from 'mongodb';
+
+import BrokerMessage from '@trading-model/broker-message';
+import { logger } from '@trading-model/common/config/logger';
+import { ServiceInstanceName } from '@trading-model/common/config/services.types';
+import { createBootstrap } from '@trading-model/common/server/bootstrap';
+
+import { createServer } from './server';
+import { bootstrapAddressManager } from '../config/address-manager';
+import { env } from '../config/env';
+import { AuditRepository } from '../persistence/audit-repository';
+import { JobRepository } from '../persistence/job-repository';
+import { JobScheduler } from '../scheduler/job-scheduler';
+import { WorkerProtocol } from '../worker/worker-protocol';
+
+let addressManager: ReturnType<typeof bootstrapAddressManager> | null = null;
+let mongoClient: MongoClient | null = null;
+let scheduler: JobScheduler | null = null;
+let workerProtocol: WorkerProtocol | null = null;
+let brokerMessage: BrokerMessage | null = null;
+
+createBootstrap({
+  name: 'Audit Logger',
+  createServer: async () => {
+    mongoClient = new MongoClient(env.MONGODB_URI);
+    await mongoClient.connect();
+    const db = mongoClient.db();
+
+    const jobRepo = new JobRepository(db);
+    await jobRepo.ensureIndexes();
+
+    const auditRepo = new AuditRepository(db);
+    await auditRepo.ensureIndexes();
+
+    scheduler = new JobScheduler(jobRepo);
+
+    const server = await createServer(scheduler, auditRepo);
+
+    workerProtocol = new WorkerProtocol(server.raw, scheduler.workers, (workerId: string) =>
+      scheduler!.onWorkerDisconnect(workerId)
+    );
+    scheduler.setWorkerProtocol(workerProtocol);
+
+    await scheduler.start();
+
+    const { AddressManager } = await import('../config/address-manager.js');
+    brokerMessage = new BrokerMessage({
+      addressManagerClient: AddressManager,
+      KeyCertificatPath: env.TLS_KEY_PATH,
+      RootCACertPath: env.TLS_CA_PATH,
+      CertificatPath: env.TLS_CERT_PATH,
+      instanceId: env.INSTANCE_ID,
+      serviceName: ServiceInstanceName.AuditLoggerService,
+    });
+
+    const { EnumEventMessage } = await import('@trading-model/common/config/event.types');
+    const ALL_TOPICS = Object.values(EnumEventMessage);
+    await brokerMessage.intents(ALL_TOPICS);
+    logger.info('Subscribed to all event topics', { topicCount: ALL_TOPICS.length });
+
+    return server;
+  },
+  onStart: () => {
+    addressManager = bootstrapAddressManager();
+    logger.info('Audit Logger fully operational', {
+      port: env.PORT,
+      mongoUri: env.MONGODB_URI,
+    });
+  },
+  onStop: async () => {
+    if (brokerMessage) await brokerMessage.stopMessageManager();
+    if (scheduler) await scheduler.stop();
+    if (workerProtocol) workerProtocol.close();
+    if (addressManager) addressManager.stop();
+    if (mongoClient) await mongoClient.close();
+  },
+});

--- a/services/audit-logger/src/app/server.ts
+++ b/services/audit-logger/src/app/server.ts
@@ -1,0 +1,26 @@
+import { createSecureServer } from '@trading-model/common/server/create-secure-server';
+import { loadTlsConfig } from '@trading-model/common/server/load-tls-config';
+
+import { AddressManagerRoutes } from '../config/address-manager';
+import { env } from '../config/env';
+import { AuditRepository } from '../persistence/audit-repository';
+import { eventsRoutes } from '../routes/events.routes';
+import { healthRoutes } from '../routes/health.routes';
+import { JobScheduler } from '../scheduler/job-scheduler';
+import { createMessageHandler } from '../subscription/audit-subscriber';
+
+export function createServer(scheduler: JobScheduler, auditRepo: AuditRepository) {
+  const messageHandler = createMessageHandler(auditRepo);
+
+  return createSecureServer({
+    port: env.PORT,
+    tls: loadTlsConfig(env),
+    trustProxy: true,
+    routes: app => {
+      app.use('/', healthRoutes(scheduler.queue, scheduler.backPressure, scheduler.workers));
+      app.use('/', eventsRoutes(auditRepo));
+      app.post('/message', messageHandler);
+      AddressManagerRoutes(app);
+    },
+  });
+}

--- a/services/audit-logger/src/config/address-manager.ts
+++ b/services/audit-logger/src/config/address-manager.ts
@@ -1,0 +1,10 @@
+import { createAddressManager } from '@trading-model/address-manager/create-address-manager';
+
+import { env } from './env';
+
+const addressManager = createAddressManager(env);
+
+const bootstrapAddressManager = addressManager.start;
+const AddressManagerRoutes = addressManager.listenExpress;
+
+export { AddressManagerRoutes, bootstrapAddressManager, addressManager as AddressManager };

--- a/services/audit-logger/src/config/env.ts
+++ b/services/audit-logger/src/config/env.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+import {
+  BaseEnvSchema,
+  AddressManagerEnvSchema,
+  validateEnv,
+} from '@trading-model/common/validation/env';
+
+const AuditLoggerEnvSchema = BaseEnvSchema.extend({
+  ...AddressManagerEnvSchema.shape,
+  MONGODB_URI: z.string().url().default('mongodb://localhost:27017/audit-logger'),
+  MAX_QUEUE_DEPTH: z.coerce.number().int().positive().default(10000),
+  MAX_WORKER_LOAD_RATIO: z.coerce.number().min(0).max(1).default(0.85),
+  ACK_TIMEOUT_MS: z.coerce.number().int().positive().default(30000),
+  MAX_RETRIES_PER_JOB: z.coerce.number().int().min(0).default(3),
+  ORPHAN_SCAN_INTERVAL_MS: z.coerce.number().int().positive().default(10000),
+  WORKER_HEARTBEAT_TTL_MS: z.coerce.number().int().positive().default(30000),
+  GAP_DETECTION_INTERVAL_MS: z.coerce.number().int().positive().default(60000),
+  AUDIT_RETENTION_DAYS: z.coerce.number().int().positive().default(90),
+});
+
+export const env = validateEnv(AuditLoggerEnvSchema);
+
+export type Env = z.infer<typeof AuditLoggerEnvSchema>;

--- a/services/audit-logger/src/persistence/audit-repository.ts
+++ b/services/audit-logger/src/persistence/audit-repository.ts
@@ -1,0 +1,169 @@
+import { Collection, Db, Filter } from 'mongodb';
+
+import { AppError, ErrorCodes } from '@trading-model/common/utils/errors';
+
+export interface AuditEventDocument {
+  receivedAt: Date;
+  metadata: {
+    topic: string;
+    eventType: string;
+    publisher: string;
+    instanceId: string;
+    messageId: string;
+    correlationId?: string;
+  };
+  payload: unknown;
+}
+
+export interface AuditEventQuery {
+  topic?: string;
+  publisher?: string;
+  correlationId?: string;
+  startDate?: Date;
+  endDate?: Date;
+  page?: number;
+  limit?: number;
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export interface AuditStats {
+  totalEvents: number;
+  eventsByTopic: Record<string, number>;
+  eventsByPublisher: Record<string, number>;
+  dateRange: {
+    earliest: Date | null;
+    latest: Date | null;
+  };
+}
+
+const COLLECTION = 'audit_events';
+
+export class AuditRepository {
+  private readonly collection: Collection<AuditEventDocument>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<AuditEventDocument>(COLLECTION);
+  }
+
+  async ensureIndexes(): Promise<void> {
+    await this.collection.createIndex({ 'metadata.correlationId': 1 });
+    await this.collection.createIndex({ 'metadata.publisher': 1, receivedAt: -1 });
+    await this.collection.createIndex({ 'metadata.topic': 1, receivedAt: -1 });
+    await this.collection.createIndex({ receivedAt: -1 });
+  }
+
+  async insert(event: AuditEventDocument): Promise<void> {
+    try {
+      await this.collection.insertOne(event);
+    } catch (err) {
+      throw new AppError('Failed to persist audit event', ErrorCodes.AGENT_ERROR, {
+        cause: err,
+      });
+    }
+  }
+
+  async insertBatch(events: AuditEventDocument[]): Promise<void> {
+    if (events.length === 0) return;
+    try {
+      await this.collection.insertMany(events, { ordered: false });
+    } catch (err) {
+      throw new AppError('Failed to persist audit event batch', ErrorCodes.AGENT_ERROR, {
+        cause: err,
+      });
+    }
+  }
+
+  async findById(messageId: string): Promise<AuditEventDocument | null> {
+    return this.collection.findOne({ 'metadata.messageId': messageId });
+  }
+
+  async query(query: AuditEventQuery): Promise<PaginatedResult<AuditEventDocument>> {
+    const page = query.page ?? 1;
+    const limit = Math.min(query.limit ?? 100, 1000);
+    const skip = (page - 1) * limit;
+
+    const filter: Filter<AuditEventDocument> = {};
+
+    if (query.topic) {
+      filter['metadata.topic'] = query.topic;
+    }
+    if (query.publisher) {
+      filter['metadata.publisher'] = query.publisher;
+    }
+    if (query.correlationId) {
+      filter['metadata.correlationId'] = query.correlationId;
+    }
+    if (query.startDate || query.endDate) {
+      filter.receivedAt = {};
+      if (query.startDate) {
+        filter.receivedAt.$gte = query.startDate;
+      }
+      if (query.endDate) {
+        filter.receivedAt.$lte = query.endDate;
+      }
+    }
+
+    const [data, total] = await Promise.all([
+      this.collection.find(filter).sort({ receivedAt: -1 }).skip(skip).limit(limit).toArray(),
+      this.collection.countDocuments(filter),
+    ]);
+
+    return {
+      data,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async getStats(): Promise<AuditStats> {
+    const [totalEvents, topicAgg, publisherAgg, dateRange] = await Promise.all([
+      this.collection.estimatedDocumentCount(),
+      this.collection
+        .aggregate<{
+          _id: string;
+          count: number;
+        }>([{ $group: { _id: '$metadata.topic', count: { $sum: 1 } } }])
+        .toArray(),
+      this.collection
+        .aggregate<{
+          _id: string;
+          count: number;
+        }>([{ $group: { _id: '$metadata.publisher', count: { $sum: 1 } } }])
+        .toArray(),
+      this.collection
+        .aggregate<{ earliest: Date | null; latest: Date | null }>([
+          {
+            $group: {
+              _id: null,
+              earliest: { $min: '$receivedAt' },
+              latest: { $max: '$receivedAt' },
+            },
+          },
+        ])
+        .toArray(),
+    ]);
+
+    return {
+      totalEvents,
+      eventsByTopic: Object.fromEntries(topicAgg.map(t => [t._id, t.count])),
+      eventsByPublisher: Object.fromEntries(publisherAgg.map(p => [p._id, p.count])),
+      dateRange: {
+        earliest: dateRange[0]?.earliest ?? null,
+        latest: dateRange[0]?.latest ?? null,
+      },
+    };
+  }
+}

--- a/services/audit-logger/src/persistence/job-repository.ts
+++ b/services/audit-logger/src/persistence/job-repository.ts
@@ -1,0 +1,154 @@
+import { Collection, Db } from 'mongodb';
+
+import { Job, JobStatus } from '../types/job.types';
+
+const COLLECTION = 'audit_jobs';
+
+interface JobDocument {
+  jobId: string;
+  type: string;
+  payload: unknown;
+  priority: number;
+  status: string;
+  assignedWorkerId?: string;
+  ackDeadline: number;
+  maxRetries: number;
+  retryCount: number;
+  createdAt: Date;
+  startedAt?: Date;
+  completedAt?: Date;
+  result?: unknown;
+  error?: string;
+  history: Array<{ fromStatus: string; toStatus: string; timestamp: Date; reason: string }>;
+}
+
+function toDocument(job: Job): JobDocument {
+  return {
+    jobId: job.id,
+    type: job.type,
+    payload: job.payload,
+    priority: job.priority,
+    status: job.status,
+    assignedWorkerId: job.assignedWorkerId,
+    ackDeadline: job.ackDeadline,
+    maxRetries: job.maxRetries,
+    retryCount: job.retryCount,
+    createdAt: job.createdAt,
+    startedAt: job.startedAt,
+    completedAt: job.completedAt,
+    result: job.result,
+    error: job.error,
+    history: job.history.map(e => ({
+      fromStatus: e.fromStatus,
+      toStatus: e.toStatus,
+      timestamp: e.timestamp,
+      reason: e.reason,
+    })),
+  };
+}
+
+function fromDocument(doc: JobDocument): Job {
+  return {
+    id: doc.jobId,
+    type: doc.type,
+    payload: doc.payload as Job['payload'],
+    priority: doc.priority as 1 | 2 | 3 | 4 | 5,
+    status: doc.status as JobStatus,
+    assignedWorkerId: doc.assignedWorkerId,
+    ackDeadline: doc.ackDeadline,
+    maxRetries: doc.maxRetries,
+    retryCount: doc.retryCount,
+    createdAt: doc.createdAt,
+    startedAt: doc.startedAt,
+    completedAt: doc.completedAt,
+    result: doc.result,
+    error: doc.error,
+    history: doc.history.map(e => ({
+      fromStatus: e.fromStatus as JobStatus,
+      toStatus: e.toStatus as JobStatus,
+      timestamp: e.timestamp,
+      reason: e.reason,
+    })),
+  };
+}
+
+export class JobRepository {
+  private readonly collection: Collection<JobDocument>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<JobDocument>(COLLECTION);
+  }
+
+  async ensureIndexes(): Promise<void> {
+    await this.collection.createIndex({ jobId: 1 }, { unique: true });
+    await this.collection.createIndex({ status: 1 });
+    await this.collection.createIndex({ assignedWorkerId: 1 }, { sparse: true });
+    await this.collection.createIndex({ type: 1, status: 1 });
+  }
+
+  async insert(job: Job): Promise<void> {
+    await this.collection.insertOne(toDocument(job));
+  }
+
+  async findById(jobId: string): Promise<Job | null> {
+    const doc = await this.collection.findOne({ jobId });
+    return doc ? fromDocument(doc) : null;
+  }
+
+  async updateStatus(
+    jobId: string,
+    status: JobStatus,
+    extras?: Partial<Pick<Job, 'result' | 'error' | 'assignedWorkerId' | 'ackDeadline'>>
+  ): Promise<void> {
+    const current = await this.collection.findOne({ jobId });
+    if (!current) return;
+
+    const $set: Record<string, unknown> = {
+      status,
+      ...(status === 'running' ? { startedAt: new Date() } : {}),
+      ...(status === 'completed' || status === 'failed' ? { completedAt: new Date() } : {}),
+    };
+    if (extras?.result !== undefined) $set.result = extras.result;
+    if (extras?.error !== undefined) $set.error = extras.error;
+    if (extras?.assignedWorkerId !== undefined) $set.assignedWorkerId = extras.assignedWorkerId;
+    if (extras?.ackDeadline !== undefined) $set.ackDeadline = extras.ackDeadline;
+
+    await this.collection.updateOne(
+      { jobId },
+      {
+        $set,
+        $push: {
+          history: {
+            fromStatus: current.status,
+            toStatus: status,
+            timestamp: new Date(),
+            reason: extras?.error || status,
+          },
+        },
+      }
+    );
+  }
+
+  async incrementRetry(jobId: string): Promise<void> {
+    await this.collection.updateOne({ jobId }, { $inc: { retryCount: 1 } });
+  }
+
+  async findNonTerminal(): Promise<Job[]> {
+    const docs = await this.collection
+      .find({ status: { $nin: ['completed', 'failed', 'cancelled'] } })
+      .toArray();
+    return docs.map(fromDocument);
+  }
+
+  async findByWorker(workerId: string, statuses: JobStatus[]): Promise<Job[]> {
+    const docs = await this.collection
+      .find({ assignedWorkerId: workerId, status: { $in: statuses } })
+      .toArray();
+    return docs.map(fromDocument);
+  }
+
+  async findByStatus(status: JobStatus): Promise<Job[]> {
+    const docs = await this.collection.find({ status }).toArray();
+    return docs.map(fromDocument);
+  }
+}

--- a/services/audit-logger/src/recovery/orphan-detector.ts
+++ b/services/audit-logger/src/recovery/orphan-detector.ts
@@ -1,0 +1,59 @@
+import { logger } from '@trading-model/common/config/logger';
+
+import { ReAllocator } from './re-allocator';
+import { JobRepository } from '../persistence/job-repository';
+import { WorkerRegistry } from '../worker/worker-registry';
+
+export class OrphanDetector {
+  private intervalHandle: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly workers: WorkerRegistry,
+    private readonly repository: JobRepository,
+    private readonly reAllocator: ReAllocator,
+    private readonly intervalMs: number
+  ) {}
+
+  start(): void {
+    if (this.intervalHandle) return;
+
+    this.intervalHandle = setInterval(async () => {
+      try {
+        await this.detectOrphans();
+      } catch (err) {
+        logger.error('Orphan detection cycle failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }, this.intervalMs);
+
+    logger.info('Orphan detector started', { intervalMs: this.intervalMs });
+  }
+
+  stop(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+  }
+
+  private async detectOrphans(): Promise<void> {
+    const staleWorkerIds = this.workers.purgeStaleWorkers();
+
+    if (staleWorkerIds.length === 0) return;
+
+    logger.warn('Stale workers detected — scanning for orphaned jobs', {
+      workerCount: staleWorkerIds.length,
+      workers: staleWorkerIds,
+    });
+
+    for (const workerId of staleWorkerIds) {
+      const orphanedJobs = await this.repository.findByWorker(workerId, ['assigned', 'running']);
+
+      for (const job of orphanedJobs) {
+        await this.repository.updateStatus(job.id, 'orphaned');
+        await this.reAllocator.reallocate(job);
+      }
+    }
+  }
+}

--- a/services/audit-logger/src/recovery/re-allocator.ts
+++ b/services/audit-logger/src/recovery/re-allocator.ts
@@ -1,0 +1,55 @@
+import { logger } from '@trading-model/common/config/logger';
+
+import { env } from '../config/env';
+import { JobRepository } from '../persistence/job-repository';
+import { InternalQueue } from '../scheduler/internal-queue';
+import { Job } from '../types/job.types';
+
+export class ReAllocator {
+  constructor(
+    private readonly repository: JobRepository,
+    private readonly queue: InternalQueue
+  ) {}
+
+  async reallocate(job: Job): Promise<void> {
+    if (job.retryCount >= job.maxRetries) {
+      await this.repository.updateStatus(job.id, 'failed', {
+        error: `Exceeded max retries (${job.maxRetries})`,
+      });
+
+      logger.warn('Job failed after max retries', {
+        jobId: job.id,
+        retryCount: job.retryCount,
+      });
+      return;
+    }
+
+    const newDeadline = Date.now() + env.ACK_TIMEOUT_MS;
+    const updatedJob: Job = {
+      ...job,
+      status: 'queued',
+      ackDeadline: newDeadline,
+      retryCount: job.retryCount + 1,
+      assignedWorkerId: undefined,
+      history: [
+        ...job.history,
+        {
+          fromStatus: 'orphaned',
+          toStatus: 'queued',
+          timestamp: new Date(),
+          reason: 're-allocated',
+        },
+      ],
+    };
+
+    this.queue.enqueue(updatedJob);
+    await this.repository.updateStatus(job.id, 'queued', {
+      ackDeadline: newDeadline,
+    });
+
+    logger.info('Job re-allocated to queue', {
+      jobId: job.id,
+      retryCount: updatedJob.retryCount,
+    });
+  }
+}

--- a/services/audit-logger/src/routes/events.controller.ts
+++ b/services/audit-logger/src/routes/events.controller.ts
@@ -1,0 +1,44 @@
+import { RequestHandler } from 'express';
+
+import { catchSync } from '@trading-model/common/middleware/catch-error';
+import { sendResponse } from '@trading-model/common/middleware/response-exception';
+
+import { AuditRepository, AuditEventQuery } from '../persistence/audit-repository';
+
+export function createEventsController(auditRepo: AuditRepository) {
+  const listEvents: RequestHandler = catchSync(async req => {
+    const queryParams = req.query as Record<string, string | undefined>;
+    const { topic, publisher, correlationId, startDate, endDate, page, limit } = queryParams;
+
+    const query: AuditEventQuery = {
+      topic,
+      publisher,
+      correlationId,
+      startDate: startDate ? new Date(startDate) : undefined,
+      endDate: endDate ? new Date(endDate) : undefined,
+      page: page ? parseInt(page, 10) : undefined,
+      limit: limit ? parseInt(limit, 10) : undefined,
+    };
+
+    const result = await auditRepo.query(query);
+    return sendResponse(result, 200);
+  });
+
+  const getEvent: RequestHandler = catchSync(async req => {
+    const { messageId } = req.params as { messageId: string };
+    const event = await auditRepo.findById(messageId);
+
+    if (!event) {
+      return sendResponse({ error: 'Event not found' }, 404);
+    }
+
+    return sendResponse(event, 200);
+  });
+
+  const getStats: RequestHandler = catchSync(async () => {
+    const stats = await auditRepo.getStats();
+    return sendResponse(stats, 200);
+  });
+
+  return { listEvents, getEvent, getStats };
+}

--- a/services/audit-logger/src/routes/events.routes.ts
+++ b/services/audit-logger/src/routes/events.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+
+import { createEventsController } from './events.controller';
+import { AuditRepository } from '../persistence/audit-repository';
+
+export function eventsRoutes(auditRepo: AuditRepository): Router {
+  const router = Router();
+  const controller = createEventsController(auditRepo);
+
+  router.get('/events', controller.listEvents);
+  router.get('/events/stats', controller.getStats);
+  router.get('/events/:messageId', controller.getEvent);
+
+  return router;
+}

--- a/services/audit-logger/src/routes/health.controller.ts
+++ b/services/audit-logger/src/routes/health.controller.ts
@@ -1,0 +1,36 @@
+import { RequestHandler } from 'express';
+
+import { catchSync } from '@trading-model/common/middleware/catch-error';
+import { sendResponse } from '@trading-model/common/middleware/response-exception';
+
+import { BackPressure } from '../scheduler/back-pressure';
+import { InternalQueue } from '../scheduler/internal-queue';
+import { WorkerRegistry } from '../worker/worker-registry';
+
+export function createHealthController(
+  queue: InternalQueue,
+  backPressure: BackPressure,
+  workers: WorkerRegistry
+) {
+  const ping: RequestHandler = catchSync(async () => {
+    return sendResponse({ status: 'ok', timestamp: new Date().toISOString() }, 200);
+  });
+
+  const health: RequestHandler = catchSync(async () => {
+    const queueDepth = queue.depth();
+
+    return sendResponse(
+      {
+        status: 'ok',
+        queueDepth,
+        canAccept: backPressure.canAccept(),
+        workerCount: workers.count(),
+        averageLoad: workers.averageLoad(),
+        timestamp: new Date().toISOString(),
+      },
+      200
+    );
+  });
+
+  return { ping, health };
+}

--- a/services/audit-logger/src/routes/health.routes.ts
+++ b/services/audit-logger/src/routes/health.routes.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+
+import { createHealthController } from './health.controller';
+import { BackPressure } from '../scheduler/back-pressure';
+import { InternalQueue } from '../scheduler/internal-queue';
+import { WorkerRegistry } from '../worker/worker-registry';
+
+export function healthRoutes(
+  queue: InternalQueue,
+  backPressure: BackPressure,
+  workers: WorkerRegistry
+): Router {
+  const router = Router();
+  const controller = createHealthController(queue, backPressure, workers);
+
+  router.get('/ping', controller.ping);
+  router.get('/health', controller.health);
+
+  return router;
+}

--- a/services/audit-logger/src/scheduler/back-pressure.ts
+++ b/services/audit-logger/src/scheduler/back-pressure.ts
@@ -1,0 +1,40 @@
+export class BackPressure {
+  private queueDepth = 0;
+  private readonly workerLoads: Map<string, number> = new Map();
+
+  constructor(
+    private readonly maxQueueDepth: number,
+    private readonly maxWorkerLoadRatio: number
+  ) {}
+
+  updateQueueDepth(depth: number): void {
+    this.queueDepth = depth;
+  }
+
+  updateWorkerLoad(workerId: string, load: number): void {
+    this.workerLoads.set(workerId, load);
+  }
+
+  removeWorker(workerId: string): void {
+    this.workerLoads.delete(workerId);
+  }
+
+  canAccept(): boolean {
+    if (this.queueDepth >= this.maxQueueDepth) {
+      return false;
+    }
+    if (this.workerLoads.size === 0) {
+      return true;
+    }
+    for (const load of this.workerLoads.values()) {
+      if (load < this.maxWorkerLoadRatio) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  retryAfterSeconds(): number {
+    return Math.ceil(this.queueDepth / 100) * 5;
+  }
+}

--- a/services/audit-logger/src/scheduler/internal-queue.ts
+++ b/services/audit-logger/src/scheduler/internal-queue.ts
@@ -1,0 +1,72 @@
+import { QueuedJob, Job } from '../types/job.types';
+
+export class InternalQueue {
+  private readonly queues: Map<number, QueuedJob[]> = new Map();
+  private readonly ackTimers: Map<string, NodeJS.Timeout> = new Map();
+  private readonly ackTimeoutMs: number;
+  private onAckTimeoutCallback: ((jobId: string) => void) | null = null;
+
+  constructor(ackTimeoutMs: number) {
+    this.ackTimeoutMs = ackTimeoutMs;
+  }
+
+  setOnAckTimeout(callback: (jobId: string) => void): void {
+    this.onAckTimeoutCallback = callback;
+  }
+
+  enqueue(job: Job): void {
+    const priority = job.priority;
+    if (!this.queues.has(priority)) {
+      this.queues.set(priority, []);
+    }
+    this.queues.get(priority)!.push({
+      job,
+      state: 'queued',
+      deliveryAttempts: 0,
+      expiresAt: 0,
+    });
+  }
+
+  dequeue(): QueuedJob | null {
+    for (let p = 1; p <= 5; p++) {
+      const queue = this.queues.get(p);
+      if (queue && queue.length > 0) {
+        return queue.shift()!;
+      }
+    }
+    return null;
+  }
+
+  markDelivered(jobId: string): void {
+    const timer = setTimeout(() => {
+      this.ackTimers.delete(jobId);
+      if (this.onAckTimeoutCallback) {
+        this.onAckTimeoutCallback(jobId);
+      }
+    }, this.ackTimeoutMs);
+    this.ackTimers.set(jobId, timer);
+  }
+
+  ack(jobId: string): void {
+    const timer = this.ackTimers.get(jobId);
+    if (timer) {
+      clearTimeout(timer);
+      this.ackTimers.delete(jobId);
+    }
+  }
+
+  depth(): number {
+    let total = 0;
+    for (const q of this.queues.values()) {
+      total += q.length;
+    }
+    return total;
+  }
+
+  stop(): void {
+    for (const timer of this.ackTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.ackTimers.clear();
+  }
+}

--- a/services/audit-logger/src/scheduler/job-scheduler.ts
+++ b/services/audit-logger/src/scheduler/job-scheduler.ts
@@ -1,0 +1,318 @@
+import { randomUUID } from 'node:crypto';
+
+import { logger } from '@trading-model/common/config/logger';
+
+import { BackPressure } from './back-pressure';
+import { InternalQueue } from './internal-queue';
+import { env } from '../config/env';
+import { JobRepository } from '../persistence/job-repository';
+import { OrphanDetector } from '../recovery/orphan-detector';
+import { ReAllocator } from '../recovery/re-allocator';
+import { Job } from '../types/job.types';
+import { WorkerProtocol } from '../worker/worker-protocol';
+import { WorkerRegistry } from '../worker/worker-registry';
+
+export class JobScheduler {
+  readonly queue: InternalQueue;
+  readonly backPressure: BackPressure;
+  readonly workers: WorkerRegistry;
+  readonly repository: JobRepository;
+  readonly reAllocator: ReAllocator;
+  readonly orphanDetector: OrphanDetector;
+  private workerProtocol: WorkerProtocol | null = null;
+
+  constructor(repository: JobRepository) {
+    this.queue = new InternalQueue(env.ACK_TIMEOUT_MS);
+    this.backPressure = new BackPressure(env.MAX_QUEUE_DEPTH, env.MAX_WORKER_LOAD_RATIO);
+    this.workers = new WorkerRegistry(env.WORKER_HEARTBEAT_TTL_MS);
+    this.repository = repository;
+    this.reAllocator = new ReAllocator(repository, this.queue);
+    this.orphanDetector = new OrphanDetector(
+      this.workers,
+      repository,
+      this.reAllocator,
+      env.ORPHAN_SCAN_INTERVAL_MS
+    );
+
+    this.queue.setOnAckTimeout(jobId => {
+      this.handleAckTimeout(jobId);
+    });
+  }
+
+  setWorkerProtocol(protocol: WorkerProtocol): void {
+    this.workerProtocol = protocol;
+  }
+
+  async submit(
+    type: string,
+    payload: unknown,
+    priority: 1 | 2 | 3 | 4 | 5 = 3,
+    maxRetries: number = env.MAX_RETRIES_PER_JOB
+  ): Promise<string> {
+    if (!this.backPressure.canAccept()) {
+      logger.warn('Back pressure active — rejecting job submission');
+      throw Object.assign(new Error('Job scheduler at capacity'), {
+        code: 'BACK_PRESSURE',
+        retryAfter: this.backPressure.retryAfterSeconds(),
+      });
+    }
+
+    const jobId = randomUUID();
+    const now = new Date();
+
+    const job: Job = {
+      id: jobId,
+      type,
+      payload,
+      priority,
+      status: 'pending',
+      ackDeadline: 0,
+      maxRetries,
+      retryCount: 0,
+      createdAt: now,
+      history: [],
+    };
+
+    await this.repository.insert(job);
+    this.enqueueJob(job);
+
+    logger.info('Job submitted', { jobId, type, priority });
+    return jobId;
+  }
+
+  private enqueueJob(job: Job): void {
+    const updated: Job = { ...job, status: 'queued' };
+    this.queue.enqueue(updated);
+    this.backPressure.updateQueueDepth(this.queue.depth());
+    this.repository.updateStatus(job.id, 'queued').catch(err => {
+      logger.error('Failed to persist queued status', { jobId: job.id, error: String(err) });
+    });
+    this.distributeNext();
+  }
+
+  private distributeNext(): void {
+    const queued = this.queue.dequeue();
+    if (!queued) return;
+
+    const worker = this.workers.findBestWorker(queued.job.type);
+    if (!worker) {
+      this.queue.enqueue(queued.job);
+      return;
+    }
+
+    const deadline = Date.now() + env.ACK_TIMEOUT_MS;
+    const assignedJob: Job = {
+      ...queued.job,
+      status: 'assigned',
+      assignedWorkerId: worker.workerId,
+      ackDeadline: deadline,
+    };
+
+    this.queue.markDelivered(assignedJob.id);
+
+    if (this.workerProtocol) {
+      this.workerProtocol.sendToWorker(worker.workerId, {
+        type: 'job.assigned',
+        job: {
+          id: assignedJob.id,
+          type: assignedJob.type,
+          payload: assignedJob.payload,
+          ackDeadline: deadline,
+        },
+      });
+    }
+
+    worker.currentLoad += 1;
+    this.backPressure.updateWorkerLoad(worker.workerId, worker.currentLoad / worker.maxConcurrency);
+
+    this.repository
+      .updateStatus(assignedJob.id, 'assigned', {
+        assignedWorkerId: worker.workerId,
+        ackDeadline: deadline,
+      })
+      .catch(err => {
+        logger.error('Failed to persist assigned status', {
+          jobId: assignedJob.id,
+          error: String(err),
+        });
+      });
+
+    logger.info('Job assigned to worker', {
+      jobId: assignedJob.id,
+      workerId: worker.workerId,
+    });
+  }
+
+  private handleAckTimeout(jobId: string): void {
+    logger.warn('ACK timeout for job', { jobId });
+
+    this.repository
+      .findById(jobId)
+      .then(job => {
+        if (
+          !job ||
+          job.status === 'completed' ||
+          job.status === 'failed' ||
+          job.status === 'cancelled'
+        )
+          return;
+
+        const workerId = job.assignedWorkerId;
+        if (workerId) {
+          const worker = this.workers.get(workerId);
+          if (worker) {
+            worker.currentLoad = Math.max(0, worker.currentLoad - 1);
+            this.backPressure.updateWorkerLoad(
+              workerId,
+              worker.currentLoad / worker.maxConcurrency
+            );
+          }
+        }
+
+        this.repository
+          .updateStatus(jobId, 'orphaned')
+          .then(() => {
+            this.reAllocator.reallocate(job);
+          })
+          .catch(err => {
+            logger.error('Failed to persist orphaned status on ACK timeout', {
+              jobId,
+              error: String(err),
+            });
+          });
+      })
+      .catch(err => {
+        logger.error('Failed to find job on ACK timeout', {
+          jobId,
+          error: String(err),
+        });
+      });
+  }
+
+  async ack(jobId: string): Promise<void> {
+    this.queue.ack(jobId);
+    await this.repository.updateStatus(jobId, 'running');
+
+    logger.info('Job acknowledged by worker', { jobId });
+  }
+
+  async complete(jobId: string, result: unknown): Promise<void> {
+    this.queue.ack(jobId);
+    await this.repository.updateStatus(jobId, 'completed', { result });
+
+    const job = await this.repository.findById(jobId);
+    if (job?.assignedWorkerId) {
+      const worker = this.workers.get(job.assignedWorkerId);
+      if (worker) {
+        worker.currentLoad = Math.max(0, worker.currentLoad - 1);
+        this.backPressure.updateWorkerLoad(
+          job.assignedWorkerId,
+          worker.currentLoad / worker.maxConcurrency
+        );
+      }
+    }
+
+    logger.info('Job completed', { jobId });
+    this.distributeNext();
+  }
+
+  async fail(jobId: string, error: string): Promise<void> {
+    this.queue.ack(jobId);
+
+    const job = await this.repository.findById(jobId);
+    if (!job) return;
+
+    if (job.assignedWorkerId) {
+      const worker = this.workers.get(job.assignedWorkerId);
+      if (worker) {
+        worker.currentLoad = Math.max(0, worker.currentLoad - 1);
+        this.backPressure.updateWorkerLoad(
+          job.assignedWorkerId,
+          worker.currentLoad / worker.maxConcurrency
+        );
+      }
+    }
+
+    if (job.retryCount >= job.maxRetries) {
+      await this.repository.updateStatus(jobId, 'failed', { error });
+
+      logger.warn('Job failed permanently', { jobId, retryCount: job.retryCount, error });
+    } else {
+      const newDeadline = Date.now() + env.ACK_TIMEOUT_MS;
+      const updatedJob: Job = {
+        ...job,
+        status: 'queued',
+        ackDeadline: newDeadline,
+        retryCount: job.retryCount + 1,
+        assignedWorkerId: undefined,
+      };
+
+      this.queue.enqueue(updatedJob);
+      await this.repository.incrementRetry(jobId);
+      await this.repository.updateStatus(jobId, 'queued', {
+        ackDeadline: newDeadline,
+      });
+
+      logger.info('Job re-queued after failure', { jobId, retryCount: updatedJob.retryCount });
+      this.distributeNext();
+    }
+  }
+
+  async cancel(jobId: string): Promise<void> {
+    const job = await this.repository.findById(jobId);
+    if (!job) return;
+
+    if (job.status === 'running' || job.status === 'completed') {
+      throw new Error('Cannot cancel a running or completed job');
+    }
+
+    this.queue.ack(jobId);
+    await this.repository.updateStatus(jobId, 'cancelled');
+
+    if (job.assignedWorkerId) {
+      const worker = this.workers.get(job.assignedWorkerId);
+      if (worker) {
+        worker.currentLoad = Math.max(0, worker.currentLoad - 1);
+      }
+    }
+
+    logger.info('Job cancelled', { jobId });
+  }
+
+  onWorkerDisconnect(workerId: string): void {
+    this.backPressure.removeWorker(workerId);
+  }
+
+  async start(): Promise<void> {
+    const nonTerminal = await this.repository.findNonTerminal();
+
+    for (const job of nonTerminal) {
+      if (job.status === 'queued' || job.status === 'pending') {
+        this.queue.enqueue({ ...job, status: 'queued' });
+      } else if (job.status === 'assigned' || job.status === 'running') {
+        await this.repository.updateStatus(job.id, 'orphaned');
+        await this.reAllocator.reallocate(job);
+      } else if (job.status === 'orphaned') {
+        await this.reAllocator.reallocate(job);
+      }
+    }
+
+    this.backPressure.updateQueueDepth(this.queue.depth());
+
+    logger.info('Job scheduler started — recovered jobs from persistence', {
+      recovered: nonTerminal.length,
+    });
+
+    this.orphanDetector.start();
+  }
+
+  async stop(): Promise<void> {
+    this.orphanDetector.stop();
+    this.queue.stop();
+    if (this.workerProtocol) {
+      this.workerProtocol.close();
+    }
+
+    logger.info('Audit job scheduler stopped');
+  }
+}

--- a/services/audit-logger/src/subscription/audit-subscriber.ts
+++ b/services/audit-logger/src/subscription/audit-subscriber.ts
@@ -1,0 +1,87 @@
+import { RequestHandler } from 'express';
+
+import { catchSync } from '@trading-model/common/middleware/catch-error';
+import { sendResponse } from '@trading-model/common/middleware/response-exception';
+
+import { AuditRepository, AuditEventDocument } from '../persistence/audit-repository';
+
+interface MessageMetadata {
+  topic: string;
+  eventType?: string;
+  messageId?: string;
+  correlationId?: string;
+  causationId?: string;
+  emittedAt?: string;
+  schemaVersion?: string;
+  publisher?: {
+    serviceName: string;
+    instanceId: string;
+  };
+  routing?: {
+    partitionKey?: string;
+    priority?: number;
+  };
+  delivery?: {
+    mode?: string;
+    ttl?: number;
+    deduplicationId?: string;
+  };
+}
+
+interface IncomingEnvelope {
+  message?: {
+    metadata: MessageMetadata;
+    payload: unknown;
+  };
+  context?: {
+    deliveryAttempt: number;
+    consumerGroup: string;
+  };
+  metadata?: MessageMetadata;
+  payload?: unknown;
+}
+
+export function createMessageHandler(auditRepo: AuditRepository): RequestHandler {
+  const handler: RequestHandler = catchSync(async req => {
+    const body = req.body as IncomingEnvelope;
+
+    let topic: string | undefined;
+    let payload: unknown;
+    let metadata: MessageMetadata | undefined;
+
+    if (body.message?.metadata?.topic) {
+      topic = body.message.metadata.topic;
+      payload = body.message.payload;
+      metadata = body.message.metadata;
+    } else if (body.metadata?.topic) {
+      topic = body.metadata.topic;
+      payload = body.payload;
+      metadata = body.metadata;
+    }
+
+    if (!topic) {
+      return sendResponse({ error: 'Invalid message format: no topic' }, 400);
+    }
+
+    const publisher = metadata?.publisher;
+
+    const document: AuditEventDocument = {
+      receivedAt: metadata?.emittedAt ? new Date(metadata.emittedAt) : new Date(),
+      metadata: {
+        topic,
+        eventType: metadata?.eventType ?? topic,
+        publisher: publisher?.serviceName ?? 'unknown',
+        instanceId: publisher?.instanceId ?? 'unknown',
+        messageId: metadata?.messageId ?? 'unknown',
+        correlationId: metadata?.correlationId,
+      },
+      payload,
+    };
+
+    await auditRepo.insert(document);
+
+    return sendResponse({ status: 'recorded' }, 200);
+  });
+
+  return handler;
+}

--- a/services/audit-logger/src/types/job.types.ts
+++ b/services/audit-logger/src/types/job.types.ts
@@ -1,0 +1,50 @@
+export type JobStatus =
+  | 'pending'
+  | 'queued'
+  | 'assigned'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'orphaned';
+
+export interface JobEvent {
+  fromStatus: JobStatus;
+  toStatus: JobStatus;
+  timestamp: Date;
+  reason: string;
+}
+
+export interface Job<T = unknown> {
+  id: string;
+  type: string;
+  payload: T;
+  priority: 1 | 2 | 3 | 4 | 5;
+  status: JobStatus;
+  assignedWorkerId?: string;
+  ackDeadline: number;
+  maxRetries: number;
+  retryCount: number;
+  createdAt: Date;
+  startedAt?: Date;
+  completedAt?: Date;
+  result?: unknown;
+  error?: string;
+  history: JobEvent[];
+}
+
+export interface QueuedJob<T = unknown> {
+  job: Job<T>;
+  state: 'queued' | 'delivered' | 'acknowledged';
+  deliveryAttempts: number;
+  expiresAt: number;
+  assignedAt?: Date;
+}
+
+export const JOB_STATUS_NON_TERMINAL: JobStatus[] = [
+  'pending',
+  'queued',
+  'assigned',
+  'running',
+  'orphaned',
+];

--- a/services/audit-logger/src/types/worker.types.ts
+++ b/services/audit-logger/src/types/worker.types.ts
@@ -1,0 +1,61 @@
+export type WorkerStatus = 'active' | 'draining' | 'offline';
+
+export interface WorkerRegistration {
+  workerId: string;
+  address: string;
+  port: number;
+  capabilities: string[];
+  maxConcurrency: number;
+  currentLoad: number;
+  lastHeartbeat: Date;
+  status: WorkerStatus;
+}
+
+export interface WorkerWsRegisterMessage {
+  type: 'register';
+  workerId: string;
+  address: string;
+  port: number;
+  capabilities: string[];
+  maxConcurrency: number;
+}
+
+export interface WorkerWsHeartbeatMessage {
+  type: 'heartbeat';
+  workerId: string;
+  currentLoad: number;
+}
+
+export interface WorkerWsDisconnectMessage {
+  type: 'disconnect';
+  workerId: string;
+  reason?: string;
+}
+
+export type WorkerIncomingMessage =
+  | WorkerWsRegisterMessage
+  | WorkerWsHeartbeatMessage
+  | WorkerWsDisconnectMessage;
+
+export interface SchedulerWsJobAssignedMessage {
+  type: 'job.assigned';
+  job: {
+    id: string;
+    type: string;
+    payload: unknown;
+    ackDeadline: number;
+  };
+}
+
+export interface SchedulerWsHeartbeatAckMessage {
+  type: 'heartbeat.ack';
+}
+
+export interface SchedulerWsDrainMessage {
+  type: 'drain';
+}
+
+export type SchedulerOutgoingMessage =
+  | SchedulerWsJobAssignedMessage
+  | SchedulerWsHeartbeatAckMessage
+  | SchedulerWsDrainMessage;

--- a/services/audit-logger/src/worker/worker-protocol.ts
+++ b/services/audit-logger/src/worker/worker-protocol.ts
@@ -1,0 +1,117 @@
+import https from 'node:https';
+
+import WebSocket, { WebSocketServer } from 'ws';
+
+import { logger } from '@trading-model/common/config/logger';
+
+import { WorkerRegistry } from './worker-registry';
+import { SchedulerOutgoingMessage, WorkerIncomingMessage } from '../types/worker.types';
+
+export class WorkerProtocol {
+  private readonly wss: WebSocketServer;
+  private readonly connections: Map<string, WebSocket> = new Map();
+
+  constructor(
+    server: https.Server,
+    private readonly workerRegistry: WorkerRegistry,
+    private readonly onWorkerDisconnect: (workerId: string) => void
+  ) {
+    this.wss = new WebSocketServer({ server });
+
+    this.wss.on('connection', (ws: WebSocket) => {
+      ws.on('message', (data: WebSocket.Data) => {
+        try {
+          const message: WorkerIncomingMessage = JSON.parse(data.toString());
+
+          switch (message.type) {
+            case 'register':
+              this.handleRegister(message, ws);
+              break;
+            case 'heartbeat':
+              this.handleHeartbeat(message);
+              break;
+            case 'disconnect':
+              this.handleDisconnect(message);
+              break;
+          }
+        } catch (err) {
+          logger.error('Invalid WebSocket message from worker', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      });
+
+      ws.on('close', () => {
+        for (const [workerId, conn] of this.connections) {
+          if (conn === ws) {
+            this.connections.delete(workerId);
+            this.workerRegistry.setStatus(workerId, 'draining');
+            this.onWorkerDisconnect(workerId);
+            break;
+          }
+        }
+      });
+    });
+  }
+
+  private handleRegister(
+    message: WorkerIncomingMessage & { type: 'register' },
+    ws: WebSocket
+  ): void {
+    this.workerRegistry.register(message.workerId, {
+      workerId: message.workerId,
+      address: message.address,
+      port: message.port,
+      capabilities: message.capabilities,
+      maxConcurrency: message.maxConcurrency,
+      currentLoad: 0,
+    });
+    this.connections.set(message.workerId, ws);
+
+    logger.info('Worker registered via WebSocket', { workerId: message.workerId });
+  }
+
+  private handleHeartbeat(message: WorkerIncomingMessage & { type: 'heartbeat' }): void {
+    this.workerRegistry.heartbeat(message.workerId);
+    this.workerRegistry.updateLoad(message.workerId, message.currentLoad);
+
+    const ws = this.connections.get(message.workerId);
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'heartbeat.ack' }));
+    }
+  }
+
+  private handleDisconnect(message: WorkerIncomingMessage & { type: 'disconnect' }): void {
+    this.connections.delete(message.workerId);
+    this.workerRegistry.unregister(message.workerId);
+    this.onWorkerDisconnect(message.workerId);
+
+    logger.info('Worker disconnected', { workerId: message.workerId, reason: message.reason });
+  }
+
+  sendToWorker(workerId: string, message: SchedulerOutgoingMessage): void {
+    const ws = this.connections.get(workerId);
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(message));
+    }
+  }
+
+  sendDrain(workerId: string): void {
+    this.sendToWorker(workerId, { type: 'drain' });
+  }
+
+  broadcastDrain(): void {
+    for (const [workerId] of this.connections) {
+      this.sendDrain(workerId);
+    }
+  }
+
+  close(): void {
+    this.broadcastDrain();
+    for (const ws of this.connections.values()) {
+      ws.close();
+    }
+    this.connections.clear();
+    this.wss.close();
+  }
+}

--- a/services/audit-logger/src/worker/worker-registry.ts
+++ b/services/audit-logger/src/worker/worker-registry.ts
@@ -1,0 +1,100 @@
+import { WorkerRegistration, WorkerStatus } from '../types/worker.types';
+
+export class WorkerRegistry {
+  private readonly workers: Map<string, WorkerRegistration> = new Map();
+  private readonly heartbeatTtlMs: number;
+
+  constructor(heartbeatTtlMs: number) {
+    this.heartbeatTtlMs = heartbeatTtlMs;
+  }
+
+  register(
+    workerId: string,
+    registration: Omit<WorkerRegistration, 'lastHeartbeat' | 'status'>
+  ): void {
+    this.workers.set(workerId, {
+      ...registration,
+      lastHeartbeat: new Date(),
+      status: 'active',
+    });
+  }
+
+  unregister(workerId: string): void {
+    this.workers.delete(workerId);
+  }
+
+  get(workerId: string): WorkerRegistration | undefined {
+    return this.workers.get(workerId);
+  }
+
+  heartbeat(workerId: string): void {
+    const worker = this.workers.get(workerId);
+    if (worker) {
+      worker.lastHeartbeat = new Date();
+    }
+  }
+
+  updateLoad(workerId: string, currentLoad: number): void {
+    const worker = this.workers.get(workerId);
+    if (worker) {
+      worker.currentLoad = currentLoad;
+    }
+  }
+
+  setStatus(workerId: string, status: WorkerStatus): void {
+    const worker = this.workers.get(workerId);
+    if (worker) {
+      worker.status = status;
+    }
+  }
+
+  findBestWorker(jobType: string): WorkerRegistration | null {
+    let best: WorkerRegistration | null = null;
+    let bestLoad = Infinity;
+
+    for (const worker of this.workers.values()) {
+      if (worker.status !== 'active') continue;
+      if (!worker.capabilities.includes(jobType)) continue;
+      if (worker.currentLoad >= worker.maxConcurrency) continue;
+      if (worker.currentLoad < bestLoad) {
+        best = worker;
+        bestLoad = worker.currentLoad;
+      }
+    }
+    return best;
+  }
+
+  purgeStaleWorkers(): string[] {
+    const now = Date.now();
+    const stale: string[] = [];
+    for (const [id, worker] of this.workers) {
+      if (now - worker.lastHeartbeat.getTime() > this.heartbeatTtlMs) {
+        worker.status = 'offline';
+        stale.push(id);
+      }
+    }
+    for (const id of stale) {
+      this.workers.delete(id);
+    }
+    return stale;
+  }
+
+  count(): number {
+    return this.workers.size;
+  }
+
+  averageLoad(): number {
+    if (this.workers.size === 0) return 0;
+    let total = 0;
+    for (const worker of this.workers.values()) {
+      if (worker.maxConcurrency > 0) {
+        total += worker.currentLoad / worker.maxConcurrency;
+      }
+    }
+    return total / this.workers.size;
+  }
+
+  getAllActive(): WorkerRegistration[] {
+    return Array.from(this.workers.values()).filter(w => w.status === 'active');
+  }
+}

--- a/services/audit-logger/tests/fixtures/audit.fixture.ts
+++ b/services/audit-logger/tests/fixtures/audit.fixture.ts
@@ -1,0 +1,43 @@
+import type {
+  AuditEventDocument,
+  AuditStats,
+  PaginatedResult,
+} from '../../src/persistence/audit-repository';
+
+export const createAuditEvent = (overrides?: Partial<AuditEventDocument>): AuditEventDocument => ({
+  receivedAt: new Date(),
+  metadata: {
+    topic: 'test-topic',
+    eventType: 'test.event',
+    publisher: 'test-service',
+    instanceId: 'instance-1',
+    messageId: 'msg-1',
+    correlationId: 'corr-1',
+  },
+  payload: { key: 'value' },
+  ...overrides,
+});
+
+export const createPaginatedResult = (
+  overrides?: Partial<PaginatedResult<AuditEventDocument>>
+): PaginatedResult<AuditEventDocument> => ({
+  data: [createAuditEvent()],
+  pagination: {
+    page: 1,
+    limit: 100,
+    total: 1,
+    totalPages: 1,
+  },
+  ...overrides,
+});
+
+export const createAuditStats = (overrides?: Partial<AuditStats>): AuditStats => ({
+  totalEvents: 10,
+  eventsByTopic: { 'test-topic': 10 },
+  eventsByPublisher: { 'test-service': 10 },
+  dateRange: {
+    earliest: new Date('2024-01-01'),
+    latest: new Date('2024-12-31'),
+  },
+  ...overrides,
+});

--- a/services/audit-logger/tests/fixtures/job.fixture.ts
+++ b/services/audit-logger/tests/fixtures/job.fixture.ts
@@ -1,0 +1,31 @@
+import type { Job, JobEvent, QueuedJob } from '../../src/types/job.types';
+
+export const createJobEvent = (overrides?: Partial<JobEvent>): JobEvent => ({
+  fromStatus: 'pending',
+  toStatus: 'queued',
+  timestamp: new Date(),
+  reason: 'created',
+  ...overrides,
+});
+
+export const createJob = (overrides?: Partial<Job>): Job => ({
+  id: 'test-job-1',
+  type: 'test-job-type',
+  payload: { key: 'value' },
+  priority: 3,
+  status: 'pending',
+  ackDeadline: 0,
+  maxRetries: 3,
+  retryCount: 0,
+  createdAt: new Date(),
+  history: [],
+  ...overrides,
+});
+
+export const createQueuedJob = (overrides?: Partial<QueuedJob>): QueuedJob => ({
+  job: createJob(),
+  state: 'queued',
+  deliveryAttempts: 0,
+  expiresAt: 0,
+  ...overrides,
+});

--- a/services/audit-logger/tests/fixtures/worker.fixture.ts
+++ b/services/audit-logger/tests/fixtures/worker.fixture.ts
@@ -1,0 +1,15 @@
+import type { WorkerRegistration } from '../../src/types/worker.types';
+
+export const createWorkerRegistration = (
+  overrides?: Partial<WorkerRegistration>
+): WorkerRegistration => ({
+  workerId: 'test-worker-1',
+  address: '192.168.1.10',
+  port: 9000,
+  capabilities: ['test-job-type', 'another-type'],
+  maxConcurrency: 5,
+  currentLoad: 0,
+  lastHeartbeat: new Date(),
+  status: 'active',
+  ...overrides,
+});

--- a/services/audit-logger/tests/helpers/express.ts
+++ b/services/audit-logger/tests/helpers/express.ts
@@ -1,0 +1,11 @@
+export const createReq = (overrides: Record<string, unknown> = {}): any => ({
+  body: {},
+  params: {},
+  query: {},
+  headers: {},
+  ...overrides,
+});
+
+export const createRes = (): any => ({});
+
+export const createNext = () => undefined;

--- a/services/audit-logger/tests/unit/app/index.spec.ts
+++ b/services/audit-logger/tests/unit/app/index.spec.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeAll, jest } from '@jest/globals';
+
+const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+jest.mock('@trading-model/common/config/logger', () => ({
+  logger: mockLogger,
+}));
+
+let capturedOptions: any;
+
+jest.mock('@trading-model/common/server/bootstrap', () => ({
+  createBootstrap: jest.fn((options: any) => {
+    capturedOptions = options;
+    return { server: null, shutdown: jest.fn() };
+  }),
+}));
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    MONGODB_URI: 'mongodb://localhost:27017/audit-logger',
+    PORT: 3001,
+    MAX_QUEUE_DEPTH: 10000,
+    ACK_TIMEOUT_MS: 30000,
+    TLS_KEY_PATH: '/some/key.pem',
+    TLS_CERT_PATH: '/some/cert.pem',
+    TLS_CA_PATH: '/some/ca.pem',
+    INSTANCE_ID: 'instance-1',
+  },
+}));
+
+jest.mock('@trading-model/address-manager/create-address-manager', () => ({
+  createAddressManager: jest.fn(() => ({
+    start: jest.fn(),
+    stop: jest.fn(),
+    listenExpress: jest.fn(),
+  })),
+}));
+
+const mockAddressManager = { stop: jest.fn() };
+jest.mock('../../../src/config/address-manager', () => ({
+  bootstrapAddressManager: jest.fn(() => mockAddressManager),
+  AddressManager: { stop: jest.fn() },
+  AddressManagerRoutes: jest.fn(),
+}));
+
+const mockJobRepositoryInstance = {
+  ensureIndexes: jest.fn<any>(),
+  insert: jest.fn<any>(),
+  findById: jest.fn<any>(),
+  updateStatus: jest.fn<any>(),
+  incrementRetry: jest.fn<any>(),
+  findNonTerminal: jest.fn<any>(),
+  findByWorker: jest.fn<any>(),
+  findByStatus: jest.fn<any>(),
+};
+
+jest.mock('../../../src/persistence/job-repository', () => ({
+  JobRepository: jest.fn(() => mockJobRepositoryInstance),
+}));
+
+const mockAuditRepositoryInstance = {
+  insert: jest.fn<any>(),
+  insertBatch: jest.fn<any>(),
+  findById: jest.fn<any>(),
+  query: jest.fn<any>(),
+  getStats: jest.fn<any>(),
+  ensureIndexes: jest.fn<any>(),
+};
+
+jest.mock('../../../src/persistence/audit-repository', () => ({
+  AuditRepository: jest.fn(() => mockAuditRepositoryInstance),
+}));
+
+const mockSchedulerInstance = {
+  workers: { register: jest.fn(), get: jest.fn(), unregister: jest.fn() },
+  setWorkerProtocol: jest.fn<any>(),
+  start: jest.fn<any>(),
+  stop: jest.fn<any>(),
+  onWorkerDisconnect: jest.fn(),
+};
+
+jest.mock('../../../src/scheduler/job-scheduler', () => ({
+  JobScheduler: jest.fn(() => mockSchedulerInstance),
+}));
+
+const mockWorkerProtocolInstance = { close: jest.fn() };
+
+jest.mock('../../../src/worker/worker-protocol', () => ({
+  WorkerProtocol: jest.fn(() => mockWorkerProtocolInstance),
+}));
+
+const mockHttpServer = { raw: 'mock-raw-server' };
+jest.mock('../../../src/app/server', () => ({
+  createServer: jest.fn(() => mockHttpServer),
+}));
+
+const mockDb = { collection: jest.fn() };
+const mockMongoClient = {
+  connect: jest.fn<any>(),
+  db: jest.fn(() => mockDb),
+  close: jest.fn<any>(),
+};
+
+jest.mock('mongodb', () => ({
+  MongoClient: jest.fn(() => mockMongoClient),
+}));
+
+const mockBrokerMessageInstance = {
+  intents: jest.fn<any>(),
+  stopMessageManager: jest.fn<any>(),
+};
+
+jest.mock('@trading-model/broker-message', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => mockBrokerMessageInstance),
+  };
+});
+
+import { createBootstrap } from '@trading-model/common/server/bootstrap';
+import { bootstrapAddressManager } from '../../../src/config/address-manager';
+import { JobRepository } from '../../../src/persistence/job-repository';
+import { AuditRepository } from '../../../src/persistence/audit-repository';
+import { JobScheduler } from '../../../src/scheduler/job-scheduler';
+import { WorkerProtocol } from '../../../src/worker/worker-protocol';
+import { createServer } from '../../../src/app/server';
+
+const mockCreateBootstrap = createBootstrap as jest.Mock;
+
+import '../../../src/app/index';
+
+describe('Audit Logger entry point (index.ts)', () => {
+  beforeAll(() => {
+    expect(capturedOptions).toBeDefined();
+  });
+
+  it('should call createBootstrap with name "Audit Logger"', () => {
+    expect(mockCreateBootstrap).toHaveBeenCalledTimes(1);
+    expect(capturedOptions.name).toBe('Audit Logger');
+  });
+
+  it('should handle onStop when all resources are null', async () => {
+    await capturedOptions.onStop();
+
+    expect(mockSchedulerInstance.stop).not.toHaveBeenCalled();
+    expect(mockWorkerProtocolInstance.close).not.toHaveBeenCalled();
+    expect(mockAddressManager.stop).not.toHaveBeenCalled();
+    expect(mockMongoClient.close).not.toHaveBeenCalled();
+  });
+
+  describe('createServer callback', () => {
+    it('should create all resources and return server', async () => {
+      const server = await capturedOptions.createServer();
+
+      expect(mockMongoClient.connect).toHaveBeenCalledTimes(1);
+      expect(mockMongoClient.db).toHaveBeenCalledTimes(1);
+      expect(JobRepository).toHaveBeenCalledWith(mockDb);
+      expect(mockJobRepositoryInstance.ensureIndexes).toHaveBeenCalledTimes(1);
+      expect(AuditRepository).toHaveBeenCalledWith(mockDb);
+      expect(mockAuditRepositoryInstance.ensureIndexes).toHaveBeenCalledTimes(1);
+      expect(JobScheduler).toHaveBeenCalledWith(mockJobRepositoryInstance);
+      expect(createServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workers: mockSchedulerInstance.workers,
+          setWorkerProtocol: mockSchedulerInstance.setWorkerProtocol,
+          start: mockSchedulerInstance.start,
+        }),
+        mockAuditRepositoryInstance
+      );
+      expect(WorkerProtocol).toHaveBeenCalledWith(
+        'mock-raw-server',
+        expect.objectContaining({ register: expect.any(Function) }),
+        expect.any(Function)
+      );
+      expect(mockSchedulerInstance.setWorkerProtocol).toHaveBeenCalledWith(
+        mockWorkerProtocolInstance
+      );
+      expect(mockSchedulerInstance.start).toHaveBeenCalledTimes(1);
+      expect(server).toBe(mockHttpServer);
+    });
+
+    it('should pass onWorkerDisconnect callback to WorkerProtocol', async () => {
+      const [, , disconnectCallback] = (WorkerProtocol as unknown as jest.Mock).mock.calls[0];
+
+      (disconnectCallback as any)('worker-1');
+
+      expect(mockSchedulerInstance.onWorkerDisconnect).toHaveBeenCalledWith('worker-1');
+    });
+  });
+
+  describe('onStart callback', () => {
+    it('should bootstrap address manager and log service info', () => {
+      capturedOptions.onStart();
+
+      expect(bootstrapAddressManager).toHaveBeenCalledTimes(1);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Audit Logger fully operational',
+        expect.objectContaining({
+          port: 3001,
+          mongoUri: 'mongodb://localhost:27017/audit-logger',
+        })
+      );
+    });
+  });
+
+  describe('onStop callback', () => {
+    it('should stop scheduler, close worker protocol, stop broker, stop address manager, close mongo client', async () => {
+      await capturedOptions.onStop();
+
+      expect(mockBrokerMessageInstance.stopMessageManager).toHaveBeenCalledTimes(1);
+      expect(mockSchedulerInstance.stop).toHaveBeenCalledTimes(1);
+      expect(mockWorkerProtocolInstance.close).toHaveBeenCalledTimes(1);
+      expect(mockAddressManager.stop).toHaveBeenCalledTimes(1);
+      expect(mockMongoClient.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle onStop being idempotent', async () => {
+      const prevCallCount = mockBrokerMessageInstance.stopMessageManager.mock.calls.length;
+
+      await capturedOptions.onStop();
+
+      expect(mockBrokerMessageInstance.stopMessageManager).toHaveBeenCalledTimes(prevCallCount + 1);
+    });
+  });
+});

--- a/services/audit-logger/tests/unit/app/server.spec.ts
+++ b/services/audit-logger/tests/unit/app/server.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+const mockApp = {
+  use: jest.fn(),
+  post: jest.fn(),
+};
+
+const mockServer = {
+  raw: mockApp,
+};
+
+const mockTlsConfig = {
+  key: '/some/key.pem',
+  cert: '/some/cert.pem',
+  ca: '/some/ca.pem',
+};
+
+const mockMessageHandler = jest.fn();
+const mockHealthRoutes = jest.fn();
+const mockEventsRoutes = jest.fn();
+jest.mock('@trading-model/common/server/create-secure-server', () => ({
+  createSecureServer: jest.fn(() => Promise.resolve(mockServer)),
+}));
+
+jest.mock('@trading-model/common/server/load-tls-config', () => ({
+  loadTlsConfig: jest.fn(() => mockTlsConfig),
+}));
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    PORT: 3001,
+    NODE_ENV: 'test',
+    TLS_KEY_PATH: '/some/key.pem',
+    TLS_CERT_PATH: '/some/cert.pem',
+    TLS_CA_PATH: '/some/ca.pem',
+    APP_NAME: 'audit-logger',
+    SERVICE_NAME: 'audit',
+    INSTANCE_ID: 'instance-1',
+    ADDRESS_MANAGER_URL: 'https://address-manager:3000',
+  },
+}));
+
+jest.mock('../../../src/routes/health.routes', () => ({
+  healthRoutes: jest.fn(() => mockHealthRoutes),
+}));
+
+jest.mock('../../../src/routes/events.routes', () => ({
+  eventsRoutes: jest.fn(() => mockEventsRoutes),
+}));
+
+jest.mock('../../../src/config/address-manager', () => ({
+  AddressManagerRoutes: jest.fn(),
+}));
+
+jest.mock('../../../src/subscription/audit-subscriber', () => ({
+  createMessageHandler: jest.fn(() => mockMessageHandler),
+}));
+
+import { createSecureServer } from '@trading-model/common/server/create-secure-server';
+import { loadTlsConfig } from '@trading-model/common/server/load-tls-config';
+import { createServer } from '../../../src/app/server';
+import { healthRoutes } from '../../../src/routes/health.routes';
+import { eventsRoutes } from '../../../src/routes/events.routes';
+
+describe('createServer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create a secure server and register all routes', async () => {
+    const scheduler = {
+      workers: 'workers-mock',
+      queue: 'queue-mock',
+      backPressure: 'back-pressure-mock',
+    } as any;
+    const auditRepo = { insert: jest.fn() } as any;
+
+    const server = await createServer(scheduler, auditRepo);
+
+    expect(server).toBe(mockServer);
+    expect(createSecureServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        port: 3001,
+        tls: mockTlsConfig,
+        trustProxy: true,
+      })
+    );
+
+    expect(loadTlsConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TLS_KEY_PATH: '/some/key.pem',
+        TLS_CERT_PATH: '/some/cert.pem',
+        TLS_CA_PATH: '/some/ca.pem',
+      })
+    );
+
+    const secureServerOptions = (createSecureServer as jest.Mock).mock.calls[0][0] as any;
+
+    secureServerOptions.routes(mockApp);
+
+    expect(healthRoutes).toHaveBeenCalledWith(
+      scheduler.queue,
+      scheduler.backPressure,
+      scheduler.workers
+    );
+    expect(eventsRoutes).toHaveBeenCalledWith(auditRepo);
+
+    expect(mockApp.use).toHaveBeenCalledWith('/', mockHealthRoutes);
+    expect(mockApp.use).toHaveBeenCalledWith('/', mockEventsRoutes);
+    expect(mockApp.post).toHaveBeenCalledWith('/message', mockMessageHandler);
+  });
+});

--- a/services/audit-logger/tests/unit/config/address-manager.spec.ts
+++ b/services/audit-logger/tests/unit/config/address-manager.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+const mockAddressManager = {
+  start: jest.fn(),
+  listenExpress: jest.fn(),
+};
+
+jest.mock('@trading-model/address-manager/create-address-manager', () => ({
+  createAddressManager: jest.fn(() => mockAddressManager),
+}));
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    NODE_ENV: 'test',
+    PORT: 3001,
+    TLS_KEY_PATH: '/some/key.pem',
+    TLS_CERT_PATH: '/some/cert.pem',
+    TLS_CA_PATH: '/some/ca.pem',
+    APP_NAME: 'audit-logger',
+    SERVICE_NAME: 'audit',
+    INSTANCE_ID: 'instance-1',
+    ADDRESS_MANAGER_URL: 'https://address-manager:3000',
+    CACHE_TTL_MS: 30000,
+    SERVICE_PING_TIMEOUT_MS: 2000,
+    DISCOVERY_TIMEOUT_MS: 5000,
+    TOKEN_REFRESH_INTERVAL_MS: 60000,
+    TTL_REFRESH_INTERVAL_MS: 15000,
+    MONGODB_URI: 'mongodb://localhost:27017/audit-logger',
+    MAX_QUEUE_DEPTH: 10000,
+    MAX_WORKER_LOAD_RATIO: 0.85,
+    ACK_TIMEOUT_MS: 30000,
+    MAX_RETRIES_PER_JOB: 3,
+    ORPHAN_SCAN_INTERVAL_MS: 10000,
+    WORKER_HEARTBEAT_TTL_MS: 30000,
+    GAP_DETECTION_INTERVAL_MS: 60000,
+    AUDIT_RETENTION_DAYS: 90,
+  },
+}));
+
+describe('address-manager config', () => {
+  it('should export AddressManagerRoutes, bootstrapAddressManager, and AddressManager', () => {
+    const addressManagerModule = require('../../../src/config/address-manager');
+
+    expect(addressManagerModule.AddressManagerRoutes).toBeDefined();
+    expect(addressManagerModule.AddressManagerRoutes).toBe(mockAddressManager.listenExpress);
+    expect(addressManagerModule.bootstrapAddressManager).toBeDefined();
+    expect(addressManagerModule.bootstrapAddressManager).toBe(mockAddressManager.start);
+    expect(addressManagerModule.AddressManager).toBeDefined();
+    expect(addressManagerModule.AddressManager).toBe(mockAddressManager);
+  });
+});

--- a/services/audit-logger/tests/unit/config/env.spec.ts
+++ b/services/audit-logger/tests/unit/config/env.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+const REQUIRED_ENV: Record<string, string> = {
+  NODE_ENV: 'test',
+  TLS_KEY_PATH: '/some/key.pem',
+  TLS_CERT_PATH: '/some/cert.pem',
+  TLS_CA_PATH: '/some/ca.pem',
+  APP_NAME: 'audit-logger',
+  SERVICE_NAME: 'audit',
+  INSTANCE_ID: 'instance-1',
+  ADDRESS_MANAGER_URL: 'https://address-manager:3000',
+};
+
+describe('env validation', () => {
+  it('should succeed when all required env vars are set', () => {
+    jest.isolateModules(() => {
+      Object.assign(process.env, REQUIRED_ENV);
+
+      const { env } = require('../../../src/config/env');
+
+      expect(env.NODE_ENV).toBe('test');
+      expect(env.TLS_KEY_PATH).toBe('/some/key.pem');
+      expect(env.TLS_CERT_PATH).toBe('/some/cert.pem');
+      expect(env.TLS_CA_PATH).toBe('/some/ca.pem');
+      expect(env.APP_NAME).toBe('audit-logger');
+      expect(env.SERVICE_NAME).toBe('audit');
+      expect(env.INSTANCE_ID).toBe('instance-1');
+      expect(env.ADDRESS_MANAGER_URL).toBe('https://address-manager:3000');
+    });
+  });
+
+  it('should throw when required env var TLS_KEY_PATH is missing', () => {
+    jest.isolateModules(() => {
+      Object.assign(process.env, REQUIRED_ENV);
+      delete process.env.TLS_KEY_PATH;
+
+      expect(() => {
+        require('../../../src/config/env');
+      }).toThrow();
+    });
+  });
+});

--- a/services/audit-logger/tests/unit/persistence/audit-repository.spec.ts
+++ b/services/audit-logger/tests/unit/persistence/audit-repository.spec.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+const mockCollection = {
+  insertOne: jest.fn<any>(),
+  insertMany: jest.fn<any>(),
+  findOne: jest.fn<any>(),
+  find: jest.fn<any>(),
+  createIndex: jest.fn<any>(),
+  estimatedDocumentCount: jest.fn<any>(),
+  aggregate: jest.fn<any>(),
+  countDocuments: jest.fn<any>(),
+};
+
+const mockDb = {
+  collection: jest.fn<any>().mockReturnValue(mockCollection),
+};
+
+jest.mock('mongodb', () => ({
+  Db: jest.fn(),
+  Collection: jest.fn(),
+}));
+
+import { AuditRepository, AuditEventDocument } from '../../../src/persistence/audit-repository';
+
+function makeEvent(overrides: Partial<AuditEventDocument> = {}): AuditEventDocument {
+  return {
+    receivedAt: new Date(),
+    metadata: {
+      topic: 'test-topic',
+      eventType: 'test.event',
+      publisher: 'test-service',
+      instanceId: 'instance-1',
+      messageId: 'msg-1',
+      correlationId: 'corr-1',
+    },
+    payload: { key: 'value' },
+    ...overrides,
+  };
+}
+
+describe('AuditRepository', () => {
+  let repository: AuditRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCollection.find.mockReturnValue({
+      sort: jest.fn<any>().mockReturnThis(),
+      skip: jest.fn<any>().mockReturnThis(),
+      limit: jest.fn<any>().mockReturnThis(),
+      toArray: jest.fn<any>(),
+    });
+    mockCollection.aggregate.mockReturnValue({ toArray: jest.fn<any>() });
+    repository = new AuditRepository(mockDb as any);
+  });
+
+  describe('constructor', () => {
+    it('should call db.collection with "audit_events"', () => {
+      expect(mockDb.collection).toHaveBeenCalledWith('audit_events');
+    });
+  });
+
+  describe('ensureIndexes', () => {
+    it('should create 4 indexes', async () => {
+      mockCollection.createIndex.mockResolvedValue(undefined);
+
+      await repository.ensureIndexes();
+
+      expect(mockCollection.createIndex).toHaveBeenCalledTimes(4);
+      expect(mockCollection.createIndex).toHaveBeenCalledWith({ 'metadata.correlationId': 1 });
+      expect(mockCollection.createIndex).toHaveBeenCalledWith({
+        'metadata.publisher': 1,
+        receivedAt: -1,
+      });
+      expect(mockCollection.createIndex).toHaveBeenCalledWith({
+        'metadata.topic': 1,
+        receivedAt: -1,
+      });
+      expect(mockCollection.createIndex).toHaveBeenCalledWith({ receivedAt: -1 });
+    });
+  });
+
+  describe('insert', () => {
+    it('should call insertOne with the event document', async () => {
+      mockCollection.insertOne.mockResolvedValue({ insertedId: 'id' });
+      const event = makeEvent();
+
+      await repository.insert(event);
+
+      expect(mockCollection.insertOne).toHaveBeenCalledTimes(1);
+      expect(mockCollection.insertOne).toHaveBeenCalledWith(event);
+    });
+
+    it('should throw AppError on failure', async () => {
+      mockCollection.insertOne.mockRejectedValue(new Error('DB error'));
+
+      await expect(repository.insert(makeEvent())).rejects.toThrow('Failed to persist audit event');
+    });
+  });
+
+  describe('insertBatch', () => {
+    it('should call insertMany with the events', async () => {
+      mockCollection.insertMany.mockResolvedValue({ insertedCount: 2 });
+      const events = [
+        makeEvent({ metadata: { ...makeEvent().metadata, messageId: 'msg-1' } }),
+        makeEvent({ metadata: { ...makeEvent().metadata, messageId: 'msg-2' } }),
+      ];
+
+      await repository.insertBatch(events);
+
+      expect(mockCollection.insertMany).toHaveBeenCalledWith(events, { ordered: false });
+    });
+
+    it('should not call insertMany for empty array', async () => {
+      await repository.insertBatch([]);
+
+      expect(mockCollection.insertMany).not.toHaveBeenCalled();
+    });
+
+    it('should throw AppError on failure', async () => {
+      mockCollection.insertMany.mockRejectedValue(new Error('DB error'));
+
+      await expect(repository.insertBatch([makeEvent()])).rejects.toThrow(
+        'Failed to persist audit event batch'
+      );
+    });
+  });
+
+  describe('findById', () => {
+    it('should find event by metadata.messageId', async () => {
+      const event = makeEvent();
+      mockCollection.findOne.mockResolvedValue(event);
+
+      const result = await repository.findById('msg-1');
+
+      expect(mockCollection.findOne).toHaveBeenCalledWith({ 'metadata.messageId': 'msg-1' });
+      expect(result).toEqual(event);
+    });
+
+    it('should return null when not found', async () => {
+      mockCollection.findOne.mockResolvedValue(null);
+
+      const result = await repository.findById('nonexistent');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('query', () => {
+    it('should apply filters and return paginated results', async () => {
+      mockCollection.find.mockReturnValue({
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        toArray: jest.fn<any>().mockResolvedValue([makeEvent()]),
+      });
+      mockCollection.countDocuments.mockResolvedValue(1);
+
+      const result = await repository.query({
+        topic: 'test-topic',
+        publisher: 'test-service',
+        page: 1,
+        limit: 10,
+      });
+
+      expect(mockCollection.countDocuments).toHaveBeenCalled();
+      expect(result).toMatchObject({
+        data: [expect.any(Object)],
+        pagination: { page: 1, limit: 10, total: 1, totalPages: 1 },
+      });
+    });
+
+    it('should apply date range filters', async () => {
+      const startDate = new Date('2024-01-01');
+      const endDate = new Date('2024-12-31');
+
+      await repository.query({ startDate, endDate });
+
+      const findFilter = (mockCollection.find as jest.Mock).mock.calls[0][0] as any;
+      expect(findFilter.receivedAt).toMatchObject({ $gte: startDate, $lte: endDate });
+    });
+
+    it('should apply startDate only', async () => {
+      const startDate = new Date('2024-06-01');
+
+      await repository.query({ startDate });
+
+      const findFilter = (mockCollection.find as jest.Mock).mock.calls[0][0] as any;
+      expect(findFilter.receivedAt.$gte).toEqual(startDate);
+      expect(findFilter.receivedAt.$lte).toBeUndefined();
+    });
+
+    it('should apply endDate only', async () => {
+      const endDate = new Date('2024-12-31');
+
+      await repository.query({ endDate });
+
+      const findFilter = (mockCollection.find as jest.Mock).mock.calls[0][0] as any;
+      expect(findFilter.receivedAt.$lte).toEqual(endDate);
+      expect(findFilter.receivedAt.$gte).toBeUndefined();
+    });
+
+    it('should apply correlationId filter', async () => {
+      await repository.query({ correlationId: 'corr-1' });
+
+      const findFilter = (mockCollection.find as jest.Mock).mock.calls[0][0] as any;
+      expect(findFilter['metadata.correlationId']).toBe('corr-1');
+    });
+
+    it('should cap limit at 1000', async () => {
+      await repository.query({ limit: 5000 });
+
+      expect(mockCollection.countDocuments).toHaveBeenCalled();
+
+      const findCall = mockCollection.find.mock.calls[0][1];
+      expect(findCall).toBeUndefined();
+    });
+
+    it('should handle empty result set', async () => {
+      mockCollection.find.mockReturnValue({
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        toArray: jest.fn<any>().mockResolvedValue([]),
+      });
+      mockCollection.countDocuments.mockResolvedValue(0);
+
+      const result = await repository.query({});
+
+      expect(result).toMatchObject({
+        data: [],
+        pagination: { page: 1, limit: 100, total: 0, totalPages: 0 },
+      });
+    });
+  });
+
+  describe('getStats', () => {
+    function makeAggregateResult<T>(value: T[]) {
+      return { toArray: jest.fn<any>().mockResolvedValue(value) };
+    }
+
+    it('should return aggregated statistics', async () => {
+      mockCollection.estimatedDocumentCount.mockResolvedValue(10);
+      mockCollection.aggregate
+        .mockReturnValueOnce(
+          makeAggregateResult([
+            { _id: 'topic-a', count: 6 },
+            { _id: 'topic-b', count: 4 },
+          ])
+        )
+        .mockReturnValueOnce(makeAggregateResult([{ _id: 'svc-a', count: 10 }]))
+        .mockReturnValueOnce(
+          makeAggregateResult([
+            { earliest: new Date('2024-01-01'), latest: new Date('2024-12-31') },
+          ])
+        );
+
+      const stats = await repository.getStats();
+
+      expect(stats).toMatchObject({
+        totalEvents: 10,
+        eventsByTopic: { 'topic-a': 6, 'topic-b': 4 },
+        eventsByPublisher: { 'svc-a': 10 },
+        dateRange: {
+          earliest: new Date('2024-01-01'),
+          latest: new Date('2024-12-31'),
+        },
+      });
+    });
+
+    it('should handle empty dateRange aggregations', async () => {
+      mockCollection.estimatedDocumentCount.mockResolvedValue(0);
+      mockCollection.aggregate
+        .mockReturnValueOnce(makeAggregateResult([]))
+        .mockReturnValueOnce(makeAggregateResult([]))
+        .mockReturnValueOnce(makeAggregateResult([]));
+
+      const stats = await repository.getStats();
+
+      expect(stats.dateRange.earliest).toBeNull();
+      expect(stats.dateRange.latest).toBeNull();
+    });
+  });
+});

--- a/services/audit-logger/tests/unit/persistence/job-repository.spec.ts
+++ b/services/audit-logger/tests/unit/persistence/job-repository.spec.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+const mockCollection = {
+  insertOne: jest.fn<any>(),
+  findOne: jest.fn<any>(),
+  updateOne: jest.fn<any>(),
+  find: jest.fn<any>(),
+  createIndex: jest.fn<any>(),
+};
+
+const mockDb = {
+  collection: jest.fn<any>().mockReturnValue(mockCollection),
+};
+
+jest.mock('mongodb', () => ({
+  Db: jest.fn(),
+  Collection: jest.fn(),
+}));
+
+import { JobRepository } from '../../../src/persistence/job-repository';
+import { Job } from '../../../src/types/job.types';
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: 'job-1',
+    type: 'test-type',
+    payload: { foo: 'bar' },
+    priority: 3,
+    status: 'queued',
+    assignedWorkerId: undefined,
+    ackDeadline: Date.now() + 30000,
+    maxRetries: 3,
+    retryCount: 0,
+    createdAt: new Date(),
+    startedAt: undefined,
+    completedAt: undefined,
+    result: undefined,
+    error: undefined,
+    history: [],
+    ...overrides,
+  };
+}
+
+describe('JobRepository', () => {
+  let repository: JobRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCollection.find.mockReturnValue({ toArray: jest.fn<any>() });
+    repository = new JobRepository(mockDb as any);
+  });
+
+  describe('constructor', () => {
+    it('should call db.collection with "audit_jobs"', () => {
+      expect(mockDb.collection).toHaveBeenCalledWith('audit_jobs');
+    });
+  });
+
+  describe('ensureIndexes', () => {
+    it('should create 4 indexes', async () => {
+      mockCollection.createIndex.mockResolvedValue(undefined);
+
+      await repository.ensureIndexes();
+
+      expect(mockCollection.createIndex).toHaveBeenCalledTimes(4);
+      expect(mockCollection.createIndex).toHaveBeenCalledWith({ jobId: 1 }, { unique: true });
+      expect(mockCollection.createIndex).toHaveBeenCalledWith({ status: 1 });
+      expect(mockCollection.createIndex).toHaveBeenCalledWith(
+        { assignedWorkerId: 1 },
+        { sparse: true }
+      );
+      expect(mockCollection.createIndex).toHaveBeenCalledWith({ type: 1, status: 1 });
+    });
+  });
+
+  describe('insert', () => {
+    it('should call insertOne with a document', async () => {
+      mockCollection.insertOne.mockResolvedValue({ insertedId: 'job-1' });
+      const job = makeJob();
+
+      await repository.insert(job);
+
+      expect(mockCollection.insertOne).toHaveBeenCalledTimes(1);
+      const doc = (mockCollection.insertOne as jest.Mock).mock.calls[0][0] as any;
+      expect(doc.jobId).toBe('job-1');
+      expect(doc.type).toBe('test-type');
+    });
+
+    it('should map history entries in toDocument', async () => {
+      mockCollection.insertOne.mockResolvedValue({ insertedId: 'job-1' });
+      const job = makeJob({
+        history: [
+          {
+            fromStatus: 'queued',
+            toStatus: 'assigned',
+            timestamp: new Date('2024-01-01'),
+            reason: 'assign',
+          },
+          {
+            fromStatus: 'assigned',
+            toStatus: 'running',
+            timestamp: new Date('2024-01-02'),
+            reason: 'start',
+          },
+        ],
+      });
+
+      await repository.insert(job);
+
+      const doc = (mockCollection.insertOne as jest.Mock).mock.calls[0][0] as any;
+      expect(doc.history).toHaveLength(2);
+      expect(doc.history[0]).toMatchObject({
+        fromStatus: 'queued',
+        toStatus: 'assigned',
+        reason: 'assign',
+      });
+      expect(doc.history[1]).toMatchObject({
+        fromStatus: 'assigned',
+        toStatus: 'running',
+        reason: 'start',
+      });
+    });
+  });
+
+  describe('findById', () => {
+    it('should return a job when found', async () => {
+      const doc = {
+        jobId: 'job-1',
+        type: 'test',
+        payload: {},
+        priority: 3,
+        status: 'queued',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+      };
+      mockCollection.findOne.mockResolvedValue(doc);
+
+      const result = await repository.findById('job-1');
+
+      expect(mockCollection.findOne).toHaveBeenCalledWith({ jobId: 'job-1' });
+      expect(result).toBeDefined();
+      expect(result!.id).toBe('job-1');
+    });
+
+    it('should return null when not found', async () => {
+      mockCollection.findOne.mockResolvedValue(null);
+
+      const result = await repository.findById('nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should map history entries in fromDocument', async () => {
+      const doc = {
+        jobId: 'job-1',
+        type: 'test',
+        payload: {},
+        priority: 3,
+        status: 'queued',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [
+          {
+            fromStatus: 'queued',
+            toStatus: 'assigned',
+            timestamp: new Date('2024-01-01'),
+            reason: 'assign',
+          },
+        ],
+      };
+      mockCollection.findOne.mockResolvedValue(doc);
+
+      const result = await repository.findById('job-1');
+
+      expect(result!.history).toHaveLength(1);
+      expect(result!.history[0]).toMatchObject({
+        fromStatus: 'queued',
+        toStatus: 'assigned',
+        reason: 'assign',
+      });
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('should update status and push history', async () => {
+      const currentDoc = { jobId: 'job-1', status: 'queued', history: [] };
+      mockCollection.findOne.mockResolvedValue(currentDoc);
+      mockCollection.updateOne.mockResolvedValue({ modifiedCount: 1 });
+
+      await repository.updateStatus('job-1', 'assigned', {
+        assignedWorkerId: 'w1',
+        ackDeadline: 1000,
+      });
+
+      expect(mockCollection.updateOne).toHaveBeenCalledWith(
+        { jobId: 'job-1' },
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            status: 'assigned',
+            assignedWorkerId: 'w1',
+            ackDeadline: 1000,
+          }),
+          $push: expect.objectContaining({
+            history: expect.objectContaining({
+              fromStatus: 'queued',
+              toStatus: 'assigned',
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should do nothing when current document is not found', async () => {
+      mockCollection.findOne.mockResolvedValue(null);
+
+      await repository.updateStatus('nonexistent', 'completed');
+
+      expect(mockCollection.updateOne).not.toHaveBeenCalled();
+    });
+
+    it('should set startedAt when status becomes running', async () => {
+      const currentDoc = { jobId: 'job-1', status: 'assigned', history: [] };
+      mockCollection.findOne.mockResolvedValue(currentDoc);
+      mockCollection.updateOne.mockResolvedValue({ modifiedCount: 1 });
+
+      await repository.updateStatus('job-1', 'running');
+
+      const updateCall = (mockCollection.updateOne as jest.Mock).mock.calls[0][1] as any;
+      expect(updateCall.$set.startedAt).toBeDefined();
+      expect(updateCall.$set.startedAt).toBeInstanceOf(Date);
+    });
+
+    it('should set completedAt when status becomes completed or failed', async () => {
+      const currentDoc = { jobId: 'job-1', status: 'running', history: [] };
+      mockCollection.findOne.mockResolvedValue(currentDoc);
+      mockCollection.updateOne.mockResolvedValue({ modifiedCount: 1 });
+
+      await repository.updateStatus('job-1', 'completed', { result: 'success' });
+
+      const updateCall = (mockCollection.updateOne as jest.Mock).mock.calls[0][1] as any;
+      expect(updateCall.$set.completedAt).toBeDefined();
+      expect(updateCall.$set.completedAt).toBeInstanceOf(Date);
+      expect(updateCall.$set.result).toBe('success');
+    });
+
+    it('should set error when extras.error is provided', async () => {
+      const currentDoc = { jobId: 'job-1', status: 'running', history: [] };
+      mockCollection.findOne.mockResolvedValue(currentDoc);
+      mockCollection.updateOne.mockResolvedValue({ modifiedCount: 1 });
+
+      await repository.updateStatus('job-1', 'failed', { error: 'Something went wrong' });
+
+      const updateCall = (mockCollection.updateOne as jest.Mock).mock.calls[0][1] as any;
+      expect(updateCall.$set.error).toBe('Something went wrong');
+      expect(updateCall.$set.completedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('incrementRetry', () => {
+    it('should increment retryCount by 1', async () => {
+      mockCollection.updateOne.mockResolvedValue({ modifiedCount: 1 });
+
+      await repository.incrementRetry('job-1');
+
+      expect(mockCollection.updateOne).toHaveBeenCalledWith(
+        { jobId: 'job-1' },
+        { $inc: { retryCount: 1 } }
+      );
+    });
+  });
+
+  describe('findNonTerminal', () => {
+    it('should find all non-terminal jobs', async () => {
+      const docs = [
+        { jobId: 'j1', status: 'queued', history: [] },
+        { jobId: 'j2', status: 'running', history: [] },
+      ];
+      mockCollection.find.mockReturnValue({ toArray: jest.fn<any>().mockResolvedValue(docs) });
+
+      const results = await repository.findNonTerminal();
+
+      expect(mockCollection.find).toHaveBeenCalledWith({
+        status: { $nin: ['completed', 'failed', 'cancelled'] },
+      });
+      expect(results).toHaveLength(2);
+    });
+  });
+
+  describe('findByWorker', () => {
+    it('should find jobs by worker ID and statuses', async () => {
+      const docs = [{ jobId: 'j1', assignedWorkerId: 'w1', status: 'assigned', history: [] }];
+      mockCollection.find.mockReturnValue({ toArray: jest.fn<any>().mockResolvedValue(docs) });
+
+      const results = await repository.findByWorker('w1', ['assigned', 'running']);
+
+      expect(mockCollection.find).toHaveBeenCalledWith({
+        assignedWorkerId: 'w1',
+        status: { $in: ['assigned', 'running'] },
+      });
+      expect(results).toHaveLength(1);
+    });
+  });
+
+  describe('findByStatus', () => {
+    it('should find jobs by status', async () => {
+      const docs = [{ jobId: 'j1', status: 'queued', history: [] }];
+      mockCollection.find.mockReturnValue({ toArray: jest.fn<any>().mockResolvedValue(docs) });
+
+      const results = await repository.findByStatus('queued');
+
+      expect(mockCollection.find).toHaveBeenCalledWith({ status: 'queued' });
+      expect(results).toHaveLength(1);
+    });
+  });
+});

--- a/services/audit-logger/tests/unit/recovery/orphan-detector.spec.ts
+++ b/services/audit-logger/tests/unit/recovery/orphan-detector.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, jest, afterEach } from '@jest/globals';
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    ACK_TIMEOUT_MS: 30000,
+    MAX_QUEUE_DEPTH: 10000,
+    MAX_WORKER_LOAD_RATIO: 0.85,
+    MAX_RETRIES_PER_JOB: 3,
+    ORPHAN_SCAN_INTERVAL_MS: 10000,
+    WORKER_HEARTBEAT_TTL_MS: 30000,
+  },
+}));
+
+import { OrphanDetector } from '../../../src/recovery/orphan-detector';
+import { ReAllocator } from '../../../src/recovery/re-allocator';
+import { WorkerRegistry } from '../../../src/worker/worker-registry';
+import { JobRepository } from '../../../src/persistence/job-repository';
+import { InternalQueue } from '../../../src/scheduler/internal-queue';
+import { createJob } from '../../fixtures/job.fixture';
+
+describe('OrphanDetector', () => {
+  let registry: WorkerRegistry;
+  let reAllocator: ReAllocator;
+  let mockRepository: jest.Mocked<JobRepository>;
+  let mockQueue: InternalQueue;
+  let orphanDetector: OrphanDetector;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    mockRepository = {
+      insert: jest.fn(),
+      findById: jest.fn(),
+      updateStatus: jest.fn(),
+      incrementRetry: jest.fn(),
+      findNonTerminal: jest.fn(),
+      findByWorker: jest.fn(),
+      findByStatus: jest.fn(),
+      ensureIndexes: jest.fn(),
+    } as unknown as jest.Mocked<JobRepository>;
+
+    mockQueue = new InternalQueue(30000);
+    registry = new WorkerRegistry(5000);
+    reAllocator = new ReAllocator(mockRepository, mockQueue);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('start / stop', () => {
+    it('should start and stop the detection interval', () => {
+      orphanDetector = new OrphanDetector(registry, mockRepository, reAllocator, 10000);
+
+      orphanDetector.start();
+      expect(jest.getTimerCount()).toBeGreaterThan(0);
+
+      orphanDetector.stop();
+      jest.advanceTimersByTime(10000);
+      expect(mockRepository.findByWorker).not.toHaveBeenCalled();
+    });
+
+    it('should not start multiple intervals', () => {
+      orphanDetector = new OrphanDetector(registry, mockRepository, reAllocator, 10000);
+
+      orphanDetector.start();
+      orphanDetector.start();
+
+      jest.advanceTimersByTime(10000);
+      expect(mockRepository.findByWorker).toHaveBeenCalledTimes(0);
+    });
+
+    it('should not throw when stopping without having started', () => {
+      orphanDetector = new OrphanDetector(registry, mockRepository, reAllocator, 10000);
+
+      expect(() => orphanDetector.stop()).not.toThrow();
+    });
+  });
+
+  describe('detection cycle', () => {
+    it('should detect orphaned jobs from stale workers', () => {
+      registry.register('stale-worker', {
+        workerId: 'stale-worker',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      jest.advanceTimersByTime(10000);
+
+      mockRepository.findByWorker.mockResolvedValue([createJob({ id: 'orphan-1' })]);
+
+      orphanDetector = new OrphanDetector(registry, mockRepository, reAllocator, 5000);
+      orphanDetector.start();
+
+      jest.advanceTimersByTime(5000);
+
+      expect(mockRepository.findByWorker).toHaveBeenCalledWith('stale-worker', [
+        'assigned',
+        'running',
+      ]);
+    });
+
+    it('should log error but not crash when detection fails', () => {
+      mockRepository.findByWorker.mockRejectedValue(new Error('DB error'));
+
+      registry.register('bad-worker', {
+        workerId: 'bad-worker',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      jest.advanceTimersByTime(10000);
+
+      orphanDetector = new OrphanDetector(registry, mockRepository, reAllocator, 5000);
+      orphanDetector.start();
+
+      expect(() => {
+        jest.advanceTimersByTime(5000);
+      }).not.toThrow();
+    });
+
+    it('should handle non-Error rejection in detection cycle', () => {
+      mockRepository.findByWorker.mockRejectedValue('string error');
+
+      registry.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      jest.advanceTimersByTime(10000);
+
+      orphanDetector = new OrphanDetector(registry, mockRepository, reAllocator, 5000);
+      orphanDetector.start();
+
+      expect(() => {
+        jest.advanceTimersByTime(5000);
+      }).not.toThrow();
+    });
+  });
+});

--- a/services/audit-logger/tests/unit/recovery/re-allocator.spec.ts
+++ b/services/audit-logger/tests/unit/recovery/re-allocator.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    ACK_TIMEOUT_MS: 30000,
+    MAX_QUEUE_DEPTH: 10000,
+    MAX_WORKER_LOAD_RATIO: 0.85,
+    MAX_RETRIES_PER_JOB: 3,
+    ORPHAN_SCAN_INTERVAL_MS: 10000,
+    WORKER_HEARTBEAT_TTL_MS: 30000,
+  },
+}));
+
+import { ReAllocator } from '../../../src/recovery/re-allocator';
+import { InternalQueue } from '../../../src/scheduler/internal-queue';
+import { JobRepository } from '../../../src/persistence/job-repository';
+import { createJob } from '../../fixtures/job.fixture';
+
+describe('ReAllocator', () => {
+  let reAllocator: ReAllocator;
+  let mockRepository: jest.Mocked<JobRepository>;
+  let mockQueue: InternalQueue;
+
+  beforeEach(() => {
+    mockRepository = {
+      insert: jest.fn(),
+      findById: jest.fn(),
+      updateStatus: jest.fn(),
+      incrementRetry: jest.fn(),
+      findNonTerminal: jest.fn(),
+      findByWorker: jest.fn(),
+      findByStatus: jest.fn(),
+      ensureIndexes: jest.fn(),
+    } as unknown as jest.Mocked<JobRepository>;
+
+    mockQueue = new InternalQueue(30000);
+    reAllocator = new ReAllocator(mockRepository, mockQueue);
+  });
+
+  describe('reallocate', () => {
+    it('should mark job as failed when maxRetries exceeded', async () => {
+      const job = createJob({ retryCount: 3, maxRetries: 3 });
+
+      await reAllocator.reallocate(job);
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(
+        job.id,
+        'failed',
+        expect.objectContaining({ error: expect.stringContaining('max retries') })
+      );
+    });
+
+    it('should re-enqueue job when retries remain', async () => {
+      const job = createJob({ id: 'rejob-1', retryCount: 0, maxRetries: 3 });
+
+      await reAllocator.reallocate(job);
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(
+        job.id,
+        'queued',
+        expect.objectContaining({ ackDeadline: expect.any(Number) })
+      );
+      expect(mockQueue.depth()).toBe(1);
+    });
+  });
+});

--- a/services/audit-logger/tests/unit/routes/events.controller.spec.ts
+++ b/services/audit-logger/tests/unit/routes/events.controller.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+import { createReq, createRes, createNext } from '../../helpers/express';
+
+jest.mock('@trading-model/common/middleware/catch-error', () => ({
+  catchSync: (fn: any) => fn,
+}));
+
+jest.mock('@trading-model/common/middleware/response-exception', () => {
+  const sendResponse = (data: any, status: number) => ({ status, data });
+  return { sendResponse };
+});
+
+import { AuditRepository } from '../../../src/persistence/audit-repository';
+import { createEventsController } from '../../../src/routes/events.controller';
+
+describe('EventsController', () => {
+  let mockRepo: jest.Mocked<AuditRepository>;
+  let controller: ReturnType<typeof createEventsController>;
+
+  beforeEach(() => {
+    mockRepo = {
+      insert: jest.fn(),
+      insertBatch: jest.fn(),
+      findById: jest.fn(),
+      query: jest.fn(),
+      getStats: jest.fn(),
+      ensureIndexes: jest.fn(),
+    } as unknown as jest.Mocked<AuditRepository>;
+
+    controller = createEventsController(mockRepo);
+  });
+
+  describe('listEvents', () => {
+    it('should return paginated events with query params', async () => {
+      const mockResult = { data: [], pagination: { page: 1, limit: 100, total: 0, totalPages: 0 } };
+      mockRepo.query.mockResolvedValue(mockResult);
+
+      const result = await controller.listEvents(
+        createReq({ query: { topic: 'test', page: '1', limit: '50' } }),
+        createRes(),
+        createNext
+      );
+
+      expect(mockRepo.query).toHaveBeenCalledWith({
+        topic: 'test',
+        publisher: undefined,
+        correlationId: undefined,
+        startDate: undefined,
+        endDate: undefined,
+        page: 1,
+        limit: 50,
+      });
+      expect(result).toMatchObject({ status: 200, data: mockResult });
+    });
+
+    it('should parse date params', async () => {
+      mockRepo.query.mockResolvedValue({
+        data: [],
+        pagination: { page: 1, limit: 100, total: 0, totalPages: 0 },
+      });
+
+      await controller.listEvents(
+        createReq({ query: { startDate: '2024-01-01', endDate: '2024-12-31' } }),
+        createRes(),
+        createNext
+      );
+
+      const callArgs = mockRepo.query.mock.calls[0][0];
+      expect(callArgs.startDate).toEqual(new Date('2024-01-01'));
+      expect(callArgs.endDate).toEqual(new Date('2024-12-31'));
+    });
+
+    it('should handle missing query params gracefully', async () => {
+      mockRepo.query.mockResolvedValue({
+        data: [],
+        pagination: { page: 1, limit: 100, total: 0, totalPages: 0 },
+      });
+
+      const result = await controller.listEvents(createReq({ query: {} }), createRes(), createNext);
+
+      expect(mockRepo.query).toHaveBeenCalledWith({
+        topic: undefined,
+        publisher: undefined,
+        correlationId: undefined,
+        startDate: undefined,
+        endDate: undefined,
+        page: undefined,
+        limit: undefined,
+      });
+      expect(result).toMatchObject({ status: 200 });
+    });
+  });
+
+  describe('getEvent', () => {
+    it('should return 200 with the event when found', async () => {
+      const mockEvent = { metadata: { messageId: 'msg-1' } } as any;
+      mockRepo.findById.mockResolvedValue(mockEvent);
+
+      const result = await controller.getEvent(
+        createReq({ params: { messageId: 'msg-1' } }),
+        createRes(),
+        createNext
+      );
+
+      expect(mockRepo.findById).toHaveBeenCalledWith('msg-1');
+      expect(result).toMatchObject({ status: 200, data: mockEvent });
+    });
+
+    it('should return 404 when event not found', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+
+      const result = await controller.getEvent(
+        createReq({ params: { messageId: 'nonexistent' } }),
+        createRes(),
+        createNext
+      );
+
+      expect(result).toMatchObject({ status: 404, data: { error: 'Event not found' } });
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return 200 with audit stats', async () => {
+      const mockStats = { totalEvents: 42 } as any;
+      mockRepo.getStats.mockResolvedValue(mockStats);
+
+      const result = await controller.getStats(createReq(), createRes(), createNext);
+
+      expect(mockRepo.getStats).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({ status: 200, data: mockStats });
+    });
+  });
+});

--- a/services/audit-logger/tests/unit/routes/events.routes.spec.ts
+++ b/services/audit-logger/tests/unit/routes/events.routes.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+const mockRouter = {
+  get: jest.fn(),
+};
+const mockController = { listEvents: jest.fn(), getEvent: jest.fn(), getStats: jest.fn() };
+
+jest.mock('express', () => ({
+  Router: jest.fn(() => mockRouter),
+}));
+
+jest.mock('../../../src/routes/events.controller', () => ({
+  createEventsController: jest.fn(() => mockController),
+}));
+
+import { eventsRoutes } from '../../../src/routes/events.routes';
+
+describe('eventsRoutes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should register GET routes for events', () => {
+    const auditRepo = {} as any;
+
+    const router = eventsRoutes(auditRepo);
+
+    expect(router).toBe(mockRouter);
+    expect(mockRouter.get).toHaveBeenCalledWith('/events', mockController.listEvents);
+    expect(mockRouter.get).toHaveBeenCalledWith('/events/stats', mockController.getStats);
+    expect(mockRouter.get).toHaveBeenCalledWith('/events/:messageId', mockController.getEvent);
+  });
+});

--- a/services/audit-logger/tests/unit/routes/health.controller.spec.ts
+++ b/services/audit-logger/tests/unit/routes/health.controller.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+import { createReq, createRes, createNext } from '../../helpers/express';
+
+jest.mock('@trading-model/common/middleware/catch-error', () => ({
+  catchSync: (fn: any) => fn,
+}));
+
+jest.mock('@trading-model/common/middleware/response-exception', () => {
+  const sendResponse = (data: any, status: number) => ({ status, data });
+  return { sendResponse };
+});
+
+import { InternalQueue } from '../../../src/scheduler/internal-queue';
+import { BackPressure } from '../../../src/scheduler/back-pressure';
+import { WorkerRegistry } from '../../../src/worker/worker-registry';
+import { createHealthController } from '../../../src/routes/health.controller';
+
+describe('HealthController', () => {
+  let queue: InternalQueue;
+  let backPressure: BackPressure;
+  let workers: WorkerRegistry;
+  let controller: ReturnType<typeof createHealthController>;
+
+  beforeEach(() => {
+    queue = new InternalQueue(30000);
+    backPressure = new BackPressure(100, 0.85);
+    workers = new WorkerRegistry(30000);
+    controller = createHealthController(queue, backPressure, workers);
+  });
+
+  describe('ping', () => {
+    it('should return 200 with status ok', async () => {
+      const result = await controller.ping(createReq(), createRes(), createNext);
+
+      expect(result).toMatchObject({ status: 200 });
+      expect((result as any).data).toHaveProperty('status', 'ok');
+      expect((result as any).data).toHaveProperty('timestamp');
+    });
+  });
+
+  describe('health', () => {
+    it('should return 200 with health metrics', async () => {
+      queue.enqueue({
+        id: 'j1',
+        type: 't',
+        payload: {},
+        priority: 3,
+        status: 'queued',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+      });
+
+      const result = await controller.health(createReq(), createRes(), createNext);
+
+      expect(result).toMatchObject({ status: 200 });
+      expect((result as any).data).toMatchObject({
+        status: 'ok',
+        queueDepth: 1,
+        canAccept: true,
+        workerCount: 0,
+        averageLoad: 0,
+      });
+      expect((result as any).data).toHaveProperty('timestamp');
+    });
+  });
+});

--- a/services/audit-logger/tests/unit/routes/health.routes.spec.ts
+++ b/services/audit-logger/tests/unit/routes/health.routes.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+const mockRouter = {
+  get: jest.fn(),
+};
+const mockController = { ping: jest.fn(), health: jest.fn() };
+
+jest.mock('express', () => ({
+  Router: jest.fn(() => mockRouter),
+}));
+
+jest.mock('../../../src/routes/health.controller', () => ({
+  createHealthController: jest.fn(() => mockController),
+}));
+
+import { healthRoutes } from '../../../src/routes/health.routes';
+
+describe('healthRoutes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should register GET /ping and GET /health', () => {
+    const queue = {} as any;
+    const backPressure = {} as any;
+    const workers = {} as any;
+
+    const router = healthRoutes(queue, backPressure, workers);
+
+    expect(router).toBe(mockRouter);
+    expect(mockRouter.get).toHaveBeenCalledWith('/ping', mockController.ping);
+    expect(mockRouter.get).toHaveBeenCalledWith('/health', mockController.health);
+  });
+});

--- a/services/audit-logger/tests/unit/scheduler/back-pressure.spec.ts
+++ b/services/audit-logger/tests/unit/scheduler/back-pressure.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+import { BackPressure } from '../../../src/scheduler/back-pressure';
+
+describe('BackPressure', () => {
+  let backPressure: BackPressure;
+
+  beforeEach(() => {
+    backPressure = new BackPressure(100, 0.85);
+  });
+
+  describe('canAccept', () => {
+    it('should return true when queue is empty and no workers', () => {
+      expect(backPressure.canAccept()).toBe(true);
+    });
+
+    it('should return true when queue depth is below threshold', () => {
+      backPressure.updateQueueDepth(50);
+      expect(backPressure.canAccept()).toBe(true);
+    });
+
+    it('should return false when queue depth exceeds max', () => {
+      backPressure.updateQueueDepth(100);
+      expect(backPressure.canAccept()).toBe(false);
+    });
+
+    it('should return true when all workers are below load ratio', () => {
+      backPressure.updateWorkerLoad('worker-1', 0.5);
+      backPressure.updateWorkerLoad('worker-2', 0.6);
+      expect(backPressure.canAccept()).toBe(true);
+    });
+
+    it('should return false when all workers are above load ratio', () => {
+      backPressure.updateWorkerLoad('worker-1', 0.9);
+      backPressure.updateWorkerLoad('worker-2', 0.95);
+      expect(backPressure.canAccept()).toBe(false);
+    });
+
+    it('should return true when some workers are below load ratio', () => {
+      backPressure.updateWorkerLoad('worker-1', 0.9);
+      backPressure.updateWorkerLoad('worker-2', 0.5);
+      expect(backPressure.canAccept()).toBe(true);
+    });
+  });
+
+  describe('retryAfterSeconds', () => {
+    it('should return 5s for queue depth under 100', () => {
+      backPressure.updateQueueDepth(50);
+      expect(backPressure.retryAfterSeconds()).toBe(5);
+    });
+
+    it('should return 15s for queue depth around 210', () => {
+      backPressure.updateQueueDepth(210);
+      expect(backPressure.retryAfterSeconds()).toBe(15);
+    });
+  });
+
+  describe('updateQueueDepth', () => {
+    it('should update the internal queue depth', () => {
+      backPressure.updateQueueDepth(50);
+      expect(backPressure.canAccept()).toBe(true);
+
+      backPressure.updateQueueDepth(150);
+      expect(backPressure.canAccept()).toBe(false);
+    });
+  });
+
+  describe('updateWorkerLoad / removeWorker', () => {
+    it('should update individual worker loads', () => {
+      backPressure.updateWorkerLoad('worker-1', 0.9);
+      backPressure.updateWorkerLoad('worker-2', 0.5);
+
+      expect(backPressure.canAccept()).toBe(true);
+    });
+
+    it('should allow acceptance when a removed worker was the bottleneck', () => {
+      backPressure.updateWorkerLoad('worker-1', 0.9);
+      expect(backPressure.canAccept()).toBe(false);
+
+      backPressure.removeWorker('worker-1');
+      expect(backPressure.canAccept()).toBe(true);
+    });
+  });
+});

--- a/services/audit-logger/tests/unit/scheduler/internal-queue.spec.ts
+++ b/services/audit-logger/tests/unit/scheduler/internal-queue.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, jest, afterEach } from '@jest/globals';
+
+import { InternalQueue } from '../../../src/scheduler/internal-queue';
+import { createJob } from '../../fixtures/job.fixture';
+
+describe('InternalQueue', () => {
+  let queue: InternalQueue;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    queue = new InternalQueue(30000);
+  });
+
+  afterEach(() => {
+    queue.stop();
+    jest.useRealTimers();
+  });
+
+  describe('enqueue', () => {
+    it('should add a job to the correct priority queue', () => {
+      const job = createJob({ priority: 1 });
+      queue.enqueue(job);
+
+      expect(queue.depth()).toBe(1);
+    });
+
+    it('should enqueue jobs at different priorities', () => {
+      queue.enqueue(createJob({ priority: 1 }));
+      queue.enqueue(createJob({ priority: 5 }));
+
+      expect(queue.depth()).toBe(2);
+    });
+  });
+
+  describe('dequeue', () => {
+    it('should return null when queue is empty', () => {
+      expect(queue.dequeue()).toBeNull();
+    });
+
+    it('should return the highest priority job first', () => {
+      queue.enqueue(createJob({ id: 'low', priority: 5 }));
+      queue.enqueue(createJob({ id: 'high', priority: 1 }));
+
+      const result = queue.dequeue();
+      expect(result).not.toBeNull();
+      expect(result!.job.id).toBe('high');
+    });
+
+    it('should return jobs in FIFO order within the same priority', () => {
+      queue.enqueue(createJob({ id: 'first', priority: 3 }));
+      queue.enqueue(createJob({ id: 'second', priority: 3 }));
+
+      expect(queue.dequeue()!.job.id).toBe('first');
+      expect(queue.dequeue()!.job.id).toBe('second');
+    });
+
+    it('should remove the job from the queue', () => {
+      queue.enqueue(createJob({ priority: 3 }));
+      queue.dequeue();
+
+      expect(queue.depth()).toBe(0);
+    });
+  });
+
+  describe('markDelivered / ack', () => {
+    it('should call onAckTimeout when ack is not called within timeout', () => {
+      const onTimeout = jest.fn();
+      queue.setOnAckTimeout(onTimeout);
+
+      queue.enqueue(createJob({ id: 'job-1' }));
+      queue.markDelivered('job-1');
+
+      jest.advanceTimersByTime(30000);
+
+      expect(onTimeout).toHaveBeenCalledWith('job-1');
+    });
+
+    it('should not call onAckTimeout when ack is called in time', () => {
+      const onTimeout = jest.fn();
+      queue.setOnAckTimeout(onTimeout);
+
+      queue.markDelivered('job-1');
+      queue.ack('job-1');
+
+      jest.advanceTimersByTime(30000);
+
+      expect(onTimeout).not.toHaveBeenCalled();
+    });
+
+    it('should not fail when ack is called for unknown jobId', () => {
+      expect(() => queue.ack('unknown')).not.toThrow();
+    });
+  });
+
+  describe('depth', () => {
+    it('should return 0 for empty queue', () => {
+      expect(queue.depth()).toBe(0);
+    });
+
+    it('should return total count across all priorities', () => {
+      queue.enqueue(createJob({ priority: 1 }));
+      queue.enqueue(createJob({ priority: 2 }));
+      queue.enqueue(createJob({ priority: 5 }));
+
+      expect(queue.depth()).toBe(3);
+    });
+  });
+
+  describe('markDelivered without callback', () => {
+    it('should not throw when ack timeout fires without callback set', () => {
+      queue.markDelivered('job-1');
+      expect(() => {
+        jest.advanceTimersByTime(30000);
+      }).not.toThrow();
+    });
+  });
+
+  describe('stop', () => {
+    it('should clear all pending ack timers', () => {
+      const onTimeout = jest.fn();
+      queue.setOnAckTimeout(onTimeout);
+
+      queue.markDelivered('job-1');
+      queue.markDelivered('job-2');
+      queue.stop();
+
+      jest.advanceTimersByTime(30000);
+
+      expect(onTimeout).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/services/audit-logger/tests/unit/scheduler/job-scheduler.spec.ts
+++ b/services/audit-logger/tests/unit/scheduler/job-scheduler.spec.ts
@@ -1,0 +1,941 @@
+import { describe, it, expect, beforeEach, jest, afterEach } from '@jest/globals';
+
+jest.mock('@trading-model/common/config/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('../../../src/config/env', () => ({
+  env: {
+    ACK_TIMEOUT_MS: 30000,
+    MAX_QUEUE_DEPTH: 10000,
+    MAX_WORKER_LOAD_RATIO: 0.85,
+    MAX_RETRIES_PER_JOB: 3,
+    ORPHAN_SCAN_INTERVAL_MS: 10000,
+    WORKER_HEARTBEAT_TTL_MS: 30000,
+  },
+}));
+
+import { JobScheduler } from '../../../src/scheduler/job-scheduler';
+import { JobRepository } from '../../../src/persistence/job-repository';
+import type { WorkerProtocol } from '../../../src/worker/worker-protocol';
+
+type MockLogger = { info: jest.Mock; warn: jest.Mock; error: jest.Mock; debug: jest.Mock };
+const mockLogger = (
+  jest.requireMock('@trading-model/common/config/logger') as { logger: MockLogger }
+).logger;
+
+describe('JobScheduler', () => {
+  let scheduler: JobScheduler;
+  let mockRepository: jest.Mocked<JobRepository>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    mockRepository = {
+      insert: jest.fn(),
+      findById: jest.fn(),
+      updateStatus: jest.fn(),
+      incrementRetry: jest.fn(),
+      findNonTerminal: jest.fn(),
+      findByWorker: jest.fn(),
+      findByStatus: jest.fn(),
+      ensureIndexes: jest.fn(),
+    } as unknown as jest.Mocked<JobRepository>;
+
+    scheduler = new JobScheduler(mockRepository);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('submit', () => {
+    it('should create and enqueue a job', async () => {
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      const jobId = await scheduler.submit('test-type', { data: 1 }, 3, 3);
+
+      expect(jobId).toBeDefined();
+      expect(typeof jobId).toBe('string');
+      expect(mockRepository.insert).toHaveBeenCalled();
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(jobId, 'queued');
+    });
+
+    it('should throw BACK_PRESSURE when queue is full', async () => {
+      scheduler.backPressure.updateQueueDepth(99999);
+
+      await expect(scheduler.submit('test-type', {})).rejects.toThrow('Job scheduler at capacity');
+    });
+
+    it('should log error when enqueueJob updateStatus fails', async () => {
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockRejectedValue(new Error('DB error'));
+
+      await scheduler.submit('test-type', {});
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to persist queued status',
+        expect.objectContaining({ error: 'Error: DB error' })
+      );
+    });
+  });
+
+  describe('ack', () => {
+    it('should update job status to running', async () => {
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.ack('job-1');
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith('job-1', 'running');
+    });
+  });
+
+  describe('complete', () => {
+    it('should update job status to completed', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 1,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-1',
+        assignedWorkerId: 'w1',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: Date.now() + 30000,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.complete('job-1', { result: 'ok' });
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(
+        'job-1',
+        'completed',
+        expect.objectContaining({ result: { result: 'ok' } })
+      );
+    });
+
+    it('should handle complete without assignedWorkerId', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-no-worker',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.complete('job-no-worker', { ok: true });
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(
+        'job-no-worker',
+        'completed',
+        expect.any(Object)
+      );
+    });
+
+    it('should handle complete when worker is not found in registry', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-worker-gone',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: 'nonexistent',
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await expect(scheduler.complete('job-worker-gone', {})).resolves.not.toThrow();
+    });
+  });
+
+  describe('fail', () => {
+    it('should re-enqueue job when retries remain', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-retry',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        result: undefined,
+        error: undefined,
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.fail('job-retry', 'timeout');
+
+      expect(mockRepository.incrementRetry).toHaveBeenCalledWith('job-retry');
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(
+        'job-retry',
+        'queued',
+        expect.any(Object)
+      );
+      expect(scheduler.queue.depth()).toBe(1);
+    });
+
+    it('should mark job as failed when max retries exceeded', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-fail',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 3,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        result: undefined,
+        error: undefined,
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.fail('job-fail', 'fatal');
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith(
+        'job-fail',
+        'failed',
+        expect.objectContaining({ error: 'fatal' })
+      );
+    });
+
+    it('should do nothing for unknown job', async () => {
+      mockRepository.findById.mockResolvedValue(null);
+
+      await expect(scheduler.fail('unknown', 'error')).resolves.not.toThrow();
+    });
+
+    it('should decrement worker load when failing with assigned worker', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-worker',
+        assignedWorkerId: 'w1',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.fail('job-worker', 'error');
+
+      expect(scheduler.workers.get('w1')!.currentLoad).toBe(1);
+    });
+
+    it('should handle fail when worker is not found in registry', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-worker-gone',
+        assignedWorkerId: 'nonexistent',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await expect(scheduler.fail('job-worker-gone', 'error')).resolves.not.toThrow();
+    });
+  });
+
+  describe('cancel', () => {
+    it('should cancel a queued job', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-cancel',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'queued',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        result: undefined,
+        error: undefined,
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.cancel('job-cancel');
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith('job-cancel', 'cancelled');
+    });
+
+    it('should throw for running job', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-running',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'running',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        result: undefined,
+        error: undefined,
+      } as any);
+
+      await expect(scheduler.cancel('job-running')).rejects.toThrow('Cannot cancel');
+    });
+
+    it('should throw for completed job', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-completed',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'completed',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        result: undefined,
+        error: undefined,
+      } as any);
+
+      await expect(scheduler.cancel('job-completed')).rejects.toThrow('Cannot cancel');
+    });
+
+    it('should decrement worker load when cancelling assigned job', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-assigned',
+        assignedWorkerId: 'w1',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'queued',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.cancel('job-assigned');
+
+      expect(scheduler.workers.get('w1')!.currentLoad).toBe(2);
+    });
+
+    it('should do nothing for unknown job', async () => {
+      mockRepository.findById.mockResolvedValue(null);
+
+      await expect(scheduler.cancel('unknown')).resolves.not.toThrow();
+    });
+
+    it('should handle cancel when worker is not found in registry', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-cancel-worker',
+        assignedWorkerId: 'nonexistent',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'queued',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await expect(scheduler.cancel('job-cancel-worker')).resolves.not.toThrow();
+    });
+  });
+
+  describe('start', () => {
+    it('should recover non-terminal jobs on startup', async () => {
+      const queuedJob = {
+        id: 'recover-queued',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'queued' as const,
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        result: undefined,
+        error: undefined,
+      };
+
+      mockRepository.findNonTerminal.mockResolvedValue([queuedJob] as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.start();
+
+      expect(scheduler.queue.depth()).toBe(1);
+      expect(scheduler.queue.depth()).toBeGreaterThan(0);
+    });
+
+    it('should recover pending jobs', async () => {
+      const pendingJob = {
+        id: 'recover-pending',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'pending' as const,
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+      };
+
+      mockRepository.findNonTerminal.mockResolvedValue([pendingJob] as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.start();
+
+      expect(scheduler.queue.depth()).toBe(1);
+    });
+
+    it('should recover assigned and running jobs as orphaned', async () => {
+      const assignedJob = {
+        id: 'recover-assigned',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'assigned' as const,
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: 'w1',
+      };
+
+      mockRepository.findNonTerminal.mockResolvedValue([assignedJob] as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.start();
+
+      expect(mockRepository.updateStatus).toHaveBeenCalledWith('recover-assigned', 'orphaned');
+    });
+
+    it('should recover orphaned jobs via reAllocator', async () => {
+      const orphanedJob = {
+        id: 'recover-orphan',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'orphaned' as const,
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+      };
+
+      mockRepository.findNonTerminal.mockResolvedValue([orphanedJob] as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.start();
+
+      expect(scheduler.queue.depth()).toBe(1);
+    });
+
+    it('should skip jobs with unknown status during recovery', async () => {
+      const unknownJob = {
+        id: 'recover-unknown',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'unknown' as any,
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+      };
+
+      mockRepository.findNonTerminal.mockResolvedValue([unknownJob] as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await expect(scheduler.start()).resolves.not.toThrow();
+    });
+  });
+
+  describe('onWorkerDisconnect', () => {
+    it('should remove worker from back pressure tracking', () => {
+      scheduler.backPressure.updateWorkerLoad('w1', 0.9);
+      expect(scheduler.backPressure.canAccept()).toBe(false);
+
+      scheduler.onWorkerDisconnect('w1');
+      expect(scheduler.backPressure.canAccept()).toBe(true);
+    });
+  });
+
+  describe('setWorkerProtocol', () => {
+    it('should store the worker protocol reference', async () => {
+      const protocol = { sendToWorker: jest.fn() } as unknown as WorkerProtocol;
+      scheduler.setWorkerProtocol(protocol);
+
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {});
+
+      expect(protocol.sendToWorker).toHaveBeenCalled();
+    });
+  });
+
+  describe('stop', () => {
+    it('should stop orphan detector, queue, and close protocol', async () => {
+      const protocol = { close: jest.fn() } as unknown as WorkerProtocol;
+      scheduler.setWorkerProtocol(protocol);
+
+      await scheduler.stop();
+
+      expect(protocol.close).toHaveBeenCalled();
+    });
+
+    it('should stop without worker protocol', async () => {
+      await expect(scheduler.stop()).resolves.not.toThrow();
+    });
+  });
+
+  describe('handleAckTimeout', () => {
+    it('should mark job as orphaned on ACK timeout', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-timeout',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'assigned',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: 'w1',
+      } as any);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.insert.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith('ACK timeout for job', expect.any(Object));
+    });
+
+    it('should ignore completed jobs on ACK timeout', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-done',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'completed',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+      } as any);
+
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockRepository.updateStatus).not.toHaveBeenCalledWith('job-done', 'orphaned');
+    });
+
+    it('should ignore failed jobs on ACK timeout', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-failed',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'failed',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+      } as any);
+
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockRepository.updateStatus).not.toHaveBeenCalledWith('job-failed', 'orphaned');
+    });
+
+    it('should ignore cancelled jobs on ACK timeout', async () => {
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-cancelled',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'cancelled',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+      } as any);
+
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockRepository.updateStatus).not.toHaveBeenCalledWith('job-cancelled', 'orphaned');
+    });
+
+    it('should decrement load for timed-out assigned worker', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 2,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-assigned',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'assigned',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: 'w1',
+      } as any);
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(scheduler.workers.get('w1')!.currentLoad).toBe(2);
+    });
+
+    it('should handle ACK timeout without assignedWorkerId', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-no-worker',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'assigned',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: undefined,
+      } as any);
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith('ACK timeout for job', expect.any(Object));
+    });
+
+    it('should handle ACK timeout when worker is not found in registry', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-orphan',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'assigned',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: 'nonexistent',
+      } as any);
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith('ACK timeout for job', expect.any(Object));
+    });
+
+    it('should log error when updateStatus fails on ACK timeout', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.findById.mockResolvedValue({
+        id: 'job-ack-fail',
+        type: 'test-type',
+        payload: {},
+        priority: 3,
+        status: 'assigned',
+        ackDeadline: 0,
+        maxRetries: 3,
+        retryCount: 0,
+        createdAt: new Date(),
+        history: [],
+        assignedWorkerId: 'w1',
+      } as any);
+      mockRepository.insert.mockResolvedValue(undefined);
+      let callIdx = 0;
+      mockRepository.updateStatus.mockImplementation(() => {
+        callIdx++;
+        if (callIdx === 3) return Promise.reject(new Error('orphan persist failed'));
+        return Promise.resolve(undefined);
+      });
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to persist orphaned status on ACK timeout',
+        expect.objectContaining({ error: 'Error: orphan persist failed' })
+      );
+    });
+
+    it('should log error when findById fails on ACK timeout', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 3,
+      });
+
+      mockRepository.findById.mockRejectedValue(new Error('DB find failed'));
+      mockRepository.insert.mockResolvedValue(undefined);
+      mockRepository.updateStatus.mockResolvedValue(undefined);
+
+      await scheduler.submit('test-type', {}, 1, 3);
+
+      jest.advanceTimersByTime(30001);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to find job on ACK timeout',
+        expect.objectContaining({ error: 'Error: DB find failed' })
+      );
+    });
+  });
+
+  describe('distributeNext error handling', () => {
+    it('should log error when updateStatus fails during assignment', async () => {
+      scheduler.workers.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['test-type'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      mockRepository.insert.mockResolvedValue(undefined);
+      let callIdx = 0;
+      mockRepository.updateStatus.mockImplementation(() => {
+        callIdx++;
+        if (callIdx === 2) return Promise.reject(new Error('DB write failed'));
+        return Promise.resolve(undefined);
+      });
+
+      await scheduler.submit('test-type', {});
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to persist assigned status',
+        expect.objectContaining({ error: 'Error: DB write failed' })
+      );
+    });
+  });
+});

--- a/services/audit-logger/tests/unit/subscription/audit-subscriber.spec.ts
+++ b/services/audit-logger/tests/unit/subscription/audit-subscriber.spec.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+import { createReq, createRes, createNext } from '../../helpers/express';
+
+jest.mock('@trading-model/common/middleware/catch-error', () => ({
+  catchSync: (fn: any) => fn,
+}));
+
+jest.mock('@trading-model/common/middleware/response-exception', () => {
+  const sendResponse = (data: any, status: number) => ({ status, data });
+  return { sendResponse };
+});
+
+import { AuditRepository } from '../../../src/persistence/audit-repository';
+import { createMessageHandler } from '../../../src/subscription/audit-subscriber';
+
+describe('AuditSubscriber', () => {
+  let mockRepo: jest.Mocked<AuditRepository>;
+  let handler: ReturnType<typeof createMessageHandler>;
+
+  beforeEach(() => {
+    mockRepo = {
+      insert: jest.fn(),
+      insertBatch: jest.fn(),
+      findById: jest.fn(),
+      query: jest.fn(),
+      getStats: jest.fn(),
+      ensureIndexes: jest.fn(),
+    } as unknown as jest.Mocked<AuditRepository>;
+
+    handler = createMessageHandler(mockRepo);
+  });
+
+  describe('message handling', () => {
+    it('should accept a message in nested envelope format and return 200', async () => {
+      mockRepo.insert.mockResolvedValue(undefined);
+
+      const req = createReq({
+        body: {
+          message: {
+            metadata: {
+              topic: 'order.created',
+              eventType: 'OrderCreated',
+              messageId: 'msg-123',
+              correlationId: 'corr-456',
+              emittedAt: '2024-06-01T12:00:00Z',
+              publisher: {
+                serviceName: 'order-service',
+                instanceId: 'instance-1',
+              },
+            },
+            payload: { orderId: 'ord-1' },
+          },
+          context: { deliveryAttempt: 1, consumerGroup: 'audit-group' },
+        },
+      });
+
+      const result = await handler(req, createRes(), createNext);
+
+      expect(mockRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            topic: 'order.created',
+            eventType: 'OrderCreated',
+            publisher: 'order-service',
+            instanceId: 'instance-1',
+            messageId: 'msg-123',
+            correlationId: 'corr-456',
+          }),
+          payload: { orderId: 'ord-1' },
+        })
+      );
+      expect(result).toMatchObject({ status: 200, data: { status: 'recorded' } });
+    });
+
+    it('should accept a flat envelope format', async () => {
+      mockRepo.insert.mockResolvedValue(undefined);
+
+      const req = createReq({
+        body: {
+          metadata: {
+            topic: 'trade.executed',
+            publisher: {
+              serviceName: 'trade-service',
+              instanceId: 'instance-2',
+            },
+          },
+          payload: { tradeId: 't-1' },
+        },
+      });
+
+      const result = await handler(req, createRes(), createNext);
+
+      expect(mockRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            topic: 'trade.executed',
+            publisher: 'trade-service',
+            instanceId: 'instance-2',
+          }),
+          payload: { tradeId: 't-1' },
+        })
+      );
+      expect(result).toMatchObject({ status: 200 });
+    });
+
+    it('should return 400 when no topic is present', async () => {
+      const req = createReq({
+        body: { message: { metadata: {}, payload: {} } },
+      });
+
+      const result = await handler(req, createRes(), createNext);
+
+      expect(mockRepo.insert).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        status: 400,
+        data: { error: 'Invalid message format: no topic' },
+      });
+    });
+
+    it('should return 400 when body has no message and no metadata', async () => {
+      const req = createReq({
+        body: { random: 'data' },
+      });
+
+      const result = await handler(req, createRes(), createNext);
+
+      expect(mockRepo.insert).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        status: 400,
+        data: { error: 'Invalid message format: no topic' },
+      });
+    });
+
+    it('should handle missing publisher gracefully', async () => {
+      mockRepo.insert.mockResolvedValue(undefined);
+
+      const req = createReq({
+        body: {
+          metadata: {
+            topic: 'test.topic',
+          },
+          payload: {},
+        },
+      });
+
+      const result = await handler(req, createRes(), createNext);
+
+      expect(mockRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            publisher: 'unknown',
+            instanceId: 'unknown',
+          }),
+        })
+      );
+      expect(result).toMatchObject({ status: 200 });
+    });
+
+    it('should use current date when emittedAt is not provided', async () => {
+      mockRepo.insert.mockResolvedValue(undefined);
+
+      const before = Date.now();
+
+      const req = createReq({
+        body: {
+          metadata: {
+            topic: 'test.topic',
+          },
+          payload: {},
+        },
+      });
+
+      await handler(req, createRes(), createNext);
+
+      const insertCall = (mockRepo.insert as jest.Mock).mock.calls[0][0] as any;
+      expect(insertCall.receivedAt.getTime()).toBeGreaterThanOrEqual(before);
+    });
+  });
+});

--- a/services/audit-logger/tests/unit/types/job.types.spec.ts
+++ b/services/audit-logger/tests/unit/types/job.types.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { JOB_STATUS_NON_TERMINAL } from '../../../src/types/job.types';
+
+describe('JOB_STATUS_NON_TERMINAL', () => {
+  it('should contain all expected non-terminal statuses', () => {
+    expect(JOB_STATUS_NON_TERMINAL).toEqual([
+      'pending',
+      'queued',
+      'assigned',
+      'running',
+      'orphaned',
+    ]);
+  });
+
+  it('should exclude terminal statuses', () => {
+    expect(JOB_STATUS_NON_TERMINAL).not.toContain('completed');
+    expect(JOB_STATUS_NON_TERMINAL).not.toContain('failed');
+    expect(JOB_STATUS_NON_TERMINAL).not.toContain('cancelled');
+  });
+});

--- a/services/audit-logger/tests/unit/worker/worker-protocol.spec.ts
+++ b/services/audit-logger/tests/unit/worker/worker-protocol.spec.ts
@@ -1,0 +1,491 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('@trading-model/common/config/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('ws', () => {
+  const MockWebSocket = jest.fn(() => ({
+    on: jest.fn(),
+    send: jest.fn(),
+    readyState: 1,
+    close: jest.fn(),
+  }));
+  (MockWebSocket as any).OPEN = 1;
+  (MockWebSocket as any).CONNECTING = 0;
+  (MockWebSocket as any).CLOSING = 2;
+  (MockWebSocket as any).CLOSED = 3;
+
+  const MockWebSocketServer = jest.fn(() => ({
+    on: jest.fn(),
+    close: jest.fn(),
+  }));
+
+  return {
+    __esModule: true,
+    default: MockWebSocket,
+    WebSocketServer: MockWebSocketServer,
+  };
+});
+
+import { logger } from '@trading-model/common/config/logger';
+import { WebSocketServer } from 'ws';
+
+import { WorkerProtocol } from '../../../src/worker/worker-protocol';
+import { WorkerRegistry } from '../../../src/worker/worker-registry';
+
+const MockWebSocketServer = WebSocketServer as unknown as jest.Mock;
+
+describe('WorkerProtocol', () => {
+  let protocol: WorkerProtocol;
+  let mockRegistry: jest.Mocked<WorkerRegistry>;
+  let onWorkerDisconnect: jest.Mock;
+  let wssInstance: any;
+  let connectionHandler: Function;
+
+  function createWs(overrides: Partial<{ readyState: number }> = {}) {
+    return {
+      on: jest.fn(),
+      send: jest.fn(),
+      readyState: 1,
+      close: jest.fn(),
+      ...overrides,
+    };
+  }
+
+  function simulateConnection(ws: any) {
+    connectionHandler(ws);
+  }
+
+  function getMessageHandler(ws: any): jest.Mock {
+    return (ws.on as jest.Mock).mock.calls.find(
+      (c: any) => c[0] === 'message'
+    )![1] as unknown as jest.Mock;
+  }
+
+  function getCloseHandler(ws: any): jest.Mock {
+    return (ws.on as jest.Mock).mock.calls.find(
+      (c: any) => c[0] === 'close'
+    )![1] as unknown as jest.Mock;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockRegistry = {
+      register: jest.fn(),
+      unregister: jest.fn(),
+      heartbeat: jest.fn(),
+      updateLoad: jest.fn(),
+      setStatus: jest.fn(),
+      get: jest.fn(),
+      findBestWorker: jest.fn(),
+      purgeStaleWorkers: jest.fn(),
+      count: jest.fn(),
+      averageLoad: jest.fn(),
+      getAllActive: jest.fn(),
+    } as unknown as jest.Mocked<WorkerRegistry>;
+
+    onWorkerDisconnect = jest.fn();
+
+    protocol = new WorkerProtocol({} as any, mockRegistry, onWorkerDisconnect);
+
+    wssInstance = MockWebSocketServer.mock.results[0].value;
+    connectionHandler = (wssInstance.on as jest.Mock).mock.calls.find(
+      (c: any) => c[0] === 'connection'
+    )![1] as unknown as Function;
+  });
+
+  describe('constructor', () => {
+    it('should create a WebSocketServer with the provided server', () => {
+      expect(MockWebSocketServer).toHaveBeenCalledWith({ server: {} });
+    });
+
+    it('should register a connection handler on the WebSocketServer', () => {
+      expect(wssInstance.on).toHaveBeenCalledWith('connection', expect.any(Function));
+    });
+  });
+
+  describe('on connection', () => {
+    it('should set up message and close handlers on the WebSocket', () => {
+      const ws = createWs();
+
+      simulateConnection(ws);
+
+      expect(ws.on).toHaveBeenCalledWith('message', expect.any(Function));
+      expect(ws.on).toHaveBeenCalledWith('close', expect.any(Function));
+    });
+
+    describe('message handling', () => {
+      it('should handle register message', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler(
+          JSON.stringify({
+            type: 'register',
+            workerId: 'w1',
+            address: '10.0.0.1',
+            port: 9000,
+            capabilities: ['type-a'],
+            maxConcurrency: 5,
+          })
+        );
+
+        expect(mockRegistry.register).toHaveBeenCalledWith('w1', {
+          workerId: 'w1',
+          address: '10.0.0.1',
+          port: 9000,
+          capabilities: ['type-a'],
+          maxConcurrency: 5,
+          currentLoad: 0,
+        });
+        expect(logger.info).toHaveBeenCalledWith('Worker registered via WebSocket', {
+          workerId: 'w1',
+        });
+      });
+
+      it('should handle heartbeat message', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler(
+          JSON.stringify({
+            type: 'register',
+            workerId: 'w1',
+            address: '10.0.0.1',
+            port: 9000,
+            capabilities: ['type-a'],
+            maxConcurrency: 5,
+          })
+        );
+
+        jest.clearAllMocks();
+
+        messageHandler(
+          JSON.stringify({
+            type: 'heartbeat',
+            workerId: 'w1',
+            currentLoad: 3,
+          })
+        );
+
+        expect(mockRegistry.heartbeat).toHaveBeenCalledWith('w1');
+        expect(mockRegistry.updateLoad).toHaveBeenCalledWith('w1', 3);
+        expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'heartbeat.ack' }));
+      });
+
+      it('should not send heartbeat ack when connection is not OPEN', () => {
+        const ws = createWs({ readyState: 2 });
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler(
+          JSON.stringify({
+            type: 'register',
+            workerId: 'w1',
+            address: '10.0.0.1',
+            port: 9000,
+            capabilities: [],
+            maxConcurrency: 5,
+          })
+        );
+
+        jest.clearAllMocks();
+
+        messageHandler(
+          JSON.stringify({
+            type: 'heartbeat',
+            workerId: 'w1',
+            currentLoad: 1,
+          })
+        );
+
+        expect(ws.send).not.toHaveBeenCalled();
+      });
+
+      it('should handle disconnect message', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler(
+          JSON.stringify({
+            type: 'register',
+            workerId: 'w1',
+            address: '10.0.0.1',
+            port: 9000,
+            capabilities: [],
+            maxConcurrency: 5,
+          })
+        );
+
+        jest.clearAllMocks();
+
+        messageHandler(
+          JSON.stringify({
+            type: 'disconnect',
+            workerId: 'w1',
+            reason: 'shutting down',
+          })
+        );
+
+        expect(mockRegistry.unregister).toHaveBeenCalledWith('w1');
+        expect(onWorkerDisconnect).toHaveBeenCalledWith('w1');
+        expect(logger.info).toHaveBeenCalledWith('Worker disconnected', {
+          workerId: 'w1',
+          reason: 'shutting down',
+        });
+      });
+
+      it('should log error on invalid JSON', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler('not-json');
+
+        expect(logger.error).toHaveBeenCalledWith('Invalid WebSocket message from worker', {
+          error: expect.any(String),
+        });
+      });
+
+      it('should log error with String(err) when thrown value is not an Error', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler({
+          toString: () => {
+            throw 'primitive-error';
+          },
+        });
+
+        expect(logger.error).toHaveBeenCalledWith('Invalid WebSocket message from worker', {
+          error: 'primitive-error',
+        });
+      });
+
+      it('should do nothing for unknown message type', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+
+        messageHandler(JSON.stringify({ type: 'unknown' }));
+
+        expect(mockRegistry.register).not.toHaveBeenCalled();
+        expect(mockRegistry.heartbeat).not.toHaveBeenCalled();
+        expect(mockRegistry.unregister).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('close handling', () => {
+      it('should mark worker as draining and call onWorkerDisconnect', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const messageHandler = getMessageHandler(ws);
+        const closeHandler = getCloseHandler(ws);
+
+        messageHandler(
+          JSON.stringify({
+            type: 'register',
+            workerId: 'w1',
+            address: '10.0.0.1',
+            port: 9000,
+            capabilities: ['type-a'],
+            maxConcurrency: 5,
+          })
+        );
+
+        jest.clearAllMocks();
+
+        closeHandler();
+
+        expect(mockRegistry.setStatus).toHaveBeenCalledWith('w1', 'draining');
+        expect(onWorkerDisconnect).toHaveBeenCalledWith('w1');
+      });
+
+      it('should do nothing when closing a non-registered connection', () => {
+        const ws = createWs();
+        simulateConnection(ws);
+        const closeHandler = getCloseHandler(ws);
+
+        closeHandler();
+
+        expect(mockRegistry.setStatus).not.toHaveBeenCalled();
+        expect(onWorkerDisconnect).not.toHaveBeenCalled();
+      });
+
+      it('should not match close for a different WebSocket than the one in the map', () => {
+        const ws1 = createWs();
+        simulateConnection(ws1);
+        getMessageHandler(ws1)(
+          JSON.stringify({
+            type: 'register',
+            workerId: 'w1',
+            address: '10.0.0.1',
+            port: 9000,
+            capabilities: [],
+            maxConcurrency: 5,
+          })
+        );
+
+        const ws2 = createWs();
+        simulateConnection(ws2);
+        const closeHandler2 = getCloseHandler(ws2);
+
+        jest.clearAllMocks();
+
+        closeHandler2();
+
+        expect(mockRegistry.setStatus).not.toHaveBeenCalled();
+        expect(onWorkerDisconnect).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('sendToWorker', () => {
+    it('should send JSON message to the worker connection', () => {
+      const ws = createWs();
+      simulateConnection(ws);
+      const messageHandler = getMessageHandler(ws);
+
+      messageHandler(
+        JSON.stringify({
+          type: 'register',
+          workerId: 'w1',
+          address: '10.0.0.1',
+          port: 9000,
+          capabilities: [],
+          maxConcurrency: 5,
+        })
+      );
+
+      protocol.sendToWorker('w1', { type: 'drain' });
+
+      expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'drain' }));
+    });
+
+    it('should not send if worker connection does not exist', () => {
+      const ws = createWs();
+      simulateConnection(ws);
+
+      protocol.sendToWorker('nonexistent', { type: 'drain' });
+
+      expect(ws.send).not.toHaveBeenCalled();
+    });
+
+    it('should not send if connection is not OPEN', () => {
+      const ws = createWs({ readyState: 2 });
+      simulateConnection(ws);
+      const messageHandler = getMessageHandler(ws);
+
+      messageHandler(
+        JSON.stringify({
+          type: 'register',
+          workerId: 'w1',
+          address: '10.0.0.1',
+          port: 9000,
+          capabilities: [],
+          maxConcurrency: 5,
+        })
+      );
+
+      protocol.sendToWorker('w1', { type: 'drain' });
+
+      expect(ws.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendDrain', () => {
+    it('should call sendToWorker with drain type', () => {
+      jest.spyOn(protocol, 'sendToWorker');
+
+      protocol.sendDrain('w1');
+
+      expect(protocol.sendToWorker).toHaveBeenCalledWith('w1', { type: 'drain' });
+    });
+  });
+
+  describe('broadcastDrain', () => {
+    it('should call sendDrain for all connections', () => {
+      jest.spyOn(protocol, 'sendDrain');
+
+      const ws1 = createWs();
+      simulateConnection(ws1);
+      getMessageHandler(ws1)(
+        JSON.stringify({
+          type: 'register',
+          workerId: 'w1',
+          address: '10.0.0.1',
+          port: 9000,
+          capabilities: [],
+          maxConcurrency: 5,
+        })
+      );
+
+      const ws2 = createWs();
+      simulateConnection(ws2);
+      getMessageHandler(ws2)(
+        JSON.stringify({
+          type: 'register',
+          workerId: 'w2',
+          address: '10.0.0.2',
+          port: 9000,
+          capabilities: [],
+          maxConcurrency: 5,
+        })
+      );
+
+      jest.clearAllMocks();
+
+      protocol.broadcastDrain();
+
+      expect(protocol.sendDrain).toHaveBeenCalledWith('w1');
+      expect(protocol.sendDrain).toHaveBeenCalledWith('w2');
+    });
+  });
+
+  describe('close', () => {
+    it('should broadcast drain, close all connections, clear map, and close server', () => {
+      jest.spyOn(protocol, 'broadcastDrain');
+
+      const ws1 = createWs();
+      simulateConnection(ws1);
+      getMessageHandler(ws1)(
+        JSON.stringify({
+          type: 'register',
+          workerId: 'w1',
+          address: '10.0.0.1',
+          port: 9000,
+          capabilities: [],
+          maxConcurrency: 5,
+        })
+      );
+
+      const ws2 = createWs();
+      simulateConnection(ws2);
+      getMessageHandler(ws2)(
+        JSON.stringify({
+          type: 'register',
+          workerId: 'w2',
+          address: '10.0.0.2',
+          port: 9000,
+          capabilities: [],
+          maxConcurrency: 5,
+        })
+      );
+
+      jest.clearAllMocks();
+
+      protocol.close();
+
+      expect(protocol.broadcastDrain).toHaveBeenCalledTimes(1);
+      expect(ws1.close).toHaveBeenCalledTimes(1);
+      expect(ws2.close).toHaveBeenCalledTimes(1);
+      expect(wssInstance.close).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/services/audit-logger/tests/unit/worker/worker-registry.spec.ts
+++ b/services/audit-logger/tests/unit/worker/worker-registry.spec.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, beforeEach, jest, afterEach } from '@jest/globals';
+
+import { WorkerRegistry } from '../../../src/worker/worker-registry';
+
+describe('WorkerRegistry', () => {
+  let registry: WorkerRegistry;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    registry = new WorkerRegistry(10000);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('register', () => {
+    it('should add a worker to the registry', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      expect(registry.count()).toBe(1);
+    });
+  });
+
+  describe('unregister', () => {
+    it('should remove a worker from the registry', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+      registry.unregister('worker-1');
+
+      expect(registry.count()).toBe(0);
+    });
+  });
+
+  describe('get', () => {
+    it('should return undefined for unknown worker', () => {
+      expect(registry.get('unknown')).toBeUndefined();
+    });
+
+    it('should return the worker registration', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      const worker = registry.get('worker-1');
+      expect(worker).toBeDefined();
+      expect(worker!.status).toBe('active');
+    });
+  });
+
+  describe('heartbeat', () => {
+    it('should update lastHeartbeat for a registered worker', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      const before = registry.get('worker-1')!.lastHeartbeat.getTime();
+      jest.advanceTimersByTime(1000);
+      registry.heartbeat('worker-1');
+      const after = registry.get('worker-1')!.lastHeartbeat.getTime();
+
+      expect(after).toBeGreaterThan(before);
+    });
+
+    it('should not fail for unknown worker', () => {
+      expect(() => registry.heartbeat('unknown')).not.toThrow();
+    });
+  });
+
+  describe('updateLoad', () => {
+    it('should update the current load of a worker', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      registry.updateLoad('worker-1', 3);
+      expect(registry.get('worker-1')!.currentLoad).toBe(3);
+    });
+
+    it('should not throw for unknown worker', () => {
+      expect(() => registry.updateLoad('unknown', 5)).not.toThrow();
+    });
+  });
+
+  describe('setStatus', () => {
+    it('should update the status of a worker', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      registry.setStatus('worker-1', 'draining');
+      expect(registry.get('worker-1')!.status).toBe('draining');
+    });
+
+    it('should not throw for unknown worker', () => {
+      expect(() => registry.setStatus('unknown', 'offline')).not.toThrow();
+    });
+  });
+
+  describe('findBestWorker', () => {
+    it('should return null when no workers are registered', () => {
+      expect(registry.findBestWorker('type-a')).toBeNull();
+    });
+
+    it('should return null when no worker supports the job type', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-b'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      expect(registry.findBestWorker('type-a')).toBeNull();
+    });
+
+    it('should skip draining workers', () => {
+      registry.register('draining-worker', {
+        workerId: 'draining-worker',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+      registry.setStatus('draining-worker', 'draining');
+
+      expect(registry.findBestWorker('type-a')).toBeNull();
+    });
+
+    it('should skip workers at max concurrency', () => {
+      registry.register('busy-worker', {
+        workerId: 'busy-worker',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 2,
+        currentLoad: 2,
+      });
+
+      expect(registry.findBestWorker('type-a')).toBeNull();
+    });
+
+    it('should return the least loaded compatible worker', () => {
+      registry.register('busy', {
+        workerId: 'busy',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 10,
+        currentLoad: 8,
+      });
+      registry.register('free', {
+        workerId: 'free',
+        address: '10.0.0.2',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 10,
+        currentLoad: 2,
+      });
+
+      const best = registry.findBestWorker('type-a');
+      expect(best).not.toBeNull();
+      expect(best!.workerId).toBe('free');
+    });
+
+    it('should skip workers with higher load than current best', () => {
+      registry.register('good', {
+        workerId: 'good',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 10,
+        currentLoad: 2,
+      });
+      registry.register('worse', {
+        workerId: 'worse',
+        address: '10.0.0.2',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 10,
+        currentLoad: 5,
+      });
+
+      const best = registry.findBestWorker('type-a');
+      expect(best!.workerId).toBe('good');
+    });
+  });
+
+  describe('purgeStaleWorkers', () => {
+    it('should return empty array when all workers are active', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+      registry.heartbeat('worker-1');
+
+      const stale = registry.purgeStaleWorkers();
+      expect(stale).toEqual([]);
+    });
+
+    it('should purge workers with expired heartbeats', () => {
+      registry.register('worker-1', {
+        workerId: 'worker-1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: ['type-a'],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+
+      jest.advanceTimersByTime(15000);
+
+      const stale = registry.purgeStaleWorkers();
+      expect(stale).toContain('worker-1');
+      expect(registry.count()).toBe(0);
+    });
+  });
+
+  describe('count', () => {
+    it('should return 0 for empty registry', () => {
+      expect(registry.count()).toBe(0);
+    });
+
+    it('should return the number of registered workers', () => {
+      registry.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 1,
+        currentLoad: 0,
+      });
+      registry.register('w2', {
+        workerId: 'w2',
+        address: '10.0.0.2',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 1,
+        currentLoad: 0,
+      });
+
+      expect(registry.count()).toBe(2);
+    });
+  });
+
+  describe('averageLoad', () => {
+    it('should return 0 for empty registry', () => {
+      expect(registry.averageLoad()).toBe(0);
+    });
+
+    it('should calculate the average load ratio', () => {
+      registry.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 10,
+        currentLoad: 5,
+      });
+      registry.register('w2', {
+        workerId: 'w2',
+        address: '10.0.0.2',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 10,
+        currentLoad: 3,
+      });
+
+      expect(registry.averageLoad()).toBeCloseTo(0.4, 5);
+    });
+
+    it('should handle worker with maxConcurrency of 0', () => {
+      registry.register('w1', {
+        workerId: 'w1',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 0,
+        currentLoad: 0,
+      });
+
+      expect(registry.averageLoad()).toBe(0);
+    });
+  });
+
+  describe('getAllActive', () => {
+    it('should return only active workers', () => {
+      registry.register('active-w', {
+        workerId: 'active-w',
+        address: '10.0.0.1',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+      registry.register('draining-w', {
+        workerId: 'draining-w',
+        address: '10.0.0.2',
+        port: 9000,
+        capabilities: [],
+        maxConcurrency: 5,
+        currentLoad: 0,
+      });
+      registry.setStatus('draining-w', 'draining');
+
+      const active = registry.getAllActive();
+      expect(active).toHaveLength(1);
+      expect(active[0].workerId).toBe('active-w');
+    });
+  });
+});

--- a/services/audit-logger/tsconfig.json
+++ b/services/audit-logger/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "node16",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node16",
+    "types": ["node"],
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "tests"]
+}


### PR DESCRIPTION
## Description

Adds the audit-logger service by @docteur-turboss — a comprehensive event auditing and job-scheduling microservice mirroring the job-scheduler architecture. Includes full unit test coverage at 100% for all metrics.

## Type of Change

- [x] feat — new service
- [x] test — unit tests (100% coverage)

## Changes

### Additions (audit-logger)
- Service: env config, address manager, MongoDB audit/job repositories, worker registry/protocol, job scheduler (queue + back-pressure), recovery (orphan detector + re-allocator), health/events routes, audit subscriber, TLS server, bootstrap wiring
- Tests: 19 test suites, 175 tests — fixtures, helpers, unit tests for all 26 source files
- Config: package.json, tsconfig.json, Dockerfile, .env.example, jest.config.js

### Additions (broker-message)
- Schema validators for auditHeartbeat / auditGapDetected event types
- Unit tests for new schema validators

### Modifications
- services/audit-logger/src/app/index.ts — fixed import order

## Breaking Changes

None.

## Tests

- [x] npm run lint — 0 errors
- [x] npm run build — success
- [x] npm test --coverage (audit-logger) — 19 suites, 175 tests, 100% all metrics
- [x] npm test --coverage (broker-message) — 8 suites, 82 tests, 100% all metrics

## Checklist

- [x] Code follows project conventions
- [x] Naming/structure/style compliance
- [x] Test coverage thresholds met
- [x] Branch up-to-date with development
- [x] No secrets committed
- [x] No breaking changes

## Additional Notes

The pre-commit/pre-push hooks (Prettier) report 159+ pre-existing formatting warnings across the repo, unrelated to this branch. CI will verify lint, build, and coverage independently.